### PR TITLE
Add Typescript binding generation for XML APIs.

### DIFF
--- a/java/api-schemas/pom.xml
+++ b/java/api-schemas/pom.xml
@@ -25,6 +25,8 @@
     <module>rest-api-schemas</module>
     <module>rest-api-bindings</module>
     <module>vcd-xjc-plugins</module>
+    <module>tooling/bindings-generator</module>
+    <module>tooling/vcd-bindings-maven-plugin</module>
   </modules>
   <properties>
     <cxf.version>3.1.11</cxf.version>

--- a/java/api-schemas/tooling/README.md
+++ b/java/api-schemas/tooling/README.md
@@ -1,0 +1,65 @@
+# VCD API Tools #
+The projects in this folder are tools for working with the vCloud Director APIs.
+
+## Bindings Generator ##
+A command line tool for generating Typescript bindings for vCD's XML-based REST API is available in `tooling/bindings-generator`.  The bindings generator can be executed like any typical application.  For instance, execution through Maven:
+
+`mvn exec:java -Dexec.mainClass="com.vmware.vcloud.bindings.generator.BindingsGenerator" -Dexec.args="--help"`
+
+will output the usage info:
+
+```
+Usage: BindingsGenerator [options]
+  Options:
+    -h, --help
+      Prints this help message
+    -o, --outputDir
+      A directory to output custom files to.  If none is specified, the output
+      is streamed to standard out.
+    -x, --overwrite
+      If the specified outputDir is not empty the generator will halt.  Adding
+      this flag will DELETE the content of outputDir and force the generator
+      to continue
+      Default: false
+  * -p, --packages
+      One or more packages to scan for schema classes.
+```
+
+There is also a Maven plugin available at `tooling/vcd-bindings-maven-plugin` to facilitate Typescript generation as part of a Maven project lifecycle.  Typescript can be generated for specific packages by adding the following plugin to an existing POM file:
+```xml
+<build>
+    <plugins>
+        <plugin>
+            <groupId>com.vmware.vcloud</groupId>
+            <artifactId>vcd-bindings-maven-plugin</artifactId>
+            <version>1.0.0</version>
+            <executions>
+                <execution>
+                    <phase>generate-sources</phase>
+                    <goals>
+                        <goal>generate-typescript</goal>
+                    </goals>
+                </execution>
+            </executions>
+            <configuration>
+                <packages>
+                    <package>com.vmware.vcloud.api.rest.schema.ovf</package>
+                    <package>com.vmware.vcloud.api.rest.schema.ovf.environment</package>
+                    <package>com.vmware.vcloud.api.rest.schema.ovf.vmware</package>
+                    <package>com.vmware.vcloud.api.rest.schema.versioning</package>
+                    <package>com.vmware.vcloud.api.rest.schema_v1_5</package>
+                    <package>com.vmware.vcloud.api.rest.schema_v1_5.extension</package>
+                </packages>
+            </configuration>
+            <dependencies>
+                <dependency>
+                    <groupId>com.vmware.vcloud</groupId>
+                    <artifactId>rest-api-bindings</artifactId>
+                    <version>9.1.0</version>
+                </dependency>
+            </dependencies>
+        </plugin>
+    </plugins>
+</build>
+```
+This will output a collection of classes, enums, and barrels that are ready for transpilation.

--- a/java/api-schemas/tooling/bindings-generator/pom.xml
+++ b/java/api-schemas/tooling/bindings-generator/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<!--
+ api-extension-template-vcloud-director
+ Copyright 2018 VMware, Inc.
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.vmware.vcloud</groupId>
+    <artifactId>bindings-generator</artifactId>
+    <name>${project.artifactId} :: vCloud Director bindings generator</name>
+    <description>Provides custom API bindings generation beyond what can be accomplished with xjc and OpenAPI</description>
+    <version>1.0.0</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <commons.lang.version>3.7</commons.lang.version>
+        <java.version>1.8</java.version>
+        <jaxb.version>2.3.0</jaxb.version>
+        <jcommander.version>1.72</jcommander.version>
+        <logback.version>1.2.3</logback.version>
+        <spring.version>5.0.4.RELEASE</spring.version>
+        <velocity.version>2.0</velocity.version>
+        <xstream.version>1.4.10</xstream.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.beust</groupId>
+            <artifactId>jcommander</artifactId>
+            <version>${jcommander.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>${commons.lang.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.velocity</groupId>
+            <artifactId>velocity-engine-core</artifactId>
+            <version>${velocity.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.5.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <dependencyConvergence />
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/java/api-schemas/tooling/bindings-generator/src/main/java/com/vmware/vcloud/bindings/generator/BindingsGenerator.java
+++ b/java/api-schemas/tooling/bindings-generator/src/main/java/com/vmware/vcloud/bindings/generator/BindingsGenerator.java
@@ -1,0 +1,263 @@
+/* ***************************************************************************
+ * api-extension-template-vcloud-director
+ * Copyright 2011-2018 VMware, Inc.  All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
+ * ***************************************************************************/
+package com.vmware.vcloud.bindings.generator;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.UncheckedIOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlType;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.velocity.Template;
+import org.apache.velocity.VelocityContext;
+import org.apache.velocity.app.VelocityEngine;
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.util.ClassUtils;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.vmware.vcloud.bindings.generator.typescript.TypescriptEnum;
+import com.vmware.vcloud.bindings.generator.typescript.TypescriptFile;
+
+public class BindingsGenerator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BindingsGenerator.class);
+
+    private static final Set<AnnotationTypeFilter> FILTERS = new HashSet<>();
+    static {
+        FILTERS.add(new AnnotationTypeFilter(XmlType.class));
+        FILTERS.add(new AnnotationTypeFilter(XmlEnum.class));
+    };
+
+    public static void main(String... args) {
+        BindingsGenerator generator = new BindingsGenerator();
+        JCommander commander = JCommander.newBuilder().programName(BindingsGenerator.class.getSimpleName()).addObject(generator).build();
+        commander.parse(args);
+        if (generator.help) {
+            commander.usage();
+            return;
+        }
+
+        generator.generate();
+    }
+
+    @Parameter(names = {"-p", "--packages"}, description = "One or more packages to scan for schema classes.", variableArity = true, required = true)
+    private List<String> packages;
+
+    @Parameter(names = {"-h", "--help"}, description = "Prints this help message", help = true)
+    private boolean help;
+
+    @Parameter(names = {"-o", "--outputDir"}, description = "A directory to output custom files to.  If none is specified, the output is streamed to standard out.")
+    private File outputDir;
+
+    @Parameter(names = {"-x", "--overwrite"}, arity = 0, description = "If the specified outputDir is not empty the generator will halt.  Adding this flag will DELETE "
+            + "the content of outputDir and force the generator to continue")
+    private boolean overwrite;
+
+    private ClassPathScanningCandidateComponentProvider provider;
+
+    private Template classTemplate;
+    private Template enumTemplate;
+    private Template indexTemplate;
+
+    private BindingsGenerator() {
+        provider = new ClassPathScanningCandidateComponentProvider(false) {
+            @Override
+            protected boolean isCandidateComponent(AnnotatedBeanDefinition beanDefinition) {
+                AnnotationMetadata metadata = beanDefinition.getMetadata();
+                return metadata.isIndependent() && !metadata.isInterface();
+            }
+        };
+
+        LOGGER.trace("Scanning for classes with annotations {}", FILTERS);
+        FILTERS.forEach(provider::addIncludeFilter);
+        provider.setResourcePattern("*.class");
+
+        VelocityEngine engine = new VelocityEngine();
+        engine.setProperty(RuntimeConstants.RESOURCE_LOADER, "classpath");
+        engine.setProperty("classpath.resource.loader.class", ClasspathResourceLoader.class.getName());
+        engine.init();
+
+        this.classTemplate = engine.getTemplate("/typescript/class.ts.vm");
+        this.enumTemplate = engine.getTemplate("/typescript/enum.ts.vm");
+        this.indexTemplate = engine.getTemplate("/typescript/index.ts.vm");
+    }
+
+    public BindingsGenerator(final List<String> packages) {
+        this();
+        this.packages = packages;
+    }
+
+    public BindingsGenerator outputDir(final File outputDir) {
+        this.outputDir = outputDir;
+        return this;
+    }
+
+    public BindingsGenerator overwrite(boolean overwrite) {
+        this.overwrite = overwrite;
+        return this;
+    }
+
+    public void generate() {
+        long start = System.currentTimeMillis();
+        validateOutputState();
+        this.packages.forEach(this::createBindingsForPackage);
+        createBarrels();
+
+        LOGGER.info("Complete in {} ms", System.currentTimeMillis() - start);
+    }
+
+    private void validateOutputState() {
+        if (outputDir == null || !outputDir.exists()) {
+            return;
+        }
+
+        boolean empty;
+        try (Stream<Path> files = Files.list(outputDir.toPath())) {
+            empty = !files.iterator().hasNext();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        if (empty) {
+            return;
+        }
+
+        if (!empty && !overwrite) {
+            LOGGER.error("Directory {} is not empty.  Aborting code generation.  To overwrite the directory, specify --overwrite option.", outputDir.getAbsolutePath());
+            throw new IllegalStateException("outputDir not empty and overwrite flag not specified.");
+        }
+
+        LOGGER.info("--overwrite flag specified.  Deleting current content of {}", outputDir.getAbsolutePath());
+        try {
+            Files.walk(outputDir.toPath())
+                .sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(File::delete);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void createBindingsForPackage(final String basePackage) {
+        LOGGER.info("Creating Typescript bindings for package {}", basePackage);
+        List<Class<?>> classes = this.provider.findCandidateComponents(basePackage).stream()
+                .map(bd -> ClassUtils.resolveClassName(bd.getBeanClassName(), null))
+                .collect(Collectors.toList());
+
+        if (classes.isEmpty()) {
+            LOGGER.warn("Package {} contains no bindable classes", basePackage);
+            return;
+        }
+
+        for (Class<?> clazz : classes) {
+            TypescriptFile file;
+            if (clazz.isEnum()) {
+                file = TypescriptFile.createEnum(clazz);
+            } else {
+                file = TypescriptFile.createClass(clazz);
+            }
+
+            LOGGER.debug("Adding {} to package {}", file, basePackage);
+            writeFile(file, basePackage);
+        }
+    }
+
+    private void createBarrels() {
+        Map<Path, List<String>> barrels = new HashMap<>();
+        try (Stream<Path> files = Files.walk(outputDir.toPath())) {
+            files.forEach(f -> {
+                if (Files.isDirectory(f)) {
+                    barrels.putIfAbsent(outputDir.toPath().relativize(f), new ArrayList<>());
+                }
+
+                if (f.equals(outputDir.toPath())) {
+                    return;
+                }
+
+                String value;
+                if (Files.isDirectory(f)) {
+                    value = f.getFileName().toString().concat("/");
+                } else {
+                    value = f.getFileName().toString();
+                    value = value.substring(0, value.lastIndexOf("."));
+                }
+
+                barrels.get(outputDir.toPath().relativize(f.getParent())).add(value);
+            });
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        barrels.entrySet().forEach(barrel -> {
+            VelocityContext context = new VelocityContext();
+            context.put("_formatter", StringUtils.class);
+            context.put("year", LocalDate.now().getYear());
+            context.put("imports", barrel.getValue());
+            try (Writer writer = getWriter("index.ts", barrel.getKey().toString())) {
+                indexTemplate.merge(context, writer);
+            } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+    }
+
+    private void writeFile(final TypescriptFile tsFile, final String basePackage) {
+        VelocityContext context = new VelocityContext();
+        context.put("_formatter", StringUtils.class);
+        context.put("year", LocalDate.now().getYear());
+        context.put("class", tsFile);
+
+        Template template = (tsFile instanceof TypescriptEnum)  ? enumTemplate : classTemplate;
+        try (Writer writer = getWriter(tsFile.getName() + ".ts", basePackage)) {
+            template.merge(context, writer);
+        } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private Writer getWriter(final String name, final String basePackage) {
+        if (outputDir == null) {
+            return new BufferedWriter(new PrintWriter(System.out));
+        }
+
+        try {
+            File scopedOutputDir = new File(outputDir, getRelativePackage(basePackage).replace('.', File.separatorChar) + File.separatorChar);
+            scopedOutputDir.mkdirs();
+            return new BufferedWriter(new FileWriter(new File(scopedOutputDir, name)));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private String getRelativePackage(final String basePackage) {
+        return basePackage.replace("com.vmware.", "");
+    }
+}

--- a/java/api-schemas/tooling/bindings-generator/src/main/java/com/vmware/vcloud/bindings/generator/typescript/TypescriptClass.java
+++ b/java/api-schemas/tooling/bindings-generator/src/main/java/com/vmware/vcloud/bindings/generator/typescript/TypescriptClass.java
@@ -1,0 +1,72 @@
+/* ***************************************************************************
+ * api-extension-template-vcloud-director
+ * Copyright 2011-2018 VMware, Inc.  All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
+ * ***************************************************************************/
+package com.vmware.vcloud.bindings.generator.typescript;
+
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.util.Collection;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.commons.lang3.reflect.TypeUtils;
+
+public class TypescriptClass extends TypescriptFile {
+    private Class<?> parent;
+    private boolean isAbstract;
+
+    TypescriptClass(final Class<?> clazz) {
+        setClazz(clazz);
+
+        if (clazz.getSuperclass() != Object.class) {
+            this.parent = clazz.getSuperclass();
+            addImport(clazz, this.parent);
+        }
+
+        isAbstract = Modifier.isAbstract(clazz.getModifiers());
+    }
+
+    public String getParent() {
+        return parent == null ? null : parent.getSimpleName();
+    }
+
+    public boolean getIsAbstract() {
+        return isAbstract;
+    }
+
+    @Override
+    protected void processField(java.lang.reflect.Field field, Class<?> clazz) {
+        if (Modifier.isStatic(field.getModifiers())) {
+            return;
+        }
+
+        final TypescriptMapper mapper = new TypescriptMapper();
+
+        Type genericType = field.getGenericType();
+        boolean isArray = TypeUtils.isArrayType(genericType) || TypeUtils.isAssignable(genericType, Collection.class);
+
+        Type actualType = genericType;
+        while (actualType instanceof ParameterizedType) {
+            actualType = ((ParameterizedType) actualType).getActualTypeArguments()[0];
+            if (actualType instanceof WildcardType) {
+                actualType = ((WildcardType) actualType).getUpperBounds()[0];
+            }
+        }
+
+        addField(field.getName(), mapper.getTypeName(actualType) + ((isArray) ? "[]" : ""));
+        if (!mapper.isBuiltInType(actualType) && !actualType.getTypeName().startsWith("java")) {
+            addImport(clazz, (Class <?>) actualType);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+            .append("name", getName())
+            .append("isAbstract", isAbstract).toString();
+    }
+}

--- a/java/api-schemas/tooling/bindings-generator/src/main/java/com/vmware/vcloud/bindings/generator/typescript/TypescriptEnum.java
+++ b/java/api-schemas/tooling/bindings-generator/src/main/java/com/vmware/vcloud/bindings/generator/typescript/TypescriptEnum.java
@@ -1,0 +1,32 @@
+/* ***************************************************************************
+ * api-extension-template-vcloud-director
+ * Copyright 2011-2018 VMware, Inc.  All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
+ * ***************************************************************************/
+package com.vmware.vcloud.bindings.generator.typescript;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+
+public class TypescriptEnum extends TypescriptFile {
+    TypescriptEnum(final Class<?> clazz) {
+        setClazz(clazz);
+    }
+
+    @Override
+    protected void processField(java.lang.reflect.Field field, Class<?> clazz) {
+        if (!field.isEnumConstant()) {
+            return;
+        }
+
+        addField(field.getName());
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+            .append("name", getName())
+            .append("values", getFields()).toString();
+    }
+}

--- a/java/api-schemas/tooling/bindings-generator/src/main/java/com/vmware/vcloud/bindings/generator/typescript/TypescriptFile.java
+++ b/java/api-schemas/tooling/bindings-generator/src/main/java/com/vmware/vcloud/bindings/generator/typescript/TypescriptFile.java
@@ -1,0 +1,159 @@
+/* ***************************************************************************
+ * api-extension-template-vcloud-director
+ * Copyright 2011-2018 VMware, Inc.  All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
+ * ***************************************************************************/
+package com.vmware.vcloud.bindings.generator.typescript;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
+public abstract class TypescriptFile {
+    private Class<?> clazz;
+
+    private Set<Import> imports = new HashSet<>();
+    private List<Field> fields = new ArrayList<>();
+
+    public Set<Import> getImports() {
+        return Collections.unmodifiableSet(imports);
+    }
+
+    public List<Field> getFields() {
+        return Collections.unmodifiableList(fields);
+    }
+
+    public static TypescriptClass createClass(final Class<?> clazz) {
+        Objects.requireNonNull(clazz);
+        if (clazz.isEnum()) {
+            throw new IllegalArgumentException("Can't create Typescript class for enum " + clazz.getSimpleName() + ".  Try creating Typescript enum instead.");
+        }
+
+        final TypescriptClass tc = new TypescriptClass(clazz);
+        Arrays.stream(clazz.getDeclaredFields()).forEach(field -> tc.processField(field, clazz));
+
+        return tc;
+    }
+
+    public static TypescriptEnum createEnum(final Class<?> clazz) {
+        Objects.requireNonNull(clazz);
+        if (!clazz.isEnum()) {
+            throw new IllegalArgumentException("Can't create Typescript enum for class " + clazz.getSimpleName() + ".  Try creating Typescript class instead.");
+        }
+
+        TypescriptEnum te = new TypescriptEnum(clazz);
+        Arrays.stream(clazz.getDeclaredFields()).forEach(field -> te.processField(field, clazz));
+
+        return te;
+    }
+
+    public String getName() {
+        return clazz.getSimpleName();
+    }
+
+    protected Class<?> getClazz() {
+        return clazz;
+    }
+
+    protected void setClazz(Class<?> clazz) {
+        this.clazz = clazz;
+    }
+
+    protected void addField(final String name, final String type) {
+        Field field = new Field();
+        field.name = name;
+        field.type = type;
+
+        fields.add(field);
+    }
+
+    protected void addField(final String name) {
+        Field field = new Field();
+        field.name = name;
+
+        this.fields.add(field);
+    }
+
+    protected void addImport(final Class<?> usingClass, final Class<?> referencedClass) {
+        if (referencedClass == null || referencedClass.getName().startsWith("java")) {
+            return;
+        }
+
+        Path usingClassPath = Paths.get(usingClass.getPackage().getName().replace(".", "/")).normalize();
+        Path referencedClassPath = Paths.get(referencedClass.getName().replace(".", "/")).normalize();
+
+        this.imports.add(new Import(referencedClass.getSimpleName(), "./" + usingClassPath.relativize(referencedClassPath).toString().replace("\\", "/")));
+    }
+
+    protected abstract void processField(final java.lang.reflect.Field field, final Class<?> clazz);
+
+    public static class Import {
+        private String definition;
+        private String module;
+
+        public Import(final String definition, final String module) {
+            this.definition = definition;
+            this.module = module;
+        }
+
+        public String getDefinition() {
+            return definition;
+        }
+
+        public String getModule() {
+            return module;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof Import)) {
+                return false;
+            }
+
+            Import other = (Import) obj;
+            return Objects.equals(this.definition, other.definition) && Objects.equals(this.module, other.module);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.definition, this.module);
+        }
+    }
+
+    public static class Field {
+        private String name;
+        private String type;
+        private boolean required;
+
+        public String getName() {
+            return name;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public boolean isRequired() {
+            return required;
+        }
+
+        @Override
+        public String toString() {
+            ToStringBuilder builder = new ToStringBuilder(this, ToStringStyle.NO_CLASS_NAME_STYLE).append(getName());
+            if (type != null) {
+                builder.append(": ").append(type);
+            }
+
+            return builder.toString();
+        }
+    }
+}

--- a/java/api-schemas/tooling/bindings-generator/src/main/java/com/vmware/vcloud/bindings/generator/typescript/TypescriptMapper.java
+++ b/java/api-schemas/tooling/bindings-generator/src/main/java/com/vmware/vcloud/bindings/generator/typescript/TypescriptMapper.java
@@ -1,0 +1,106 @@
+/* ***************************************************************************
+ * api-extension-template-vcloud-director
+ * Copyright 2011-2018 VMware, Inc.  All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
+ * ***************************************************************************/
+package com.vmware.vcloud.bindings.generator.typescript;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
+import java.util.Date;
+
+import javax.xml.datatype.Duration;
+import javax.xml.datatype.XMLGregorianCalendar;
+import javax.xml.namespace.QName;
+
+import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.reflect.TypeUtils;
+
+public class TypescriptMapper {
+    public boolean isBuiltInType(Type type) {
+        return isBooleanType(type)
+                || isDateType(type)
+                || isNumberType(type)
+                || isStringType(type);
+    }
+
+    private String getInternalTypeName(final Type type) {
+        if (isBooleanType(type)) {
+            return "boolean";
+        }
+
+        if (isDateType(type)) {
+            return "Date";
+        }
+
+        if (isNumberType(type)) {
+            return "number";
+        }
+
+        if (isStringType(type)) {
+            return "string";
+        }
+
+        return null;
+    }
+
+    private boolean isBooleanType(final Type type) {
+        return TypeUtils.isAssignable(type, boolean.class)
+                || TypeUtils.isAssignable(type, Boolean.class);
+    }
+
+    private boolean isNumberType(final Type type) {
+        return TypeUtils.isAssignable(type, Number.class)
+                || TypeUtils.isAssignable(type, byte.class)
+                || TypeUtils.isAssignable(type, short.class)
+                || TypeUtils.isAssignable(type, int.class)
+                || TypeUtils.isAssignable(type, long.class)
+                || TypeUtils.isAssignable(type, float.class)
+                || TypeUtils.isAssignable(type, double.class);
+    }
+
+    private boolean isStringType(final Type type) {
+        return TypeUtils.isAssignable(type, String.class)
+                || TypeUtils.isAssignable(type, char[].class)
+                || TypeUtils.isAssignable(type, byte[].class)
+                || TypeUtils.isAssignable(type, Duration.class);
+    }
+
+    private boolean isDateType(final Type type) {
+        return TypeUtils.isAssignable(type, XMLGregorianCalendar.class)
+                || TypeUtils.isAssignable(type, Date.class);
+    }
+
+    public String getTypeName(final Type type) {
+        if (type instanceof ParameterizedType) {
+            final ParameterizedType parameterizedType = (ParameterizedType) type;
+            Type superType = parameterizedType.getActualTypeArguments()[0];
+            return getTypeName(superType);
+        }
+
+        if (type instanceof Class) {
+            if (((Class<?>) type).equals(Object.class)) {
+                return "object";
+            }
+
+            if (((Class<?>) type).equals(QName.class)) {
+                return "object";
+            }
+
+            String name = getInternalTypeName(type);
+            return name != null ? name : ClassUtils.getSimpleName((Class<?>) type);
+        }
+
+        if (type instanceof WildcardType) {
+            Type superType = ((WildcardType) type).getUpperBounds()[0];
+
+            if (superType instanceof Class) {
+                String name = getInternalTypeName(superType);
+                return name != null ? name : ClassUtils.getSimpleName((Class<?>) superType);
+            }
+        }
+
+        throw new IllegalArgumentException("Unable to determine type name for " + type);
+    }
+}

--- a/java/api-schemas/tooling/bindings-generator/src/main/resources/logback.xml
+++ b/java/api-schemas/tooling/bindings-generator/src/main/resources/logback.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+ api-extension-template-vcloud-director
+ Copyright 2018 VMware, Inc.
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.vmware.vcloud.bindings" level="debug"/>
+    <logger name="com.vmware.vcloud.bindings.generator.BindingsGenerator$1" level="off"/>
+
+    <root level="error">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/java/api-schemas/tooling/bindings-generator/src/main/resources/typescript/class.ts.vm
+++ b/java/api-schemas/tooling/bindings-generator/src/main/resources/typescript/class.ts.vm
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) ${year} VMware, Inc. All rights reserved.
+ */
+#foreach(${import} in ${class.imports})
+import {${import.definition}} from "${import.module}";
+#end
+
+export#if(${class.isAbstract}) abstract#end class ${class.name} #if(${class.parent})extends ${class.parent} #end{
+#foreach(${field} in ${class.fields})
+    public ${field.name}#if(!${field.required})?#end: ${field.type};
+#end
+}
+
+export namespace ${class.name} {
+    export class Fields #if(${class.parent})extends ${class.parent}.Fields #end{
+#foreach(${field} in ${class.fields})
+        public static readonly $field.name.replaceAll("(.)(\p{Upper})", "$1_$2").toUpperCase(): "${field.name}";
+#end
+    }
+}

--- a/java/api-schemas/tooling/bindings-generator/src/main/resources/typescript/enum.ts.vm
+++ b/java/api-schemas/tooling/bindings-generator/src/main/resources/typescript/enum.ts.vm
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) ${year} VMware, Inc. All rights reserved.
+ */
+export enum ${class.name} {
+#foreach(${field} in ${class.fields})
+    ${field.name},
+#end
+}

--- a/java/api-schemas/tooling/bindings-generator/src/main/resources/typescript/index.ts.vm
+++ b/java/api-schemas/tooling/bindings-generator/src/main/resources/typescript/index.ts.vm
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) ${year} VMware, Inc. All rights reserved.
+ */
+#foreach(${import} in ${imports})
+#if(${import.endsWith("/")})
+import * as ${_formatter.chop(${import})} from './${import}';
+export {
+    ${_formatter.chop(${import})}
+}
+#else
+export * from './${import}';
+#end
+#end

--- a/java/api-schemas/tooling/vcd-bindings-maven-plugin/pom.xml
+++ b/java/api-schemas/tooling/vcd-bindings-maven-plugin/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!--
+ api-extension-template-vcloud-director
+ Copyright 2018 VMware, Inc.
+ SPDX-License-Identifier: BSD-2-Clause
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.vmware.vcloud</groupId>
+    <artifactId>vcd-bindings-maven-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
+    <version>1.0.0</version>
+    <name>binding-plugin Maven Mojo</name>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>2.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.5.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vmware.vcloud</groupId>
+            <artifactId>bindings-generator</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <mojoDependencies>
+                        <value>com.vmware.vcloud:vcd-bindings-maven-plugin</value>
+                    </mojoDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/java/api-schemas/tooling/vcd-bindings-maven-plugin/src/main/java/com/vmware/vcloud/binding/plugin/TypescriptBindingsGeneratorMojo.java
+++ b/java/api-schemas/tooling/vcd-bindings-maven-plugin/src/main/java/com/vmware/vcloud/binding/plugin/TypescriptBindingsGeneratorMojo.java
@@ -1,0 +1,36 @@
+/* ***************************************************************************
+ * api-extension-template-vcloud-director
+ * Copyright 2011-2018 VMware, Inc.  All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
+ * ***************************************************************************/
+package com.vmware.vcloud.binding.plugin;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import com.vmware.vcloud.bindings.generator.BindingsGenerator;
+
+@Mojo(name = "generate-typescript")
+public class TypescriptBindingsGeneratorMojo extends AbstractMojo {
+    @Parameter(defaultValue = "${project.build.directory}/generated-typescript-bindings")
+    private File outputDirectory;
+
+    @Parameter(required = true)
+    private List<String> packages;
+
+    @Parameter(defaultValue = "true")
+    private boolean overwrite;
+
+    public void execute() throws MojoExecutionException {
+        getLog().info("Generating bindings into " + outputDirectory.getAbsolutePath());
+        new BindingsGenerator(packages)
+            .outputDir(outputDirectory)
+            .overwrite(overwrite)
+            .generate();
+    }
+}


### PR DESCRIPTION
This change adds a bindings generator that processes the JAXB
annotations from vCD's Java API bindings and uses that information to
construct Typescript bindings of the XSD-based schemas.  A Maven plugin
is also included.

This tool focuses specifically on the XML-based APIs because the newer
APIs available at the /cloudapi endpoint are based on YAML definitions
and have generation support available through OpenAPI tooling.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>