### PR TITLE
Add new overwrite type to bindings generation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ yarn-error.log
 
 # Eclipse
 .metadata/
+.project
+.classpath
+.settings/

--- a/java/api-schemas/tooling/bindings-generator/src/main/java/com/vmware/vcloud/bindings/generator/OverwriteType.java
+++ b/java/api-schemas/tooling/bindings-generator/src/main/java/com/vmware/vcloud/bindings/generator/OverwriteType.java
@@ -1,0 +1,12 @@
+/* ***************************************************************************
+ * api-extension-template-vcloud-director
+ * Copyright 2011-2018 VMware, Inc.  All rights reserved.
+ * SPDX-License-Identifier: BSD-2-Clause
+ * ***************************************************************************/
+package com.vmware.vcloud.bindings.generator;
+
+public enum OverwriteType {
+    Full,
+    Merge,
+    None
+}

--- a/java/api-schemas/tooling/vcd-bindings-maven-plugin/src/main/java/com/vmware/vcloud/binding/plugin/TypescriptBindingsGeneratorMojo.java
+++ b/java/api-schemas/tooling/vcd-bindings-maven-plugin/src/main/java/com/vmware/vcloud/binding/plugin/TypescriptBindingsGeneratorMojo.java
@@ -15,6 +15,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import com.vmware.vcloud.bindings.generator.BindingsGenerator;
 import com.vmware.vcloud.bindings.generator.OutputType;
+import com.vmware.vcloud.bindings.generator.OverwriteType;
 
 @Mojo(name = "generate-typescript")
 public class TypescriptBindingsGeneratorMojo extends AbstractMojo {
@@ -24,8 +25,8 @@ public class TypescriptBindingsGeneratorMojo extends AbstractMojo {
     @Parameter(required = true)
     private List<String> packages;
 
-    @Parameter(defaultValue = "true")
-    private boolean overwrite;
+    @Parameter(defaultValue = "None")
+    private OverwriteType overwrite;
 
     @Parameter(defaultValue = "Class")
     private OutputType outputType;

--- a/ui/api-client/README.md
+++ b/ui/api-client/README.md
@@ -14,13 +14,13 @@ An Angular module that provides a REST API client with consistent handling of pa
 ### Prerequisites ###
 Before the `api-client` packages can be built, the `java/api-schemas` projects must be built.  Generation of the Java API bindings is a prerequisite to generating the Typescript bindings because it is these Java classes that drive the binding generation.  From the `vcd-ext-sdk` project root directory:
 ```bash
-cd java/api-schemas
+cd java
 mvn install
 ```
 
 Next navigate to the `api-client` folder and generate the bindings.  **Note: these steps only need to be performed when the bindings change.**
 ```bash
-cd ../../ui/api-client
+cd ../ui/api-client
 mvn generate-sources
 ```
 

--- a/ui/api-client/pom.xml
+++ b/ui/api-client/pom.xml
@@ -15,6 +15,29 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>io.swagger</groupId>
+        <artifactId>swagger-codegen-maven-plugin</artifactId>
+        <version>2.3.1</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <output>${basedir}/packages/bindings/target/generated-typescript-bindings</output>
+          <inputSpec>${project.basedir}/../../java/api-schemas/openapi-schemas/src/main/resources/schemas/vcloud-openapi-schemas.yaml</inputSpec>
+          <language>typescript-angular</language>
+          <generateApis>false</generateApis>
+          <generateModelTests>false</generateModelTests>
+          <generateModelDocumentation>false</generateModelDocumentation>
+          <generateSupportingFiles>false</generateSupportingFiles>
+          <modelPackage>vcloud.rest.openapi.model</modelPackage>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>com.vmware.vcloud</groupId>
         <artifactId>vcd-bindings-maven-plugin</artifactId>
         <version>1.0.0</version>
@@ -27,6 +50,7 @@
           </execution>
         </executions>
         <configuration>
+          <overwrite>Merge</overwrite>
           <outputDirectory>${basedir}/packages/bindings/target/generated-typescript-bindings</outputDirectory>
           <packages>
             <package>com.vmware.vcloud.api.rest.schema.ovf</package>


### PR DESCRIPTION
The overwrite flag was previously a boolean.  It has been changed to an
enum to support full rewrite, full failure, or a merge attempt.  The
merge is useful for incorporating Open API models which have their own
generation mechanism, and allowing the barrels to take the Open API
models into account.

The api-client project has been updated to include Open API bindings.