### PR TITLE
Move SDK toward better backward compatibility.

### DIFF
--- a/ui/api-client/packages/sdk/src/common/container-hooks.ts
+++ b/ui/api-client/packages/sdk/src/common/container-hooks.ts
@@ -2,14 +2,18 @@
  * This is the currently supported - albeit very minimal - public SDK.
  */
 
-import {OpaqueToken} from '@angular/core';
+import {OpaqueToken, NgModule} from '@angular/core';
 
 // Bind straight into the hooks provided by the container.
 if (!window["System"] || !window["System"]["registry"] || !window["System"]["registry"]["get"]) {
     throw new Error("SystemJS registry not found");
 }
 
-const containerHooks: any = window["System"]["registry"]["get"]("@vcd/common");
+let containerHooks: any = window["System"]["registry"]["get"]("@vcd/common");
+if (!containerHooks) {
+    containerHooks = window["System"]["registry"]["get"]("@vcd-ui/common");
+}
+
 if (!containerHooks) {
     throw new Error("VCD UI container hooks not present in SystemJS registry");
 }

--- a/ui/api-client/packages/sdk/src/common/index.ts
+++ b/ui/api-client/packages/sdk/src/common/index.ts
@@ -1,0 +1,1 @@
+export * from './container-hooks'

--- a/ui/api-client/packages/sdk/src/index.ts
+++ b/ui/api-client/packages/sdk/src/index.ts
@@ -1,15 +1,20 @@
-import { NgModule, ModuleWithProviders } from '@angular/core';
+import { ModuleWithProviders , NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 import { VcdApiClient } from './vcd.api.client';
 import { httpInterceptorProviders } from './http-interceptors';
 
-export * from './container-hooks';
+import * as query from './query';
+import * as common from './common';
+
 export * from './vcd.api.client';
-export * from './query';
 export * from './api.result.service';
 
-export { httpInterceptorProviders };
+export { 
+  common,
+  httpInterceptorProviders,
+  query
+};
 
 @NgModule({
   imports: [
@@ -18,7 +23,7 @@ export { httpInterceptorProviders };
   ],
   declarations: [],
   exports: [],
-  providers: [VcdApiClient,httpInterceptorProviders]
+  providers: [httpInterceptorProviders, VcdApiClient]
 })
 export class VcdSdkModule {
 }

--- a/ui/vcd-plugin-seed/src/main/simple-plugin.module.ts
+++ b/ui/vcd-plugin-seed/src/main/simple-plugin.module.ts
@@ -3,7 +3,8 @@ import {Inject, NgModule, Optional} from "@angular/core";
 import {Routes, RouterModule} from "@angular/router";
 import {ClarityModule} from "clarity-angular";
 import {Store} from "@ngrx/store";
-import {API_ROOT_URL, EXTENSION_ROUTE, ExtensionNavRegistration, ExtensionNavRegistrationAction, I18nModule, AuthTokenHolderService, VcdApiClient, VcdSdkModule} from "@vcd/sdk";
+import { VcdApiClient, VcdSdkModule } from "@vcd/sdk";
+import { EXTENSION_ROUTE, ExtensionNavRegistration, ExtensionNavRegistrationAction, I18nModule } from "@vcd/sdk/common";
 import {SimpleComponent} from "./simple/simple.component";
 
 const ROUTES: Routes = [
@@ -26,8 +27,7 @@ const ROUTES: Routes = [
     providers: [VcdApiClient]
 })
 export class SimplePluginModule {
-    constructor(private appStore: Store<any>, @Inject(EXTENSION_ROUTE) extensionRoute: string, @Inject(API_ROOT_URL) private baseUrl: string, private client: VcdApiClient,
-            @Optional() private authToken: AuthTokenHolderService) {
+    constructor(private appStore: Store<any>, @Inject(EXTENSION_ROUTE) extensionRoute: string) {
         const registration: ExtensionNavRegistration = {
             path: extensionRoute,
             icon: "page",
@@ -36,10 +36,5 @@ export class SimplePluginModule {
         };
 
         appStore.dispatch(new ExtensionNavRegistrationAction(registration));
-
-        this.client.baseUrl = this.baseUrl;
-        if (this.authToken) {
-            this.client.setAuthentication(this.authToken.token).subscribe();
-        }
     }
 }

--- a/ui/vcd-plugin-seed/src/main/simple/simple.component.ts
+++ b/ui/vcd-plugin-seed/src/main/simple/simple.component.ts
@@ -1,5 +1,6 @@
 import { Component, Inject, OnInit } from "@angular/core";
-import { EXTENSION_ASSET_URL, VcdApiClient } from '@vcd/sdk';
+import { VcdApiClient } from '@vcd/sdk';
+import { EXTENSION_ASSET_URL } from '@vcd/sdk/common';
 
 @Component({
     selector: "plugin-simple",

--- a/ui/vcd-plugin-seed/src/main/subnav-plugin.module.ts
+++ b/ui/vcd-plugin-seed/src/main/subnav-plugin.module.ts
@@ -3,7 +3,7 @@ import {Inject, NgModule} from "@angular/core";
 import {Routes, RouterModule} from "@angular/router";
 import {ClarityModule} from "clarity-angular";
 import {Store} from "@ngrx/store";
-import {EXTENSION_ROUTE, ExtensionNavRegistration, ExtensionNavRegistrationAction, I18nModule} from "@vcd/sdk";
+import {EXTENSION_ROUTE, ExtensionNavRegistration, ExtensionNavRegistrationAction, I18nModule} from "@vcd/sdk/common";
 import {SubnavComponent} from "./subnav/subnav.component";
 import {AboutComponent} from "./subnav/about.component";
 import {StatusComponent} from "./subnav/status.component";

--- a/ui/vcd-plugin-seed/src/main/subnav/about.component.ts
+++ b/ui/vcd-plugin-seed/src/main/subnav/about.component.ts
@@ -2,7 +2,7 @@
  * Copyright 2018 VMware, Inc. All rights reserved. VMware Confidential
  */
 import {Component, Inject} from "@angular/core";
-import {EXTENSION_ASSET_URL} from '@vcd/sdk';
+import {EXTENSION_ASSET_URL} from '@vcd/sdk/common';
 
 @Component({
     selector: "vcd-plugin-about",

--- a/ui/vcd-plugin-seed/src/main/subnav/status.component.ts
+++ b/ui/vcd-plugin-seed/src/main/subnav/status.component.ts
@@ -2,7 +2,7 @@
  * Copyright 2018 VMware, Inc. All rights reserved. VMware Confidential
  */
 import {Component, Inject} from "@angular/core";
-import {EXTENSION_ASSET_URL} from '@vcd/sdk';
+import {EXTENSION_ASSET_URL} from '@vcd/sdk/common';
 
 @Component({
     selector: "vcd-plugin-status",

--- a/ui/vcd-plugin-seed/src/main/subnav/subnav.component.ts
+++ b/ui/vcd-plugin-seed/src/main/subnav/subnav.component.ts
@@ -1,5 +1,5 @@
 import {Component, Inject} from "@angular/core";
-import {EXTENSION_ASSET_URL} from '@vcd/sdk';
+import {EXTENSION_ASSET_URL} from '@vcd/sdk/common';
 
 @Component({
     selector: "plugin-subnav",


### PR DESCRIPTION
Note: this change does not yet make the SDK fully backward compatible to
the 9.1 release of vCloud Director, but it is a step in the right
direction.  This change will attempt to register the container hooks
from @vcd/common which is a new location for hooks.  If that fails it
will attempt to load hooks from @vcd-ui/common (the old location) before
failing.

This change also makes some improvements to the SDK and to the seed
project.  Since the container hooks are now part of the @vcd/sdk
package, the VcdApiClient can manage its own injection of API base URL,
authentication token, etc. and so the plugin module no longer needs to
include this plumbing.  A side effect is that the clients session info
is not immeidately available, so the client methods that parsed specific
fields from the session have been changed to return Observables tracking
a BehaviorSubject.

Testing Done:
Built and deployed the seed plugin to a vCD instance and verified the
plugin successfully loaded.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>