### PR TITLE
Add basic CRUD capabilities to @vcd/sdk.

### DIFF
--- a/ui/api-client/packages/sdk/src/http-interceptors/request.headers.interceptor.ts
+++ b/ui/api-client/packages/sdk/src/http-interceptors/request.headers.interceptor.ts
@@ -8,37 +8,38 @@ export class RequestHeadersInterceptor implements HttpInterceptor {
     set enabled(_enabled: boolean) {
         this._enabled = _enabled;
     }
-    
+
     private _version: string = '31.0';
     set version(_version: string) {
         this._version = _version;
     }
-    
+
     private _authenticationHeader: string = 'Authorization';
     private _authentication: string;
     set authentication(_authentication: string) {
         this._authentication = _authentication;
         this._authenticationHeader = (this._authentication.length > 32) ? 'Authorization' : 'x-vcloud-authorization';
     }
-    
+
     intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         let headers = this.setAcceptHeader(req);
-        headers = headers.delete('_multisite');
+        headers = headers.set('Content-Type', 'application/*+json');
         if (this._authentication) {
             headers = headers.set(this._authenticationHeader, `${this._authentication}`);
         }
-            
+
         const customReq: HttpRequest<any> = req.clone({
             headers: headers
         });
-        
+
         return next.handle(customReq);
     }
 
     private setAcceptHeader(request: HttpRequest<any>): HttpHeaders {
         const value = request.headers.get('_multisite');
+        const headers = request.headers.delete('_multisite');
 
-        return request.headers.set(
+        return headers.set(
             'Accept', [
                 `application/*+json;version=${this._version}${value ? `;multisite=${value}` : ''}`,
                 `application/json;version=${this._version}${value ? `;multisite=${value}` : ''}`


### PR DESCRIPTION
This change adds both synchronous and asynchronous versions of create,
update, and delete to the VcdApiClient, along with a get.  Al of these
methods are to be considered low level API calls-they rely on pure
relative URL endpoints rather than the link navigation that is typical
of the core vCloud Director API.  These calls are ultimately a necessary
part of the SDK, since the SDK needs to support API extensions in
addition to the core API.  These low level calls WILL give a client the
capability to consume most of the existing APIs.

All ****Async versions of the functions return a TaskType.  The task is
parsed from either the Location header (OpenAPI style) or the response
body (XSD-based API style) as appropriate.

Two convenience methods have also been added: getEntity() and
removeItem().  getEntity() resolves a URN-based id or an entity
reference to a specific instance of an EntityReferenceType by using the
entityResolver URL and then automatically following the response links.
removeItem() removes a ResourceType by treating it as a navigable
object, ensuring that the appropriate 'remove' link exists, and calling
the appropriate href, all without the API consumer needing to specify
any URL fragments.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>