### PR TITLE
Fix API calls to work on the /cloudapi endpoint.

### DIFF
--- a/ui/api-client/packages/sdk/src/http-interceptors/request.headers.interceptor.ts
+++ b/ui/api-client/packages/sdk/src/http-interceptors/request.headers.interceptor.ts
@@ -23,7 +23,7 @@ export class RequestHeadersInterceptor implements HttpInterceptor {
 
     intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         let headers = this.setAcceptHeader(req);
-        headers = headers.set('Content-Type', 'application/*+json');
+        headers = headers.set('Content-Type', req.url.indexOf('cloudapi') > -1 ? 'application/json' : 'application/*+json');
         if (this._authentication) {
             headers = headers.set(this._authenticationHeader, `${this._authentication}`);
         }


### PR DESCRIPTION
Content-Type header for /api endpoints must match application/*+json to
be correctly evaluated by @Consumer annotations in the API handlers.
For the /cloudapi space, that header must be application/json.  Multiple
content types is not an option, so this fix simply uses one or the other
based on the request URL containing the 'cloudapi' string.

It isn't elegant.  It works for now.

Testing Done:
Performed a GET and PUT on the /cloudapi/branding endpoint to update the
portal name, and did a GET on /api/session and several query endpoints.
Verified that no calls returned a 415 error.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>