### PR TITLE
Fix serialization issues with underscores in models.

### DIFF
--- a/java/api-schemas/tooling/bindings-generator/src/main/resources/typescript/class.ts.vm
+++ b/java/api-schemas/tooling/bindings-generator/src/main/resources/typescript/class.ts.vm
@@ -14,7 +14,7 @@ export#if(${class.isAbstract}) abstract#end class ${class.name} #if(${class.pare
 export namespace ${class.name} {
     export class Fields #if(${class.parent})extends ${class.parent}.Fields #end{
 #foreach(${field} in ${class.fields})
-        public static readonly $field.name.replaceAll("(.)(\p{Upper})", "$1_$2").toUpperCase(): "${field.name}";
+        public static readonly $field.name.replaceAll("(.)(\p{Upper})", "$1_$2").toUpperCase(): string = "${field.name}";
 #end
     }
 }

--- a/java/api-schemas/tooling/bindings-generator/src/main/resources/typescript/index.ts.vm
+++ b/java/api-schemas/tooling/bindings-generator/src/main/resources/typescript/index.ts.vm
@@ -3,7 +3,7 @@
  */
 #foreach(${import} in ${imports})
 #if(${import.endsWith("/")})
-import * as ${_formatter.chop(${import})} from './${import}';
+import * as ${_formatter.chop(${import})} from './${import}/index';
 export {
     ${_formatter.chop(${import})}
 }

--- a/java/api-schemas/tooling/bindings-generator/src/main/resources/typescript/interface.ts.vm
+++ b/java/api-schemas/tooling/bindings-generator/src/main/resources/typescript/interface.ts.vm
@@ -14,7 +14,7 @@ export interface ${class.name} #if(${class.parent})extends ${class.parent} #end{
 export namespace ${class.name} {
     export class Fields #if(${class.parent})extends ${class.parent}.Fields #end{
 #foreach(${field} in ${class.fields})
-        public static readonly $field.name.replaceAll("(.)(\p{Upper})", "$1_$2").toUpperCase(): "${field.name}";
+        public static readonly $field.name.replaceAll("(.)(\p{Upper})", "$1_$2").toUpperCase(): string = "${field.name}";
 #end
     }
 }

--- a/ui/api-client/packages/bindings/tsconfig.json
+++ b/ui/api-client/packages/bindings/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es5",
+    "module": "es6",
+    "target": "es6",
     "lib": ["es2015", "dom"],
     "declaration": true,
     "outDir": "./build",

--- a/ui/api-client/pom.xml
+++ b/ui/api-client/pom.xml
@@ -15,6 +15,16 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>${basedir}/packages/bindings/target/generated-typescript-bindings</directory>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>io.swagger</groupId>
         <artifactId>swagger-codegen-maven-plugin</artifactId>
         <version>2.3.1</version>
@@ -35,6 +45,9 @@
           <generateModelDocumentation>false</generateModelDocumentation>
           <generateSupportingFiles>false</generateSupportingFiles>
           <modelPackage>vcloud.rest.openapi.model</modelPackage>
+          <configOptions>
+            <modelPropertyNaming>original</modelPropertyNaming>
+          </configOptions>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
The Swagger codegen for Typescript defaults to converting the Swagger
definition fields to camelCase instead of leaving them in their original
style.  This is a bit odd, since it causes JSON.stringify to produce
invalid JSON for the model.  The codegen process has been modified to
force use of original field name.  The codegen process also now includes
the generated typescript dir in a mvn clean.

Also fixed the string const definitions in field name generation, and
converted the @vcd/bindings package to an es6 module instead of a
commonjs module.  The rollup of plugins was having some issues trying to
determine the named exports from this package, causing the
rollup.config.js to require undeterministic tweaks.

Testing Done:
Regenerated models.  Visually inspected UiPluginMetadata to ensure
property was generated as tenant_scoped and not tenantScoped.  Ensured
/index in barrels, and successful build of @vcd/bindings.  Verified
successful build of a plugin that used bindings that were previously
problematic.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>