### PR TITLE
Add filtering and field selection to Query.Builder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+[![Build Status](https://travis-ci.org/vmware/vcd-ext-sdk.svg?branch=master)](https://travis-ci.org/vmware/vcd-ext-sdk)
+
+# vcd-ext-sdk
+
+## Overview
+
+The **vcd-ext-sdk** is a set of templates for creating extensions to VMware vCloud Director. Service Providers looking to add custom service offerings to vCloud Director, can use these templates as a starting point to build new services. The templates captures best practices for API, Object and, UI extension development and are offered in Java, Javascript/Typescript/nodejs and, Python.
+
+## Contributing
+
+The **vcd-ext-sdk** project team welcomes contributions from the community. Before you start working with **vcd-ext-sdk**, please read our [Developer Certificate of Origin](https://cla.vmware.com/dco). All contributions to this repository must be signed as described on that page. Your signature certifies that you wrote the patch or have the right to pass it on as an open-source patch. For more detailed information, refer to [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+
+[BSD-2](LICENSE.txt)

--- a/ui/api-client/packages/sdk/src/query/filter.builder.ts
+++ b/ui/api-client/packages/sdk/src/query/filter.builder.ts
@@ -1,0 +1,353 @@
+export namespace Filter {
+    class Operators {
+        public static readonly OR: string = ',';
+        public static readonly AND: string = ';';
+        public static readonly GT: string = '=gt=';
+        public static readonly GE: string = '=ge=';
+        public static readonly LT: string = '=lt=';
+        public static readonly LE: string = '=le=';
+        public static readonly EQ: string = '==';
+        public static readonly NEQ: string = '!=';
+    }
+
+    /**
+     * Collection of strategies for wilcard string matching.
+     */
+    export class MatchMode {
+        /**
+         * Match the start of a string.
+         */
+        public static readonly START: string = 'START';
+
+        /**
+         * Match the end of a string.
+         */
+        public static readonly END: string = 'END';
+
+        /**
+         * Match anywhere in the string.
+         */
+        public static readonly ANYWHERE: string = 'ANYWHERE';
+    }
+
+    /**
+     * A filter item that can define a comparison/condition.
+     */
+    export interface Property {
+        /**
+         * Create a filter condition to evaluate whether the property is equal to the specified value.
+         *
+         * @param value the pattern to evaluate
+         * @param moreValues optional additional patterns to evaluate that will be treated as an OR condition
+         * @returns an evaluatable filter condition
+         */
+        equalTo(value: (boolean | number | string), ...moreValues: (boolean | number | string)[]): CompleteCondition;
+
+        /**
+         * Create a filter condition to evaluate whether the property is not equal to the specified value.
+         *
+         * @param value the pattern to evaluate
+         * @returns an evaluatable filter condition
+         */
+        notEqualTo(value: (boolean | number | string)): CompleteCondition;
+
+        /**
+         * Create a filter condition to evaluate whether the property is less than the specified value.
+         *
+         * @param value the pattern to evaluate
+         * @returns an evaluatable filter condition
+         */
+        lessThan(value: number): CompleteCondition;
+
+        /**
+         * Create a filter condition to evaluate whether the property is less than or equal to the specified value.
+         *
+         * @param value the pattern to evaluate
+         * @returns an evaluatable filter condition
+         */
+        lessOrEqualTo(value: number): CompleteCondition;
+
+        /**
+         * Create a filter condition to evaluate whether the property is greater than the specified value.
+         *
+         * @param value the pattern to evaluate
+         * @returns an evaluatable filter condition
+         */
+        greaterThan(value: number): CompleteCondition;
+
+        /**
+         * Create a filter condition to evaluate whether the property is greater than or equal to the specified value.
+         *
+         * @param value the pattern to evaluate
+         * @returns an evaluatable filter condition
+         */
+        greaterOrEqualTo(value: number): CompleteCondition;
+
+        /**
+         * Create a filter condition to evaluate whether the property is a wildcard match with the specified value.
+         *
+         * @param value the pattern to evaluate
+         * @param mode the type of wildcard evaluation to perform
+         * @returns an evaluatable filter condition
+         */
+        like(value: string, mode: MatchMode): CompleteCondition;
+    }
+
+    /**
+     * A representation of a condition that is incomplete by itself, like an empty condition, aggregation wrapper, or junction.
+     */
+    export interface PartialCondition {
+        /**
+         * Create a simple property to be evaulated as a filter condition.
+         *
+         * @param property the name of the property
+         * @returns a Property instance for defining a filter condition
+         */
+        is(property: string): Property;
+
+        /**
+         * Create a conjunction (AND) condition from existing conditions.
+         *
+         * @param condition1 first condition
+         * @param condition2 second condition
+         * @param conditionN any additional conditions
+         * @returns an evaluatable filter condition
+         */
+        and(condition1: CompleteCondition, condition2: CompleteCondition, ...conditionN: CompleteCondition[]): CompleteCondition;
+
+        /**
+         * Create a disjunction (OR) condition from existing conditions.
+         *
+         * @param condition1 first condition
+         * @param condition2 second condition
+         * @param conditionN any additional conditions
+         * @returns an evaluatable filter condition
+         */
+        or(condition1: CompleteCondition, condition2: CompleteCondition, ...conditionN: CompleteCondition[]): CompleteCondition;
+    }
+
+    /**
+     * An evaluatable filter condition.
+     */
+    export interface CompleteCondition {
+        /**
+         * Add a condtion to this condition.
+         *
+         * This new condition will be ANDed to the existing condition.
+         *
+         * @returns an incomplete (empty) condition
+         */
+        and(): PartialCondition;
+
+        /**
+         * Add a condtion to this condition.
+         *
+         * This new condition will be ORed to the existing condition.
+         *
+         * @returns an incomplete (empty) condition
+         */
+        or(): PartialCondition;
+
+        /**
+         * Build the FIQL representation of the condition.
+         *
+         * @returns a FIQL string
+         */
+        query(): string;
+    }
+
+    class BuilderChain implements CompleteCondition, PartialCondition, Property {
+        private result: string = '';
+        private parent: BuilderChain;
+        private currentCompositeOp: string;
+
+        constructor(parent?: BuilderChain) {
+            this.parent = parent;
+        }
+
+        public query(): string {
+            return this.buildPartial();
+        }
+
+        public and(): PartialCondition;
+        public and(condition1: CompleteCondition, condition2: CompleteCondition, ...conditionN: CompleteCondition[]): CompleteCondition;
+        public and(condition1?: CompleteCondition, condition2?: CompleteCondition, ...conditionN: CompleteCondition[]): PartialCondition | CompleteCondition {
+            if (!condition1) {
+                return this.simpleAnd();
+            }
+
+            this.result += "(" + (<BuilderChain> condition1).buildPartial() + Operators.AND + (<BuilderChain> condition2).buildPartial();
+            if (conditionN.length) {
+                conditionN.forEach((condition) => {
+                    this.result += Operators.AND + (<BuilderChain> condition).buildPartial();
+                });
+            }
+
+            this.result += ")";
+            return this;
+        }
+
+        private simpleAnd(): PartialCondition {
+            if (this.currentCompositeOp == Operators.OR || this.parent && this.parent.currentCompositeOp == Operators.OR) {
+                if (this.parent) {
+                    this.parent.result = '(' + this.parent.result;
+                    this.result += ')';
+                } else {
+                    this.wrap();
+                }
+
+                this.currentCompositeOp = Operators.AND;
+            }
+
+            this.result += Operators.AND;
+            return this;
+        }
+
+        public or(): PartialCondition;
+        public or(condition1: CompleteCondition, condition2: CompleteCondition, ...conditionN: CompleteCondition[]): CompleteCondition;
+        public or(condition1?: CompleteCondition, condition2?: CompleteCondition, ...conditionN: CompleteCondition[]): PartialCondition | CompleteCondition {
+            if (!condition1) {
+                return this.simpleOr();
+            }
+
+            this.result += "(" + (<BuilderChain> condition1).buildPartial() + Operators.OR + (<BuilderChain> condition2).buildPartial();
+            if (conditionN.length) {
+                conditionN.forEach((condition) => {
+                    this.result += Operators.OR + (<BuilderChain> condition).buildPartial();
+                });
+            }
+
+            this.result += ")";
+            return this;
+        }
+
+        private simpleOr(): PartialCondition {
+            if (this.currentCompositeOp == Operators.AND || (this.parent && this.parent.currentCompositeOp == Operators.AND)) {
+                if (this.parent) {
+                    this.parent.result = '(' + this.parent.result;
+                    this.result += ')';
+                } else {
+                    this.wrap();
+                }
+
+                this.currentCompositeOp = Operators.OR;
+            }
+
+            this.result += Operators.OR;
+            return this;
+        }
+
+        private wrap(): CompleteCondition {
+            this.result = '(' + this.result + ')';
+            this.currentCompositeOp = null;
+            return this;
+        }
+
+        private buildPartial(): string {
+            return (this.parent) ? this.parent.buildPartial() + this.result : this.result;
+        }
+
+        public is(property: string): Property {
+            let builder: BuilderChain = new BuilderChain(this);
+            builder.result = property;
+            return builder;
+        }
+
+        public equalTo(value: (boolean | number | string), ...moreValues: (boolean | number | string)[]): CompleteCondition {
+            return this.condition(Operators.EQ, value, ...moreValues);
+        }
+
+        public notEqualTo(value: (boolean | number | string)): CompleteCondition {
+            return this.condition(Operators.NEQ, value);
+        }
+
+        public lessThan(value: number): CompleteCondition {
+            return this.condition(Operators.LT, value);
+        }
+
+        public lessOrEqualTo(value: number): CompleteCondition {
+            return this.condition(Operators.LE, value);
+        }
+
+        public greaterThan(value: number): CompleteCondition {
+            return this.condition(Operators.GT, value);
+        }
+
+        public greaterOrEqualTo(value: number): CompleteCondition {
+            return this.condition(Operators.GE, value);
+        }
+
+        public like(value: string, mode: MatchMode = MatchMode.START): CompleteCondition {
+            let wildcardValue: string;
+            switch (mode) {
+                case MatchMode.START:
+                    wildcardValue = `${value}*`;
+                    break;
+                case MatchMode.END:
+                    wildcardValue = `*${value}`;
+                    break;
+                case MatchMode.ANYWHERE:
+                    wildcardValue = `*${value}*`;
+                    break;
+                default:
+                    wildcardValue = value;
+                    break;
+            }
+
+            return this.condition(Operators.EQ, wildcardValue);
+        }
+
+        private condition(operator: string, value: any, ...moreValues: any[]): CompleteCondition {
+            const name = this.result;
+            this.result += operator + encodeURI(value as string);
+            if (moreValues.length) {
+                moreValues.forEach((next) => {
+                    this.result += ',' + name + operator + encodeURI(next as string);
+                });
+
+                this.currentCompositeOp = Operators.OR;
+            }
+
+            return this;
+        }
+    }
+
+    /**
+     * Builds a FIQL search condition using a fluent interface.
+     */
+    export class Builder implements PartialCondition {
+        /**
+         * Create a simple property to be evaulated as a filter condition.
+         *
+         * @param property the name of the property
+         * @returns a Property instance for defining a filter condition
+         */
+        is(property: string): Property {
+            return new BuilderChain().is(property);
+        }
+
+        /**
+         * Create a conjunction (AND) condition from existing conditions.
+         *
+         * @param condition1 first condition
+         * @param condition2 second condition
+         * @param conditionN any additional conditions
+         * @returns an evaluatable filter condition
+         */
+        and(condition1: CompleteCondition, condition2: CompleteCondition, ...conditionN: CompleteCondition[]): CompleteCondition {
+            return new BuilderChain().and.apply(this, arguments);
+        }
+
+        /**
+         * Create a disjunction (OR) condition from existing conditions.
+         *
+         * @param condition1 first condition
+         * @param condition2 second condition
+         * @param conditionN any additional conditions
+         * @returns an evaluatable filter condition
+         */
+        or(condition1: CompleteCondition, condition2: CompleteCondition, ...conditionN: CompleteCondition[]): CompleteCondition {
+            return new BuilderChain().or.apply(this, arguments);
+        }
+    }
+}

--- a/ui/api-client/packages/sdk/src/query/index.ts
+++ b/ui/api-client/packages/sdk/src/query/index.ts
@@ -1,1 +1,2 @@
-export * from './query.builder'
+export * from './query.builder';
+export * from './filter.builder';

--- a/ui/api-client/packages/sdk/src/query/query.builder.ts
+++ b/ui/api-client/packages/sdk/src/query/query.builder.ts
@@ -1,9 +1,13 @@
+import { Filter } from './filter.builder';
+
 export namespace Query {
     export class Builder {
         private _type: string;
         private _format: Format = Format.ID_RECORDS;
         private _links: boolean = true;
         private _pageSize: number = 25;
+        private _fields: string[];
+        private _filter: string;
 
         private constructor() { }
 
@@ -28,8 +32,25 @@ export namespace Query {
             return this;
         }
 
+        public fields(...fields: string[]): Builder {
+            this._fields = fields;
+            return this;
+        }
+
+        public filter(filter: string): Builder {
+            this._filter = filter;
+            return this;
+        }
+
         public get(): string {
             let query: string = `?type=${this._type}&format=${this._format}&links=${this._links}&pageSize=${this._pageSize}`;
+            if (this._fields && this._fields.length > 0) {
+                query += `&fields=${this._fields.join(',')}`;
+            }
+
+            if (this._filter) {
+                query += `&filter=${this._filter}`;
+            }
 
             return query;
         }


### PR DESCRIPTION
This change adds the ability to specify which fields of a query record
to populate.  If specific fields are not requested (the default
behavior), the entire record is returned.

A Filter.Builder has also been added to support programmatic creation of
filter conditions, using a fluent API style heavily influenced by the
Apache CXF SearchConditionBuilder.  The builder supports creating
conditions for equals, not equals, less than, less than or equal,
greater than, greater than or equal, and wildcard equals (like), as well
as conjunctions and disjunctions.  Strings, numbers, and booleans are
currently supported where appropriate by the different comparison
operations.

Testing Done:

Executed the following statement in a plugin:
```
let builder = new Filter.Builder();
let filter = builder.is('isEnabled').equalTo(true).and().or(
    builder.is('name').like('%aaaa', Filter.MatchMode.START),
    builder.is('name).like('org', Filter.MatchMode.START)
).query();
this.client.query(Query.Builder.ofType('organization').links(false)
    .filter(filter).fields('displayName')).subscribe(console.log);
```

Verified that the URL was built with a valid FIQL string, that the
query did the appropriate level of filtering, and that only the
displayName was populated in the respose records.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>