### PR TITLE
Support sorting in Query.Builder.

### DIFF
--- a/ui/api-client/packages/sdk/src/query/filter.builder.ts
+++ b/ui/api-client/packages/sdk/src/query/filter.builder.ts
@@ -113,7 +113,7 @@ export namespace Filter {
          * @param conditionN any additional conditions
          * @returns an evaluatable filter condition
          */
-        and(condition1: CompleteCondition, condition2: CompleteCondition, ...conditionN: CompleteCondition[]): CompleteCondition;
+        and(condition1: CompleteCondition, condition2: CompleteCondition, conditionN?: CompleteCondition[]): CompleteCondition;
 
         /**
          * Create a disjunction (OR) condition from existing conditions.
@@ -123,7 +123,7 @@ export namespace Filter {
          * @param conditionN any additional conditions
          * @returns an evaluatable filter condition
          */
-        or(condition1: CompleteCondition, condition2: CompleteCondition, ...conditionN: CompleteCondition[]): CompleteCondition;
+        or(condition1: CompleteCondition, condition2: CompleteCondition, conditionN?: CompleteCondition[]): CompleteCondition;
     }
 
     /**
@@ -170,14 +170,14 @@ export namespace Filter {
         }
 
         public and(): PartialCondition;
-        public and(condition1: CompleteCondition, condition2: CompleteCondition, ...conditionN: CompleteCondition[]): CompleteCondition;
-        public and(condition1?: CompleteCondition, condition2?: CompleteCondition, ...conditionN: CompleteCondition[]): PartialCondition | CompleteCondition {
+        public and(condition1: CompleteCondition, condition2: CompleteCondition, conditionN?: CompleteCondition[]): CompleteCondition;
+        public and(condition1?: CompleteCondition, condition2?: CompleteCondition, conditionN?: CompleteCondition[]): PartialCondition | CompleteCondition {
             if (!condition1) {
                 return this.simpleAnd();
             }
 
             this.result += "(" + (<BuilderChain> condition1).buildPartial() + Operators.AND + (<BuilderChain> condition2).buildPartial();
-            if (conditionN.length) {
+            if (conditionN && conditionN.length) {
                 conditionN.forEach((condition) => {
                     this.result += Operators.AND + (<BuilderChain> condition).buildPartial();
                 });
@@ -204,14 +204,14 @@ export namespace Filter {
         }
 
         public or(): PartialCondition;
-        public or(condition1: CompleteCondition, condition2: CompleteCondition, ...conditionN: CompleteCondition[]): CompleteCondition;
-        public or(condition1?: CompleteCondition, condition2?: CompleteCondition, ...conditionN: CompleteCondition[]): PartialCondition | CompleteCondition {
+        public or(condition1: CompleteCondition, condition2: CompleteCondition, conditionN?: CompleteCondition[]): CompleteCondition;
+        public or(condition1?: CompleteCondition, condition2?: CompleteCondition, conditionN?: CompleteCondition[]): PartialCondition | CompleteCondition {
             if (!condition1) {
                 return this.simpleOr();
             }
 
             this.result += "(" + (<BuilderChain> condition1).buildPartial() + Operators.OR + (<BuilderChain> condition2).buildPartial();
-            if (conditionN.length) {
+            if (conditionN && conditionN.length) {
                 conditionN.forEach((condition) => {
                     this.result += Operators.OR + (<BuilderChain> condition).buildPartial();
                 });
@@ -334,8 +334,8 @@ export namespace Filter {
          * @param conditionN any additional conditions
          * @returns an evaluatable filter condition
          */
-        and(condition1: CompleteCondition, condition2: CompleteCondition, ...conditionN: CompleteCondition[]): CompleteCondition {
-            return new BuilderChain().and.apply(this, arguments);
+        and(condition1: CompleteCondition, condition2: CompleteCondition, conditionN?: CompleteCondition[]): CompleteCondition {
+            return new BuilderChain().and(condition1, condition2, conditionN);
         }
 
         /**
@@ -346,8 +346,8 @@ export namespace Filter {
          * @param conditionN any additional conditions
          * @returns an evaluatable filter condition
          */
-        or(condition1: CompleteCondition, condition2: CompleteCondition, ...conditionN: CompleteCondition[]): CompleteCondition {
-            return new BuilderChain().or.apply(this, arguments);
+        or(condition1: CompleteCondition, condition2: CompleteCondition, conditionN?: CompleteCondition[]): CompleteCondition {
+            return new BuilderChain().or(condition1, condition2, conditionN);
         }
     }
 }

--- a/ui/api-client/packages/sdk/src/query/query.builder.ts
+++ b/ui/api-client/packages/sdk/src/query/query.builder.ts
@@ -8,6 +8,7 @@ export namespace Query {
         private _pageSize: number = 25;
         private _fields: string[];
         private _filter: string;
+        private _sort: { field: string, reverse?: boolean }[];
 
         private constructor() { }
 
@@ -42,6 +43,11 @@ export namespace Query {
             return this;
         }
 
+        public sort(...sort: { field: string, reverse?: boolean }[]): Builder {
+            this._sort = sort;
+            return this;
+        }
+
         public get(): string {
             let query: string = `?type=${this._type}&format=${this._format}&links=${this._links}&pageSize=${this._pageSize}`;
             if (this._fields && this._fields.length > 0) {
@@ -50,6 +56,12 @@ export namespace Query {
 
             if (this._filter) {
                 query += `&filter=${this._filter}`;
+            }
+
+            if (this._sort) {
+                this._sort.forEach(s => {
+                    query += `&${s.reverse ? 'sortDesc' : 'sortAsc'}=${s.field}`;
+                })
             }
 
             return query;


### PR DESCRIPTION
This change adds the ability to specify 0 or more sort parameters to
apply to a query.  A sort parameter is the field name to sort, and an
optional directive to reverse the sort order (an ascending sort is the
default). When multiple sort parameters are specified, they are applied
in the order that they are specified.  This change addresses Issue #40.

Also included in this change is a fix for Issue #42. The combination of
rest parameters and function overloads with different return types was
resulting in the wrong overload being called at runtime, which caused
subsequent calls to fail.  Removing the rest parameter in favor of an
optional array param is a bit more verbose for the caller, but seems to
be handled correctly.

Testing Done:
Built the following filter:
```
let filter = builder.or(
    builder.is(QueryResultOrgRecordType.Fields.NAME).like('aaaa', Filter.MatchMode.START),
    builder.is(QueryResultOrgRecordType.Fields.NAME).like('org', Filter.MatchMode.START)
).query();
```

Verified that a valid query string was constructed:
````
type=organization&format=idrecords&links=false&pageSize=25&fields=name,displayName&filter=(name==aaaa*,name==org*)
````

Also built the following filter:
```
let filter =
builder.is(QueryResultOrgRecordType.Fields.IS_ENABLED).equalTo(true).and()
    .or(
        builder.is(QueryResultOrgRecordType.Fields.NAME).like('aaaa', Filter.MatchMode.START),
        builder.is(QueryResultOrgRecordType.Fields.NAME).like('org', Filter.MatchMode.START)
).query();
```

Verified that a valid query string was constructed:
```
type=organization&format=idrecords&links=false&pageSize=25&fields=name,displayName&filter=isEnabled==true;(name==aaaa*,name==org*)
```

Built queries with 0, 1, and 2 sort params (a mix of default and reverse
sorting). Verified that the correct query string was produced in each
case and that the API call completed successfully.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>