### PR TITLE
[bindings-generator] Update TypescriptClass to deal with field names clashing with Java keywords

### DIFF
--- a/java/api-schemas/tooling/bindings-generator/src/main/java/com/vmware/vcloud/bindings/generator/typescript/TypescriptClass.java
+++ b/java/api-schemas/tooling/bindings-generator/src/main/java/com/vmware/vcloud/bindings/generator/typescript/TypescriptClass.java
@@ -9,15 +9,18 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
-import java.util.Collection;
+
+import javax.xml.bind.annotation.XmlAttribute;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.commons.lang3.reflect.TypeUtils;
 
 public class TypescriptClass extends TypescriptFile {
+    
     private Class<?> parent;
     private boolean isAbstract;
+
 
     TypescriptClass(final Class<?> clazz) {
         setClazz(clazz);
@@ -57,7 +60,10 @@ public class TypescriptClass extends TypescriptFile {
             }
         }
 
-        addField(field.getName(), mapper.getTypeName(actualType) + ((isArray) ? "[]" : ""));
+        final XmlAttribute xmlAttribute = field.getAnnotation(XmlAttribute.class);
+        final String typeScriptFieldName = xmlAttribute == null || xmlAttribute.name().equals("##default") ? 
+        		field.getName() : xmlAttribute.name();
+        addField(typeScriptFieldName, mapper.getTypeName(actualType) + ((isArray) ? "[]" : ""));
         if (!mapper.isBuiltInType(actualType) && !actualType.getTypeName().startsWith("java")) {
             addImport(clazz, (Class <?>) actualType);
         }


### PR DESCRIPTION
Issue Summary:
Java bindings get generated with '_' prefix for fields defined in xsd that have names that clash with Java keywords. Example ones encountered: default, interfacea:
e.g.
        @XmlAttribute(name = "default")
        @Supported(addedIn = "1.5")
        protected Boolean _default;

Want to preserve the @XmlAttribute name in typescript bindings to match the data sent over the wire so data can be serialized/de-serialized correctly

Testing Done:
- Successful Maven build of the bindings-generator
- Used patched Bindings Generator in vcd-ui project to generate full set of typescript Bindings - verified '_' no longer present in field names

Signed-off-by: Colm Caffrey <ccaffrey@vmware.com>