### PR TITLE
Normalize JSON serialization differences in 9.1.

### DIFF
--- a/ui/api-client/packages/sdk/src/client/index.ts
+++ b/ui/api-client/packages/sdk/src/client/index.ts
@@ -3,3 +3,4 @@ export * from './vcd.http.client';
 export * from './vcd.api.client';
 export * from './request.headers.interceptor';
 export * from './logging.interceptor';
+export * from './response.normalization.interceptor';

--- a/ui/api-client/packages/sdk/src/client/response.normalization.interceptor.ts
+++ b/ui/api-client/packages/sdk/src/client/response.normalization.interceptor.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest, HttpResponse } from '@angular/common/http';
+
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+/**
+ * An interceptor on the response chain that normalizes differences in
+ * JSON payloads between vCloud Director version 9.1 and versions
+ * greater than 9.1.
+ *
+ * In 9.1 (API version 30.0) the server serializes JSON and nests the payload in a value field:
+ * ```
+  {
+    "name" : "{http://www.vmware.com/vcloud/versions}SupportedVersions",
+    "declaredType" : "com.vmware.vcloud.api.rest.schema.versioning.SupportedVersionsType",
+    "scope" : "javax.xml.bind.JAXBElement$GlobalScope",
+    "value" : {
+      "versionInfo" : [],
+      "any" : [],
+      "otherAttributes" : {}
+    }
+  }
+  ```
+ *
+ * That same request in API versions 31.0 and above is represented as:
+ * ```
+  {
+    "versionInfo" : [],
+    "any" : [],
+    "otherAttributes" : {}
+  }
+  ```
+ * This interceptor should process responses before any other interceptors that rely
+ * on consistent API information.
+ */
+@Injectable()
+export class ResponseNormalizationInterceptor implements HttpInterceptor {
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    return next.handle(req).pipe(
+      map(response => {
+        // While this condition seems awfully specific, the alternative option of examining the 'Content-Type'
+        // response header for 'version=30.0' proved to be an unreliable condition in at least one case;
+        // returning the same JSON payload as API versions >= 31.0.
+        if (response instanceof HttpResponse && response.body && response.body.value && response.body.declaredType && response.body.scope) {
+          return response.clone({ body: response.body.value });
+        }
+
+        return response;
+      })
+    );
+  }
+}

--- a/ui/api-client/packages/sdk/src/client/response.normalization.interceptor.ts
+++ b/ui/api-client/packages/sdk/src/client/response.normalization.interceptor.ts
@@ -43,7 +43,12 @@ export class ResponseNormalizationInterceptor implements HttpInterceptor {
         // response header for 'version=30.0' proved to be an unreliable condition in at least one case;
         // returning the same JSON payload as API versions >= 31.0.
         if (response instanceof HttpResponse && response.body && response.body.value && response.body.declaredType && response.body.scope) {
-          return response.clone({ body: response.body.value });
+          const body = response.body.value;
+          if (response.body.declaredType == "com.vmware.vcloud.api.rest.schema_v1_5.QueryResultRecordsType") {
+            body.record = body.record.map(record => record.value);
+          }
+
+          return response.clone({ body: body });
         }
 
         return response;

--- a/ui/api-client/packages/sdk/src/client/response.normalization.interceptor.ts
+++ b/ui/api-client/packages/sdk/src/client/response.normalization.interceptor.ts
@@ -36,6 +36,8 @@ import { map } from 'rxjs/operators';
  */
 @Injectable()
 export class ResponseNormalizationInterceptor implements HttpInterceptor {
+  private static readonly QUERY_RESULT_TYPE = "com.vmware.vcloud.api.rest.schema_v1_5.QueryResultRecordsType";
+
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(req).pipe(
       map(response => {
@@ -44,7 +46,7 @@ export class ResponseNormalizationInterceptor implements HttpInterceptor {
         // returning the same JSON payload as API versions >= 31.0.
         if (response instanceof HttpResponse && response.body && response.body.value && response.body.declaredType && response.body.scope) {
           const body = response.body.value;
-          if (response.body.declaredType == "com.vmware.vcloud.api.rest.schema_v1_5.QueryResultRecordsType") {
+          if (response.body.declaredType == ResponseNormalizationInterceptor.QUERY_RESULT_TYPE) {
             body.record = body.record.map(record => record.value);
           }
 

--- a/ui/api-client/packages/sdk/src/client/vcd.api.client.spec.ts
+++ b/ui/api-client/packages/sdk/src/client/vcd.api.client.spec.ts
@@ -8,6 +8,7 @@ import { AuthTokenHolderService, API_ROOT_URL } from "../common";
 import { SupportedVersionsType } from "@vcd/bindings/vcloud/api/rest/schema/versioning";
 import { SessionType, TaskType, EntityReferenceType, QueryResultRecordsType } from "@vcd/bindings/vcloud/api/rest/schema_v1_5";
 import { Query } from "../query";
+import { ResponseNormalizationInterceptor } from "./response.normalization.interceptor";
 
 // verifies that the GET api/versions endpoint is called exactly once, and returns the provided response
 function handleVersionNegotiation(versionResponse: SupportedVersionsType, httpMock: HttpTestingController): void {
@@ -40,6 +41,7 @@ describe("API client pre-request validation", () => {
             providers: [
                 LoggingInterceptor,
                 RequestHeadersInterceptor,
+                ResponseNormalizationInterceptor,
                 VcdHttpClient
             ]
         });

--- a/ui/api-client/packages/sdk/src/client/vcd.api.client.ts
+++ b/ui/api-client/packages/sdk/src/client/vcd.api.client.ts
@@ -143,8 +143,7 @@ export class VcdApiClient {
      */
     public setAuthentication(authentication: string): Observable<SessionType> {
         this.http.requestHeadersInterceptor.authentication = authentication;
-        return this.http.get<SessionType>(`${this._baseUrl}/api/session`, {observe: 'response'}).pipe(
-                map(response => this.extractSessionType(response)),
+        return this.http.get<SessionType>(`${this._baseUrl}/api/session`).pipe(
                 tap(session => this._session.next(session))
             );
     }
@@ -171,7 +170,7 @@ export class VcdApiClient {
                 tap((response: HttpResponse<any>) =>
                     this.http.requestHeadersInterceptor.authentication = `${response.headers.get('x-vmware-vcloud-token-type')} ${response.headers.get('x-vmware-vcloud-access-token')}`
                 ),
-                map(this.extractSessionType),
+                map(response => response.body),
                 tap(session => this._session.next(session))
             );
     }
@@ -463,13 +462,5 @@ export class VcdApiClient {
 
     public getLocation(session: SessionType): AuthorizedLocationType {
         return session.authorizedLocations.location.find(location => location.locationId == session.locationId);
-    }
-
-    private extractSessionType(response: HttpResponse<any>): SessionType {
-        if (response.body.value) {
-            return response.body.value as SessionType;
-        } else {
-            return response.body as SessionType;
-        }
     }
 }

--- a/ui/api-client/packages/sdk/src/client/vcd.http.client.ts
+++ b/ui/api-client/packages/sdk/src/client/vcd.http.client.ts
@@ -3,6 +3,7 @@ import {Injectable} from "@angular/core";
 import {Observable} from "rxjs";
 import {LoggingInterceptor} from "./logging.interceptor";
 import {RequestHeadersInterceptor} from "./request.headers.interceptor";
+import {ResponseNormalizationInterceptor} from "./response.normalization.interceptor";
 
 /**
  * Angular's HttpInterceptorHandler is not publicly exposed.  This is a clone of it.
@@ -43,10 +44,12 @@ class VcdHttpInterceptorHandler implements HttpHandler {
      */
     constructor(httpBackend: HttpBackend,
                 loggingInterceptor: LoggingInterceptor,
-                requestHeadersInterceptor: RequestHeadersInterceptor) {
+                requestHeadersInterceptor: RequestHeadersInterceptor,
+                responseNormalizationInterceptor: ResponseNormalizationInterceptor) {
         const interceptors: HttpInterceptor[] = [
             loggingInterceptor,
-            requestHeadersInterceptor
+            requestHeadersInterceptor,
+            responseNormalizationInterceptor
         ];
         const chain = interceptors.reduceRight(
             (next, interceptor) => new VcdHttpInterceptorHandler(next, interceptor),

--- a/ui/api-client/packages/sdk/src/client/vcd.transfer.client.spec.ts
+++ b/ui/api-client/packages/sdk/src/client/vcd.transfer.client.spec.ts
@@ -6,6 +6,7 @@ import {RequestHeadersInterceptor} from "./request.headers.interceptor";
 import {VcdHttpClient} from "./vcd.http.client";
 import {TransferProgress, TransferResult, VcdTransferClient} from "./vcd.transfer.client";
 import "jasmine-ajax";
+import { ResponseNormalizationInterceptor } from "./response.normalization.interceptor";
 
 const TEST_BLOB = (function (base64: string): Blob {
     var binaryString = atob(base64);
@@ -50,6 +51,7 @@ describe("TransferClient", () => {
             providers: [
                 LoggingInterceptor,
                 RequestHeadersInterceptor,
+                ResponseNormalizationInterceptor,
                 VcdHttpClient
             ]
         });

--- a/ui/api-client/packages/sdk/src/index.ts
+++ b/ui/api-client/packages/sdk/src/index.ts
@@ -32,6 +32,7 @@ export {
   providers: [
       client.RequestHeadersInterceptor,
       client.LoggingInterceptor,
+      client.ResponseNormalizationInterceptor,
       client.VcdHttpClient,
       client.VcdApiClient,
 


### PR DESCRIPTION
This change addresses a change in JSON serialization that happened
between vCD 9.1 and vCD 9.5. The JSON mapper used in 9.1 presented some
additional metadata and put the actual response payload inside a 'value'
property. Post-9.1 vCloud Director returns the response payload directly
as the response body.

The handling is done at the HttpClient level, in an interceptor, to
allow the object bindings that happen later in the chain to just work.

Testing done:
Updated the seed plugin to use this new SDK build. Created a
distribution of the plugin and deployed to a 9.1 testbed and a 9.5
testbed. Verified that the plugin loaded and displayed the session
information in both testbeds. Inspected the Network tab in Chrome to
verify that the responses were returned in 2 different formats (wrapped
and unwrapped).

Added query call to seed project and verified that `record` payload was
correctly processed in both a 9.1 and 9.5 testbed.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-ext-sdk/75)
<!-- Reviewable:end -->
