### PR TITLE
[ui] Handle empty transfer link bodies

### DIFF
--- a/ui/api-client/packages/sdk/src/client/vcd.api.client.ts
+++ b/ui/api-client/packages/sdk/src/client/vcd.api.client.ts
@@ -201,7 +201,7 @@ export class VcdApiClient {
                 const headerLinks: LinkType[] = res.headers.has(HATEOAS_HEADER)
                     ? parseHeaderHateoasLinks(res.headers.get(HATEOAS_HEADER))
                     : [];
-                const links: LinkType[] = res.body.link || [];
+                const links: LinkType[] = res.body ? (res.body.link || []) : [];
                 const link = [...headerLinks, ...links]
                     .find((link) => link.rel == transferRel);
                 if (!link) {


### PR DESCRIPTION
Some backend responses return empty bodies when starting a transfer -
for example plugin transfer.

This handles that case.  This is required for the new plugin lifecycle
plugin to work.

Signed-off-by: David Byard <dbyard@vmware.com>