### PR TITLE
Support act-as functionality in API client.

### DIFF
--- a/ui/api-client/packages/sdk/src/client/request.headers.interceptor.ts
+++ b/ui/api-client/packages/sdk/src/client/request.headers.interceptor.ts
@@ -9,6 +9,11 @@ export class RequestHeadersInterceptor implements HttpInterceptor {
         this._enabled = _enabled;
     }
 
+    private _actAs: string;
+    set actAs(_actAs: string) {
+        this._actAs = _actAs;
+    }
+
     private _version: string = '';
     get version(): string {
         return this._version;
@@ -37,6 +42,10 @@ export class RequestHeadersInterceptor implements HttpInterceptor {
 
         if (this._authentication) {
             headers = headers.set(this._authenticationHeader, this._authentication);
+        }
+
+        if (this._actAs) {
+            headers = headers.set("X-VMWARE-VCLOUD-TENANT-CONTEXT", this._actAs);
         }
 
         const customReq: HttpRequest<any> = req.clone({

--- a/ui/api-client/packages/sdk/src/client/vcd.api.client.ts
+++ b/ui/api-client/packages/sdk/src/client/vcd.api.client.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject, Optional, Injector } from '@angular/core';
+import { Injectable, Inject, Optional, Injector, Type } from '@angular/core';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
 
 import { Observable, BehaviorSubject } from 'rxjs';
@@ -105,7 +105,8 @@ export class VcdApiClient {
             tap(version => this.setVersion(version))
         ).publishReplay(1).refCount();
 
-        this._getSession = this.setAuthentication(this.injector.get(AuthTokenHolderService).token).publishReplay(1).refCount();
+        const tokenHolder: AuthTokenHolderService = this.injector.get(AuthTokenHolderService, { token: "" });
+        this._getSession = this.setAuthentication(tokenHolder.token).publishReplay(1).refCount();
     }
 
     private negotiateVersion(serverVersions: SupportedVersionsType): string {

--- a/ui/api-client/packages/sdk/src/common/container-hooks.ts
+++ b/ui/api-client/packages/sdk/src/common/container-hooks.ts
@@ -42,6 +42,12 @@ export const SESSION_SCOPE: OpaqueToken = containerHooks.SESSION_SCOPE;
 export const SESSION_ORGANIZATION: OpaqueToken = containerHooks.SESSION_ORGANIZATION;
 
 /**
+ * Wire in as a string.  Gives the UUID identifier of the current tenant
+ * organization that the VCD-UI is being used for.
+ */
+export const SESSION_ORG_ID: OpaqueToken = containerHooks.SESSION_ORG_ID;
+
+/**
  * Wire in as a string.  Gives the full root path for module assets (e.g. images, scripts, text files)
  */
 export const EXTENSION_ASSET_URL: OpaqueToken = containerHooks.EXTENSION_ASSET_URL;

--- a/ui/api-client/packages/sdk/src/test.ts
+++ b/ui/api-client/packages/sdk/src/test.ts
@@ -45,10 +45,12 @@ window["System"] = {
 };
 window["System"]["registry"]["get"] = function(s: string): any { 
     return {
-        API_ROOT_URL: "rootUrl",
+        API_ROOT_URL: "$API_ROOT_URL",
         AuthTokenHolderService: {
-            token: "authToken"
-        }
+            token: "$token"
+        },
+        SESSION_ORG_ID: "$SESSION_ORG_ID",
+        SESSION_SCOPE: "$SESSION_SCOPE"
     };
 };
 


### PR DESCRIPTION
The 'act-as' functionality was introduced to API calls in version 9.1 of
vCloud Director. It allows a provider to make API requests in the
context of a specific tenant. The biggest use cases for this
functionality is to allow a provider access to a tenant's portal, while
showing only the entities that are visible to the tenant, instead of all
the entities visible to the provider.

The feature is enabled automatically when a provider navigates to the UI
portal for a tenant, as determined by the container hook for
SESSION_SCOPE and the organization of the looged in user's session. The
feature can additionally be manually enabled/disabled.

Testing Done:
Executed new unit tests to verify enablement, disablement, and automatic
enablement of the act-as feature.

Ran a seed plugin and verified in the Chrome Network tab that the
request header `X-VMWARE-VCLOUD-TENANT-CONTEXT` appeared as appropriate.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-ext-sdk/84)
<!-- Reviewable:end -->
