### PR TITLE
Allow multiple replacement tokens in i18n key

### DIFF
--- a/typescript/api-client/src/i18n/translate.service.spec.ts
+++ b/typescript/api-client/src/i18n/translate.service.spec.ts
@@ -1,0 +1,31 @@
+import {TranslateService} from './translate.service';
+import {TranslationLoader} from './translation.loader';
+import {Observable} from 'rxjs';
+
+class MockTranslationLoader extends TranslationLoader {
+    constructor() {
+        super(null, '');
+    }
+
+    getCombinedTranslation(): Observable<Object> {
+        const translation = {
+            'en': {
+                "duration": "{0} hours {1} minutes"
+            }
+        };
+        return Observable.of(translation);
+    }
+}
+
+describe('TranslateService', function () {
+    it('should accept 2 arguments', function () {
+        const loader = new MockTranslationLoader();
+        const translate = new TranslateService(loader);
+
+        translate.prepareTranslations(['en'], 'en');
+
+        translate.get('duration', 11, 0).subscribe((result) => {
+            expect(result).toEqual('11 hours 0 minutes');
+        });
+    });
+});

--- a/typescript/api-client/src/i18n/translate.service.ts
+++ b/typescript/api-client/src/i18n/translate.service.ts
@@ -80,7 +80,7 @@ export class TranslateService {
 
         return !result ? `#${key}#` : result.replace(/{([0-9]+)}/g, (_, ...n) => {
             const idx = parseInt(n[0]);
-            if (args && args[idx]) {
+            if (args && typeof args[idx] !== 'undefined') {
                 return args[idx];
             }
 
@@ -90,7 +90,7 @@ export class TranslateService {
 
     public get(key: string, ...args: any[]): Observable<string | any> {
         if (!this.pending) {
-            return Observable.of(this.getParsedResult(key, args));
+            return Observable.of(this.getParsedResult(key, ...args));
         }
 
         return Observable.create((observer: Observer<string>) => {
@@ -102,7 +102,7 @@ export class TranslateService {
                 observer.error(error);
             };
             this.translation$.subscribe(result => {
-                result = this.getParsedResult(key, args);
+                result = this.getParsedResult(key, ...args);
                 onComplete(result);
             }, onError);
         });


### PR DESCRIPTION
Use spread operator in arguments to spread array, so it can replace multiple tokens.
Issue #86: Multiply arguments doesn't work in TranslateService, it regards all the arguments as a single array.
Testing Done: add unit test "should accept 2 arguments" in translate.service.spec.ts
Signed-off-by: Harold Li<power0721@gmail.com>