### PR TITLE
Modify the package versions to 0.10.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
         provider: script
         skip_cleanup: true
         script: cd $TRAVIS_BUILD_DIR && bash build-resources/travis-release.sh
+        tags: true
+        branch: master
     - language: node_js
       node_js:
         - "lts/*"
@@ -22,3 +24,5 @@ matrix:
         provider: script
         skip_cleanup: true
         script: npm run deploy
+        tags: true
+        branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 matrix:
   include:
     - language: java

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.vmware.vcloud</groupId>
   <artifactId>vcd-ext-sdk-parent</artifactId>
-  <version>0.9.0</version>
+  <version>0.10.0</version>
   <packaging>pom</packaging>
   <name>${project.artifactId} :: vCloud Director Extension SDKs</name>
   <description>A collection of libraries for interacting with the extensibility features of vCloud Director.  Also includes some sample application that showcase best practices for extension building</description>

--- a/java/vcd-api-client-java/pom.xml
+++ b/java/vcd-api-client-java/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.vmware.vcloud</groupId>
     <artifactId>vcd-ext-sdk-parent</artifactId>
-    <version>0.9.0</version>
+    <version>0.10.0</version>
   </parent>
   <packaging>jar</packaging>
   <name>${project.artifactId} :: vCloud Director REST Client</name>

--- a/typescript/api-client/package.dist.json
+++ b/typescript/api-client/package.dist.json
@@ -1,7 +1,7 @@
 {
   "name": "@vcd/sdk",
-  "version": "0.9.0",
-  "description": "Typescript bindings for the vCloud Director API",
+  "version": "0.10.0",
+  "description": "Angular-based SDK client for the vCloud Director API",
   "author": "VMware",
   "license": "BSD-2-Clause",
   "main": "./sdk.js",

--- a/typescript/api-client/package.json
+++ b/typescript/api-client/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@vcd/sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "scripts": {
     "clean": "rimraf build && rimraf dist",
     "copy-metadata": "cpy package.dist.json dist --rename=package.json",
     "build": "npm run clean && ngc && ncp build/ dist/ && npm run copy-metadata",
     "test": "karma start --single",
     "test-watch": "karma start --auto-watch --no-single-run --browsers Chrome",
-    "deploy": "cpy .npmrc.dist . --rename=.npmrc && npm publish dist --access public --dry-run && rimraf .npmrc"
+    "deploy": "cpy .npmrc.dist . --rename=.npmrc && npm publish dist --access public && rimraf .npmrc"
   },
   "author": "VMware",
   "license": "BSD-2-Clause",


### PR DESCRIPTION
The sophomore release of vcd-ext-sdk packages is imminent!

In addition to updating the version number, this change removes the
dry-run status from NPM packaging, and re-enables the deploy filters for
Travis to only attempt a deploy on tagged releases from the master
branch.

Testing Done:
The release management angle of this was tested in the 06ec8ab commit,
where the dry-run status for NPM was verified in Travis, and the deploy
status for Nexus was verfied in, and dropped from, the Sonatype staging
repository.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-ext-sdk/90)
<!-- Reviewable:end -->
