### PR TITLE
Allow plugins to be written in Angular 6+.

### DIFF
--- a/typescript/api-client/src/client/vcd.api.client.ts
+++ b/typescript/api-client/src/client/vcd.api.client.ts
@@ -164,7 +164,12 @@ export class VcdApiClient {
                 tap(session => {
                     // automatically set actAs for provider in tenant scope
                     if (session.org == 'System' && this.injector.get(SESSION_SCOPE) == 'tenant') {
-                        this.actAs({id: this.injector.get(SESSION_ORG_ID)})
+                        // Automatic actAs only works in versions >=9.5
+                        try {
+                            this.actAs({id: this.injector.get(SESSION_ORG_ID)});
+                        } catch(e) {
+                            console.warn('No SESSION_ORG_ID set in container. Automatic actAs is disabled.');
+                        }
                     }
                 }),
                 tap(session => this._session.next(session))

--- a/typescript/api-client/src/common/container-hooks.ts
+++ b/typescript/api-client/src/common/container-hooks.ts
@@ -1,7 +1,7 @@
 /**
  * This is the currently supported - albeit very minimal - public SDK.
  */
-import {OpaqueToken, NgModule} from '@angular/core';
+import {InjectionToken, NgModule} from '@angular/core';
 import {Observable} from 'rxjs';
 
 // Bind straight into the hooks provided by the container.
@@ -22,45 +22,45 @@ if (!containerHooks) {
  * Wire in as a string.  Gives the root URL for API access (for example, the load balancer URL
  * or the single-cell URL).
  */
-export const API_ROOT_URL: OpaqueToken = containerHooks.API_ROOT_URL;
+export const API_ROOT_URL: InjectionToken<string> = containerHooks.API_ROOT_URL;
 
 /**
  * Wire in as a string.  Gives the root URL for the legacy Flex application.
  */
-export const FLEX_APP_URL: OpaqueToken = containerHooks.API_ROOT_URL;
+export const FLEX_APP_URL: InjectionToken<string> = containerHooks.API_ROOT_URL;
 
 /**
  * Wire in as a string.  Gives the current scope of the VCD-UI.  As of current, this will be
  * either 'tenant' for the tenant portal, or 'service-provider' for the service-provider portal.
  */
-export const SESSION_SCOPE: OpaqueToken = containerHooks.SESSION_SCOPE;
+export const SESSION_SCOPE: InjectionToken<string> = containerHooks.SESSION_SCOPE;
 
 /**
  * Wire in as a string.  Gives the unique name (not the display name) of the current tenant
  * organization that the VCD-UI is being used for.
  */
-export const SESSION_ORGANIZATION: OpaqueToken = containerHooks.SESSION_ORGANIZATION;
+export const SESSION_ORGANIZATION: InjectionToken<string> = containerHooks.SESSION_ORGANIZATION;
 
 /**
  * Wire in as a string.  Gives the UUID identifier of the current tenant
  * organization that the VCD-UI is being used for.
  */
-export const SESSION_ORG_ID: OpaqueToken = containerHooks.SESSION_ORG_ID;
+export const SESSION_ORG_ID: InjectionToken<string> = containerHooks.SESSION_ORG_ID ? containerHooks.SESSION_ORG_ID : "";
 
 /**
  * Wire in as a string.  Gives the full root path for module assets (e.g. images, scripts, text files)
  */
-export const EXTENSION_ASSET_URL: OpaqueToken = containerHooks.EXTENSION_ASSET_URL;
+export const EXTENSION_ASSET_URL: InjectionToken<string> = containerHooks.EXTENSION_ASSET_URL;
 
 /**
  * Wire in as a string.  Gives the Angular 2 route that the module is registered under.
  */
-export const EXTENSION_ROUTE: OpaqueToken = containerHooks.EXTENSION_ROUTE;
+export const EXTENSION_ROUTE: InjectionToken<string> = containerHooks.EXTENSION_ROUTE;
 
 /**
  * Wire in as a boolean.  True if running under the SDK, false if running in production.
  */
-export const SDK_MODE: OpaqueToken = containerHooks.SDK_MODE;
+export const SDK_MODE: InjectionToken<boolean> = containerHooks.SDK_MODE;
 
 /**
  * Payload for registering a navigation menu entry.


### PR DESCRIPTION
OpaqueToken was removed as an Angular construct in Angular 6. The
container hooks used OpaqueToken so plugins that tried to use newer
versions of Angular and Clarity would result in compilation errors.

This change replaces OpaqueToken use with InjectionToken. Since
InjectionToken has been available since Angular 4, compatibility back to
vCD 9.1.0.2 was tested and successfully verified. While testing backward
compatibility, an issue with actAs functionality was discovered due to
the lack of a SESSION_ORG_ID token in a 9.1 environment. The SDK was
modified to log a warning instead of failing, when actAs can't be
automatically managed.

Testing Done:
* Consumed the new SDK from a 9.1-compatible seed project (Clarity
0.10.x and Angular 4.4.x). Verified successful compilation and
deployment to a vCD 9.1.0.2 testbed.
* Updated to package.json of seed plugin to utilize Angular 6 (also
required updating rxjs references and adding rxjs-compat dependency, and
@ngrx dependencies). Verified successful compilation of a plugin with
Angular 6. Deployed plugin to a 9.1.0.2 testbed and verified successful
loading of plugin.
* Updated Clarity to 0.13.x on top of the previous step. Verified
successful compilation and deployment to a vCD 10.0 environment.
* Made wild assumtion that 9.7 will also work.

Additional Testing Notes:
Peer dependency warning will be output for a plugin that wants to use
Angular 6+. These will be addressed in a patch version of the SDK.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vmware/vcd-ext-sdk/103)
<!-- Reviewable:end -->
