### PR TITLE
Add new Injection Token for the plugin translation set

### DIFF
--- a/typescript/api-client/projects/vcd/sdk/src/lib/common/container-hooks.ts
+++ b/typescript/api-client/projects/vcd/sdk/src/lib/common/container-hooks.ts
@@ -18,6 +18,8 @@ if (!containerHooks) {
     throw new Error('VCD UI container hooks not present in SystemJS registry');
 }
 
+export const TRANSLATIONS_SET: InjectionToken<any> = containerHooks.TRANSLATIONS_SET;
+
 /**
  * Wire in as a string.  Gives the root URL for API access (for example, the load balancer URL
  * or the single-cell URL).


### PR DESCRIPTION
By using this new token the plugin writers will be able to
register the UI plugin locale file which is loaded by vcd.
With this approach we'll avoid double loading of this file,
and potentially not DoSing the server if we have a lot of plugins.

Related with VACE-2501.

Signed-off-by: Nikola Vladimirov Iliev <nvladimirovi@vmware.com>