### PR TITLE
[VACE-2589] Create ng add plugin-seed-9.7-10.0

### DIFF
--- a/typescript/api-client/package.json
+++ b/typescript/api-client/package.json
@@ -12,16 +12,18 @@
     "sdk:build:prod": "npm run sdk:build && npm run sdk:copy:schemas && npm run sdk:fix:backwards:compatability",
     "sdk:copy:schemas": "cp -R ./projects/vcd/sdk/src/schematics ./dist/vcd/sdk",
     "sdk:fix:backwards:compatability": "node ./helpers/update_packagejson.js",
-    
-    "plugin-builders:build": "tsc --build ./projects/vcd/plugin-builders/tsconfig.json && npm run plugin-builders:cpy:schema && npm run plugin-builders:cpy:builders",
+
+    "plugin-builders:build:schematics": "tsc -p ./projects/vcd/plugin-builders/tsconfig.schematics.json",
+    "plugin-builders:copy:schemas": "cp -R ./projects/vcd/plugin-builders/src/lib/schematics ./dist/vcd/plugin-builders",
+    "plugin-builders:build": "tsc --build ./projects/vcd/plugin-builders/tsconfig.json && npm run plugin-builders:cpy:schema && npm run plugin-builders:cpy:builders && npm run plugin-builders:build:schematics && npm run plugin-builders:copy:schemas",
     "plugin-builders:cpy:schema": "cp ./projects/vcd/plugin-builders/src/lib/base/schema.json ./dist/vcd/plugin-builders",
     "plugin-builders:cpy:builders": "cp ./projects/vcd/plugin-builders/builders.json ./dist/vcd/plugin-builders",
     "plugin-builders:install:dev:dep": "cd ./projects/vcd/plugin-builders && npm i && cd ../../",
-    
+
     "schematics:build": "tsc -p ./projects/vcd/schematics/tsconfig.json",
     "schematics:build:prod": "npm run schematics:build && npm run schematics:copy:schemas",
     "schematics:copy:schemas": "cp -R ./projects/vcd/schematics/src/schematics ./dist/vcd/schematics",
-
+    
     "test": "ng test",
     "lint": "ng lint",
     "deploy": "cp .npmrc.dist . --rename=.npmrc && npm publish ./dist/vcd/sdk --access public && rimraf .npmrc"

--- a/typescript/api-client/projects/vcd/plugin-builders/package.json
+++ b/typescript/api-client/projects/vcd/plugin-builders/package.json
@@ -2,6 +2,7 @@
   "name": "@vcd/plugin-builders",
   "version": "0.0.1",
   "builders": "builders.json",
+  "schematics": "./schematics/collection.json",
   "dependencies": {
     "zip-webpack-plugin": "3.0.0"
   },

--- a/typescript/api-client/projects/vcd/plugin-builders/src/lib/base/index.ts
+++ b/typescript/api-client/projects/vcd/plugin-builders/src/lib/base/index.ts
@@ -67,15 +67,7 @@ export default class PluginBuilder extends BrowserBuilder {
     this.entryPointPath = config.entry.main[0];
     let [modulePath, moduleName] = this.options.modulePath.split('#');
     modulePath = modulePath.substr(0, modulePath.indexOf(".ts"));
-    const factoryPath = `${
-      modulePath.includes('.') ? modulePath : `${modulePath}/${modulePath}`
-    }.ngfactory`;
-    const entryPointContents = `
-       export * from '${modulePath}';
-       export * from '${factoryPath}';
-       import { ${moduleName}NgFactory } from '${factoryPath}';
-       export default ${moduleName}NgFactory;
-    `;
+    const entryPointContents = `export * from '${modulePath}';`;
     this.patchEntryPoint(entryPointContents);
 
     config.output.filename = `bundle.js`;
@@ -93,7 +85,10 @@ export default class PluginBuilder extends BrowserBuilder {
 
     // Zip the result
     config.plugins.push(
-      new ZipPlugin({filename: 'plugin.zip'}),
+      new ZipPlugin({
+        filename: 'plugin.zip',
+        exclude: [/\.html$/]
+      }),
     );
 
     return config;
@@ -104,6 +99,8 @@ export default class PluginBuilder extends BrowserBuilder {
   ): Observable<BuildEvent> {
     this.options = builderConfig.options;
     this.options.fileReplacements = this.options.fileReplacements && this.options.fileReplacements.length ? this.options.fileReplacements : [];
+    this.options.styles = this.options.styles && this.options.styles.length ? this.options.styles : [];
+    this.options.scripts = this.options.scripts && this.options.scripts.length ? this.options.scripts : [];
     // I don't want to write it in my scripts every time so I keep it here
     builderConfig.options.deleteOutputPath = false;
 

--- a/typescript/api-client/projects/vcd/plugin-builders/src/lib/new/index.ts
+++ b/typescript/api-client/projects/vcd/plugin-builders/src/lib/new/index.ts
@@ -77,8 +77,15 @@ async function commandBuilder(
 
     // Zip the result
     config.plugins.push(
-      new ZipPlugin({filename: 'plugin.zip'}),
+      new ZipPlugin({
+        filename: 'plugin.zip',
+        exclude: [/\.html$/]
+      }),
     );
+
+    options.fileReplacements = options.fileReplacements && options.fileReplacements.length ? options.fileReplacements : [];
+    options.styles = options.styles && options.styles.length ? options.styles : [];
+    options.scripts = options.scripts && options.scripts.length ? options.scripts : [];
 
     // Trigger the angular browser builder
     return executeBrowserBuilder(options, context, {

--- a/typescript/api-client/projects/vcd/plugin-builders/src/lib/schematics/collection.json
+++ b/typescript/api-client/projects/vcd/plugin-builders/src/lib/schematics/collection.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../../../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Install and setup the @vcd/plugin-builders package",
+      "factory": "./ng-add/index#ngAdd",
+      "schema": "./ng-add/schema.json"
+    }
+  }
+}

--- a/typescript/api-client/projects/vcd/plugin-builders/src/lib/schematics/ng-add/index.d.ts
+++ b/typescript/api-client/projects/vcd/plugin-builders/src/lib/schematics/ng-add/index.d.ts
@@ -1,0 +1,3 @@
+import { Rule } from '@angular-devkit/schematics';
+import { Schema } from './schema';
+export declare function ngAdd(options: Schema): Rule;

--- a/typescript/api-client/projects/vcd/plugin-builders/src/lib/schematics/ng-add/index.ts
+++ b/typescript/api-client/projects/vcd/plugin-builders/src/lib/schematics/ng-add/index.ts
@@ -1,0 +1,55 @@
+import { Rule, SchematicContext, Tree, chain, SchematicsException } from '@angular-devkit/schematics';
+import {
+  getWorkspace, updateWorkspace,
+} from '@schematics/angular/utility/config';
+import { Schema } from './schema';
+
+export function ngAdd(options: Schema): Rule {
+  return chain([
+    updateAngularJson(options),
+  ]);
+}
+
+function updateAngularJson(options: Schema): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    const workspaceConfig = getWorkspace(tree);
+
+    if (!workspaceConfig) {
+      throw new SchematicsException('Could not find Angular workspace configuration');
+    }
+
+    if (!workspaceConfig.projects[options.projectName]) {
+      throw new SchematicsException(`Could not find Angular Project with name ${options.projectName} in your workspace`); 
+    }
+
+    if (!workspaceConfig.projects[options.projectName].architect) {
+      throw new SchematicsException('Could not find Angular architect configuration in your workspace');
+    }
+
+    (workspaceConfig.projects as any)[options.projectName].architect["builder-config-example"] = {
+      "builder": "@vcd/plugin-builders:plugin-builder",
+      "options": {
+        "modulePath": "src/path/to/your/plugin/plugin-example.module.ts#PluginModuleName",
+        "outputPath": "dist/",
+        "index": "src/index.html",
+        "main": "src/<CREATE_EMPTY_FILE>.ts",
+        "polyfills": "src/polyfills.ts",
+        "tsConfig": "src/tsconfig.app.json",
+        "assets": [
+          { "glob": "**/*", "input": "./src/path/to/your/assets/folder", "output": "/" }
+        ],
+        "optimization": true,
+        "outputHashing": "all",
+        "sourceMap": false,
+        "extractCss": false,
+        "namedChunks": false,
+        "aot": false,
+        "extractLicenses": false,
+        "vendorChunk": false,
+        "buildOptimizer": false
+      }
+    };
+
+    return updateWorkspace(workspaceConfig)(tree, context as any) as any;
+  }
+}

--- a/typescript/api-client/projects/vcd/plugin-builders/src/lib/schematics/ng-add/schema.d.ts
+++ b/typescript/api-client/projects/vcd/plugin-builders/src/lib/schematics/ng-add/schema.d.ts
@@ -1,0 +1,3 @@
+export interface Schema {
+    projectName: string;
+}

--- a/typescript/api-client/projects/vcd/plugin-builders/src/lib/schematics/ng-add/schema.json
+++ b/typescript/api-client/projects/vcd/plugin-builders/src/lib/schematics/ng-add/schema.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/schema",
+    "properties": {
+        "projectName": {
+            "type": "string",
+            "default": "cloud-director-container",
+            "x-prompt": "What is the name of your project?"
+        }
+    }
+}

--- a/typescript/api-client/projects/vcd/plugin-builders/tsconfig.lib.json
+++ b/typescript/api-client/projects/vcd/plugin-builders/tsconfig.lib.json
@@ -20,5 +20,8 @@
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
     "enableResourceInlining": true,
-  }
+  },
+  "exclude": [
+    "src/lib/schematics/**/*"
+  ]
 }

--- a/typescript/api-client/projects/vcd/plugin-builders/tsconfig.schematics.json
+++ b/typescript/api-client/projects/vcd/plugin-builders/tsconfig.schematics.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "lib": [
+      "es2018",
+      "dom"
+    ],
+    "declaration": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
+    "rootDir": "src/",
+    "skipDefaultLibCheck": true,
+    "skipLibCheck": true,
+    "sourceMap": false,
+    "strictNullChecks": true,
+    "target": "es6",
+    "types": [
+      "jasmine",
+      "node"
+    ]
+  },
+  "include": [
+    "./src/lib/schematics/**/*"
+  ]
+}

--- a/typescript/api-client/projects/vcd/schematics/package.json
+++ b/typescript/api-client/projects/vcd/schematics/package.json
@@ -10,6 +10,7 @@
   "schematics": "./schematics/collection.json",
   "peerDependencies": {
     "@angular-devkit/core": "7.3.8",
-    "@angular-devkit/schematics": "7.3.8"
+    "@angular-devkit/schematics": "7.3.8",
+    "@schematics/angular": "9.1.4"
   }
 }

--- a/typescript/api-client/projects/vcd/schematics/src/schematics/plugin-seed/index.d.ts
+++ b/typescript/api-client/projects/vcd/schematics/src/schematics/plugin-seed/index.d.ts
@@ -1,3 +1,3 @@
 import { Rule } from '@angular-devkit/schematics';
 import { Schema } from "./schema";
-export declare function pluginSeed(_options: Schema): Rule;
+export declare function pluginSeed(options: Schema): Rule;

--- a/typescript/api-client/projects/vcd/schematics/src/schematics/plugin-seed/index.ts
+++ b/typescript/api-client/projects/vcd/schematics/src/schematics/plugin-seed/index.ts
@@ -1,21 +1,127 @@
-import { Rule, SchematicContext, Tree, url, apply, template, mergeWith } from '@angular-devkit/schematics';
+import { Rule, SchematicContext, Tree, url, apply, template, mergeWith, chain, noop, SchematicsException, move } from '@angular-devkit/schematics';
 import { Schema } from "./schema";
 import { strings } from "@angular-devkit/core";
+import {
+  getWorkspace,
+  updateWorkspace
+} from '@schematics/angular/utility/config';
+import { normalize } from "path";
+import { getSourceFile } from "../utils";
+import { getSourceNodes } from "@schematics/angular/utility/ast-utils";
+import { SyntaxKind, SourceFile } from "@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript";
+import { Change, InsertChange } from "@schematics/angular/utility/change";
+
+const PROJECT_NAME = "cloud-director-container";
+const PLUGINS_CONTAINING_FOLDER = "src/plugins";
+
+export function pluginSeed(options: Schema): Rule {
+  return chain([
+    createDirectoryAndFiles(options),
+    isVulcan(options.vcdVersion) ? noop() : isWellingtonOrXendi(options.vcdVersion) ? updateAngularJson(options) : noop(),
+    isVulcan(options.vcdVersion) ? noop() : isWellingtonOrXendi(options.vcdVersion) ? updatePluginRegistrations(options) : noop(),
+  ]);
+}
 
 // You don't have to export the function as default. You can also have more than one rule factory
 // per file.
-export function pluginSeed(_options: Schema): Rule {
+function createDirectoryAndFiles(options: Schema): Rule {
   return (_tree: Tree, _context: SchematicContext) => {
-    const { vcdVersion } = _options;
+    const { vcdVersion } = options;
+    let temp = vcdVersion;
+    if (isWellingtonOrXendi(vcdVersion)) {
+      temp = "wellington-xendi"
+    }
 
-    const sourceTemplates = url(`./templates/${vcdVersion}`);
+    const sourceTemplates = url(`./templates/${temp}`);
     const sourceParametrizedTemplates = apply(sourceTemplates, [
       template({
-        ..._options,
+        ...options,
         ...strings
-      })
+      }),
+      move(normalize(PLUGINS_CONTAINING_FOLDER))
     ]);
 
     return mergeWith(sourceParametrizedTemplates);
   };
+}
+
+function updateAngularJson(options: Schema): Rule {
+  return (tree: Tree, context: SchematicContext) => {
+    const workspaceConfig = getWorkspace(tree);
+
+    if (!workspaceConfig) {
+      throw new SchematicsException('Could not find Angular workspace configuration');
+    }
+
+    if (!workspaceConfig.projects[PROJECT_NAME]) {
+      throw new SchematicsException(`Could not find Angular Project with name ${PROJECT_NAME} in your workspace`); 
+    }
+
+    if (!workspaceConfig.projects[PROJECT_NAME].architect) {
+      throw new SchematicsException('Could not find Angular architect configuration in your workspace');
+    }
+
+    let lazyModules: string[] = (workspaceConfig.projects as any)[PROJECT_NAME].architect.build.options.lazyModules;
+
+    if (!lazyModules || !lazyModules.length) {
+      lazyModules = [];
+    }
+
+    const moduleToAdd = `${PLUGINS_CONTAINING_FOLDER}/${options.name}/src/main/subnav-plugin.module`;
+
+    if (lazyModules.indexOf(moduleToAdd) === -1) {
+      lazyModules.push(moduleToAdd);
+    }
+
+    (workspaceConfig.projects as any)[PROJECT_NAME].architect.build.options.lazyModules = lazyModules;
+
+    return updateWorkspace(workspaceConfig)(tree, context as any) as any;
+  }
+}
+
+function updatePluginRegistrations(options: Schema): Rule {
+  return (tree: Tree, _context: SchematicContext) => {
+    const pluginConfig = getSourceFile(tree, `${PLUGINS_CONTAINING_FOLDER}/index.ts`);
+
+    if (!pluginConfig) {
+      throw new SchematicsException(`File not found: ${pluginConfig}`);
+    }
+
+    const changes: Change[] = [
+      addNewPlugin(options.name, pluginConfig)
+    ];
+    
+    const recorder = tree.beginUpdate(`${PLUGINS_CONTAINING_FOLDER}/index.ts`);
+
+    changes.forEach((change: any) => {
+      if (change instanceof InsertChange) {
+        recorder.insertLeft(change.pos, change.toAdd);
+      }
+    });
+
+    tree.commitUpdate(recorder);
+
+    return tree;
+  }
+}
+
+function addNewPlugin(folderName: string, pluginConfig: SourceFile) {
+  const arr = getSourceNodes(pluginConfig).filter((node) => {
+    return node.kind === SyntaxKind.CloseBracketToken
+  });
+
+  const lastPluginItem = arr[arr.length - 1].getStart() - 1;
+
+  return new InsertChange(
+    `${PLUGINS_CONTAINING_FOLDER}/index.ts`,
+    lastPluginItem,
+    `\tnew PluginRegistration("src/plugins/${folderName}/src", "main/subnav-plugin.module#SubnavPluginModule", "Seed Plugin"),\n`)
+}
+
+function isVulcan(version: string) {
+  return version === "9.1";
+}
+
+function isWellingtonOrXendi(version: string) {
+  return version === "9.7" || version === "10.0";
 }

--- a/typescript/api-client/projects/vcd/schematics/src/schematics/plugin-seed/templates/wellington-xendi/__name@dasherize__/src/main/subnav-plugin.module.ts
+++ b/typescript/api-client/projects/vcd/schematics/src/schematics/plugin-seed/templates/wellington-xendi/__name@dasherize__/src/main/subnav-plugin.module.ts
@@ -1,0 +1,48 @@
+import { CommonModule } from "@angular/common";
+import { Inject, NgModule } from "@angular/core";
+import { RouterModule, Routes } from "@angular/router";
+import { Store } from "@ngrx/store";
+import { VcdApiClient, VcdSdkModule, PluginModule, ExtensionNavRegistration, EXTENSION_ROUTE, EXTENSION_ASSET_URL } from "@vcd/sdk";
+import { TranslationService, I18nModule} from "@vcd/i18n";
+import { ClarityModule } from "@clr/angular";
+import { AboutComponent } from "./subnav/about.component";
+import { StatusComponent } from "./subnav/status.component";
+import { SubnavComponent } from "./subnav/subnav.component";
+
+const ROUTES: Routes = [
+    { path: "", component: SubnavComponent, children: [
+        { path: "", redirectTo: "status", pathMatch: "full" },
+        { path: "status", component: StatusComponent },
+        { path: "about", component: AboutComponent }
+    ]}
+];
+
+@NgModule({
+    imports: [
+        ClarityModule,
+        CommonModule,
+        VcdSdkModule,
+        I18nModule.forChild(EXTENSION_ASSET_URL, true),
+        RouterModule.forChild(ROUTES)
+    ],
+    declarations: [
+        AboutComponent,
+        StatusComponent,
+        SubnavComponent
+    ],
+    bootstrap: [SubnavComponent],
+    exports: [],
+    providers: [VcdApiClient]
+})
+export class SubnavPluginModule extends PluginModule {
+    constructor(appStore: Store<any>, @Inject(EXTENSION_ROUTE) extensionRoute: string, translate: TranslationService) {
+        super(appStore);
+        translate.registerTranslations(null);
+        this.registerExtension(<ExtensionNavRegistration>{
+            path: extensionRoute,
+            icon: "page",
+            nameCode: "nav.label",
+            descriptionCode: "nav.description"
+        });
+    }
+}

--- a/typescript/api-client/projects/vcd/schematics/src/schematics/plugin-seed/templates/wellington-xendi/__name@dasherize__/src/main/subnav/about.component.ts
+++ b/typescript/api-client/projects/vcd/schematics/src/schematics/plugin-seed/templates/wellington-xendi/__name@dasherize__/src/main/subnav/about.component.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018 VMware, Inc. All rights reserved. VMware Confidential
+ */
+import {Component, Inject} from "@angular/core";
+import {EXTENSION_ASSET_URL} from '@vcd/sdk';
+
+@Component({
+    selector: "vcd-plugin-about",
+    template: `
+        <div>
+            <p>{{"subnav.about.content.1" | translate}}</p>
+            <p>{{"subnav.about.content.2" | translate}}</p>
+        </div>
+
+    `
+})
+export class AboutComponent {
+    constructor(@Inject(EXTENSION_ASSET_URL) public assetUrl: string) {}
+}

--- a/typescript/api-client/projects/vcd/schematics/src/schematics/plugin-seed/templates/wellington-xendi/__name@dasherize__/src/main/subnav/status.component.ts
+++ b/typescript/api-client/projects/vcd/schematics/src/schematics/plugin-seed/templates/wellington-xendi/__name@dasherize__/src/main/subnav/status.component.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018 VMware, Inc. All rights reserved. VMware Confidential
+ */
+import {Component, Inject} from "@angular/core";
+import {EXTENSION_ASSET_URL} from '@vcd/sdk';
+
+@Component({
+    selector: "vcd-plugin-status",
+    template: `
+        <div>
+            <h1>{{"subnav.status.content" | translate:today}}</h1>
+        </div>
+
+    `
+})
+export class StatusComponent {
+    today: String = new Date().toLocaleString();
+    
+    constructor(@Inject(EXTENSION_ASSET_URL) public assetUrl: string) {}
+}

--- a/typescript/api-client/projects/vcd/schematics/src/schematics/plugin-seed/templates/wellington-xendi/__name@dasherize__/src/main/subnav/subnav.component.html
+++ b/typescript/api-client/projects/vcd/schematics/src/schematics/plugin-seed/templates/wellington-xendi/__name@dasherize__/src/main/subnav/subnav.component.html
@@ -1,0 +1,9 @@
+<div class="content-area">
+  <router-outlet></router-outlet>
+</div>
+<clr-vertical-nav [clrVerticalNavCollapsible]="true">
+  <a *ngFor="let navItem of navItems" clrVerticalNavLink routerLink="{{navItem.routerLink}}" routerLinkActive="active">
+    <clr-icon *ngIf="navItem.iconShape" clrVerticalNavIcon [attr.shape]="navItem.iconShape" title="{{navItem.labelKey | translate}}"></clr-icon>
+    {{navItem.labelKey | translate}}
+  </a>
+</clr-vertical-nav>

--- a/typescript/api-client/projects/vcd/schematics/src/schematics/plugin-seed/templates/wellington-xendi/__name@dasherize__/src/main/subnav/subnav.component.ts
+++ b/typescript/api-client/projects/vcd/schematics/src/schematics/plugin-seed/templates/wellington-xendi/__name@dasherize__/src/main/subnav/subnav.component.ts
@@ -1,0 +1,16 @@
+import {Component, Inject} from "@angular/core";
+import {EXTENSION_ASSET_URL} from '@vcd/sdk';
+
+@Component({
+    selector: "plugin-subnav",
+    templateUrl: "./subnav.component.html",
+    host: {'class': 'content-container'}
+})
+export class SubnavComponent {
+    navItems: any[] = [
+        {routerLink: "./status", iconShape: "help-info", labelKey: "subnav.menu.status"},
+        {routerLink: "./about", iconShape: "helix", labelKey: "subnav.menu.about"}
+    ];
+    
+    constructor(@Inject(EXTENSION_ASSET_URL) public assetUrl: string) {}
+}

--- a/typescript/api-client/projects/vcd/sdk/tsconfig.lib.json
+++ b/typescript/api-client/projects/vcd/sdk/tsconfig.lib.json
@@ -9,7 +9,7 @@
     "types": [],
     "lib": [
       "dom",
-      "es2018"
+      "es5"
     ],
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
[VACE-2589] Create ng add plugin-seed-9.7-10.0

Implement plugin seed for 9.7-10.0, the schematic will:
- Update the angular.json file lazy modules property in the container
service env.
- Update the index file under the plugins directory in the container
service env.

Improve the base plugin builder to exclude the html files
from the zip file and to set default values for file
replacement, scripts and styles arrays.

Add ng add support for @vcd/plugin-builders

Testing
Plugin Seed
- Seed plugin for 9.7-10.0 and verify it setups all the files
described above.
- It compiles successfully
- Upload the plugin to actual VCD env and verify it works

Plugin Builders
- Verify the ng add @vcd/plugin-builders will setup an example
plugin builder configuration in the angular.json file.
- Verify the plugin builder is able to compile and package each
angular module into an actual plugin, and the html files are
excluded from the zip file.

Signed-off-by: Nikola Vladimirov Iliev <nvladimirovi@vmware.com>