### PR TITLE
[VACE-2623] Add support for UI Plugins Incremental Loading in the @vcd/plugin-builders

### DIFF
--- a/typescript/api-client/projects/vcd/plugin-builders/README.md
+++ b/typescript/api-client/projects/vcd/plugin-builders/README.md
@@ -1,4 +1,3 @@
-
 # vCloud Director Angular Plugin Builder
 
 ## Overview
@@ -6,55 +5,55 @@ The @vcd/plugin-builders package contains an angular builder which you can use t
 
 ## How to use it?
 
-> **Note:** This version of the plugin builder is supported by angular 7.3.8^.
+> **Note:** This version of the plugin builder is supported by angular 6.1.0.
 
 1. Download the package
-```bash
-npm i @vcd/plugin-builders
-```
-2. In your `angular.json` file
-```json
-{
-	"$schema": "./node_modules/@angular/cli/lib/config/schema.json",
-	...
-	"projects": {
-		"your-project": {
-			...
-			"architect": {
-				# Note that the only thing which this builder expects is the modulePath, all other options are up to you.
-				"your-plugin-builder-config": {
-					"builder": "@vcd/plugin-builders:plugin-builder",
-					"options": {
-					"modulePath": "./path/to/your/module",
-					"outputPath": "./path/to/your/dist/folder",
-					# The index is not really neaded but have to stay there because of the angular validation.
-					"index": "src/index.html",
-					"main": "src/main.ts",
-					"tsConfig": "src/tsconfig.app.json",
-					"assets": [
-						# Include the paths to your plugin manifest and i18n json files here.
-					],
-					"optimization": true,
-					"outputHashing": "none",
-					"sourceMap": false,
-					"extractCss": true,
-					"namedChunks": false,
-					"aot": true,
-					"extractLicenses": true,
-					"vendorChunk": false,
-					"buildOptimizer": true
-					}
-				}
-			}
-		}
-		...
-	}
-}
-```
+    ```bash
+    npm i @vcd/plugin-builders
+    ```
+2. In your `angular.json` file or you can run `ng add @vcd/plugin-builders --projectName=cloud-director-container`
+    ```json
+    {
+    	"$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+    	...
+    	"projects": {
+    		"your-project": {
+    			...
+    			"architect": {
+    				# Note that the only thing which this builder expects is the modulePath, all other options are up to you.
+    				"your-plugin-builder-config": {
+    					"builder": "@vcd/plugin-builders:plugin-builder",
+    					"options": {
+    					"modulePath": "./path/to/your/module",
+    					"outputPath": "./path/to/your/dist/folder",
+    					# The index is not really neaded but have to stay there because of the angular validation.
+    					"index": "src/index.html",
+    					"main": "src/main.ts",
+    					"tsConfig": "src/tsconfig.app.json",
+    					"assets": [
+    						# Include the paths to your plugin manifest and i18n json files here.
+    					],
+    					"optimization": true,
+    					"outputHashing": "none",
+    					"sourceMap": false,
+    					"extractCss": true,
+    					"namedChunks": false,
+    					"aot": true,
+    					"extractLicenses": true,
+    					"vendorChunk": false,
+    					"buildOptimizer": true
+    					}
+    				}
+    			}
+    		}
+    		...
+    	}
+    }
+    ```
 3. Run the builder through ng cli
-```bash
-ng run your-project:your-plugin-builder-config
-```
+    ```bash
+    ng run your-project:your-plugin-builder-config
+    ```
 
 ## Build
 ```bash
@@ -68,6 +67,41 @@ npm i
 # build libraries
 npm run build
 ```
+
+## For UI Plugins with Incremental Loading allowed
+1. Download the package
+    ```bash
+    npm i @vcd/plugin-builders
+    ```
+2. Run `ng add @vcd/plugin-builders --projectName=cloud-director-container`
+3. Open your `angular.json`
+4. Find the config, `Ctrl + F` "builder-config-example"
+5. If you want to split your plugin and its dependencies into chunks you have to add `librariesConfig` in your plugin builder options object. Each library has name, version, scope and locaton (location is automatically populated but if you want you can specify it on your own.). The name and the version are standard as in your package.json file, scope on other hand tells to vCloud Director Core UI what to do with your dependecies:
+    - Provided - this dependecy will be provided by the vCloud Director Core UI.
+    - Runtime - your dependecy will be shared with other plugins which use the same version of it.
+    - Self - no matter what vCloud Director Core UI will load your your library and will not share it with any other plugin in the application.
+    ```json
+    "options": {
+        "librariesConfig": {
+            "libName": {
+                "version": "x.x.x",
+                "scope": "provided | runtime | self"
+              },
+              ...
+        }
+    }
+    ```
+6. If you want to instruct which dependecies are external for your plugin (AMD Module) you can pass `externalLibs` in your options. By adding this option you are instruction vCloud Director Core UI to provide you his own dependecies which match your selector. For example vCloud Director 10.2 is using @clr/angulra@3.1.1, your plugin will receive that version.
+    ```json
+    "options": {
+        "externalLibs": [
+            "@clr/angular"
+        ]
+    }
+    ```
+7. Can disable the default `externalLibs` by passing `ignoreDefaultExternals` in your options.
+8. In the plugin builder's `options` object add `"vcdVersion": "10.2"` to enable the functionality described above.
+
 
 ## Contributing
 

--- a/typescript/api-client/projects/vcd/plugin-builders/src/lib/base/concat.ts
+++ b/typescript/api-client/projects/vcd/plugin-builders/src/lib/base/concat.ts
@@ -1,0 +1,65 @@
+import { RawSource } from "webpack-sources";
+
+export interface ConcatWebpackPluginOptions {
+    concat: {
+        inputs: string[],
+        output: string,
+    }[];
+}
+
+/**
+ * Webpack Plugin for Concatenation
+ */
+export class ConcatWebpackPlugin {
+    private options: ConcatWebpackPluginOptions;
+
+    constructor(options: ConcatWebpackPluginOptions) {
+        this.options = options;
+    }
+
+    /**
+     * Called by Webpack
+     * @param compiler Webpack compiler
+     * see https://webpack.js.org/api/compiler-hooks/ for more detials.
+     */
+    apply(compiler) {
+        // Hook for on emit
+        compiler.hooks.emit.tapAsync('vCloud Director Concat Plugin', (
+            compilation,
+            callback
+        ) => {
+            if (compilation.compiler.isChild()) {
+                callback();
+                return;
+            }
+
+            // Cocnat files
+            this.options.concat
+                .map((obj) => {
+                    // Take sources which has to concatenated
+                    const sourcesToConcat = obj.inputs.map((input) => {
+                        const source = compilation.assets[input].source();
+                        delete compilation.assets[input];
+                        return Buffer.isBuffer(source) ? source : new Buffer(source)
+                    });
+
+                    return {
+                        output: obj.output,
+                        sourcesToConcat
+                    }
+                })
+                .map((asset) => {
+                    return {
+                        output: asset.output,
+                        source: Buffer.concat(asset.sourcesToConcat),
+                    };
+                })
+                .forEach((asset) => {
+                    // Output the result
+                    compilation.assets[asset.output] = new RawSource(asset.source as any);
+                });
+
+            callback();
+        });
+    }
+}

--- a/typescript/api-client/projects/vcd/plugin-builders/src/lib/base/index.ts
+++ b/typescript/api-client/projects/vcd/plugin-builders/src/lib/base/index.ts
@@ -1,114 +1,220 @@
+import * as fs from 'fs';
+import * as path from "path";
+import * as ZipPlugin from 'zip-webpack-plugin';
 import {
   BrowserBuilder,
   NormalizedBrowserBuilderSchema
 } from '@angular-devkit/build-angular';
 import { Path, virtualFs } from '@angular-devkit/core';
-import * as fs from 'fs';
 import { Observable } from 'rxjs';
-
 import { BuilderConfiguration, BuildEvent } from '@angular-devkit/architect';
 import { tap } from 'rxjs/operators';
-import * as ZipPlugin from 'zip-webpack-plugin';
+import { extractExternalRegExps, splitVendorsIntoChunks, processManifestJsonFile, VCD_CUSTOM_LIB_SEPARATOR, takeChunkPackageJson } from "./utilites";
+import { LibrariesConfig, ExtensionManifest } from "./interfaces";
+import { ConcatWebpackPlugin } from "./concat";
 
-interface PluginBuilderSchema extends NormalizedBrowserBuilderSchema {
+export interface PluginBuilderSchema extends NormalizedBrowserBuilderSchema {
+	vcdVersion: string;
   /**
-   * A string of the form `path/to/file#exportName` that acts as a path to include to bundle
+   * A string of the form `path/to/file#exportName`
+	 * that acts as a path to include to bundle.
    */
-  modulePath: string;
+	modulePath: string;
+	/**
+	 * List of external libraries defined by the user.
+	 */
+	externalLibs: string[];
+	/**
+	 * Will disable the default external libraries,
+	 * allowing the user to define his own thanks to externalLibs property.
+	 */
+	ignoreDefaultExternals: boolean;
+	/**
+	 * List of libraries determining thier version, scope and file name (location). 
+	 */
+	librariesConfig: LibrariesConfig;
 }
+
+export const defaultExternals = {
+	common: [
+		/^@angular\/.+$/,
+		/^@ngrx\/.+$/,
+		/^@vcd\/common$/,
+		/^@vcd-ui\/common$/,
+		{
+			reselect: 'reselect'
+		}
+	],
+	["9.7-10.0"]: [
+		/^rxjs(\/.+)?$/,
+		/^@clr\/.+$/,
+		{
+			'clarity-angular': 'clarity-angular',
+		}
+	]
+}
+
 export default class PluginBuilder extends BrowserBuilder {
-  private options: PluginBuilderSchema;
+  	private options: PluginBuilderSchema;
 
-  private entryPointPath: string;
+  	private entryPointPath: string;
+	private entryPointOriginalContent: string;
+	private pluginLibsBundles = new Map<string, string>();
 
-  constructor(context) {
-    super(context);
-  }
+	constructor(context) {
+		super(context);
+	}
 
-  patchEntryPoint(contents: string) {
-    fs.writeFileSync(this.entryPointPath, contents);
-  }
+	patchEntryPoint(contents: string) {
+		fs.writeFileSync(this.entryPointPath, contents);
+	}
 
-  buildWebpackConfig(
-    root: Path,
-    projectRoot: Path,
-    host: virtualFs.Host<fs.Stats>,
-    options: PluginBuilderSchema
-  ) {
-    if (!this.options.modulePath) {
-      throw Error('Please define modulePath!');
-    }
+	buildWebpackConfig(
+		root: Path,
+		projectRoot: Path,
+		host: virtualFs.Host<fs.Stats>,
+		options: PluginBuilderSchema
+	) {
+		if (!this.options.modulePath) {
+			throw Error('Please define modulePath!');
+		}
 
-    const config = super.buildWebpackConfig(root, projectRoot, host, options);
+		const config = super.buildWebpackConfig(root, projectRoot, host, options);
 
-    // Make sure we are producing a single bundle
-    delete config.entry.polyfills;
-    delete config.optimization.runtimeChunk;
-    delete config.optimization.splitChunks;
-    delete config.entry.styles;
-    delete config.entry["polyfills-es5"];
+		// Reset the default configurations
+		delete config.entry.polyfills;
+		delete config.optimization.runtimeChunk;
+		delete config.optimization.splitChunks;
+		delete config.entry.styles;
+		delete config.entry["polyfills-es5"];
 
-    // List the external libraries which will be provided by vcd
-    config.externals = [
-      /^rxjs(\/.+)?$/,
-      /^@angular\/.+$/,
-      /^@clr\/.+$/,
-      /^@ngrx\/.+$/,
-      /^@vcd\/common$/,
-      /^@vcd-ui\/common$/,
-      {
-        'clarity-angular': 'clarity-angular',
-        reselect: 'reselect'
-      }
-    ];
+		// List the external libraries which will be provided by vcd
+		config.externals = [
+			...(options.ignoreDefaultExternals ? [] : defaultExternals.common),
+			...(options.vcdVersion !== "10.2" && !options.ignoreDefaultExternals ? defaultExternals["9.7-10.0"] : []),
+			...extractExternalRegExps(options.externalLibs),
+		];
 
-    // preserve path to entry point
-    // so that we can clear use it within `run` method to clear that file
-    this.entryPointPath = config.entry.main[0];
-    let [modulePath, moduleName] = this.options.modulePath.split('#');
-    modulePath = modulePath.substr(0, modulePath.indexOf(".ts"));
-    const entryPointContents = `export * from '${modulePath}';`;
-    this.patchEntryPoint(entryPointContents);
+		let [modulePath, moduleName] = this.options.modulePath.split('#');
 
-    config.output.filename = `bundle.js`;
-    config.output.library = moduleName;
-    config.output.libraryTarget = 'amd';
-    // workaround to support bundle on nodejs
-    config.output.globalObject = `(typeof self !== 'undefined' ? self : this)`;
+		if (options.vcdVersion === "10.2") {
+			const self = this;
 
-    const ngCompilerPluginInstance = config.plugins.find(
-      x => x.constructor && x.constructor.name === 'AngularCompilerPlugin'
-    );
-    if (ngCompilerPluginInstance) {
-      ngCompilerPluginInstance._entryModule = modulePath;
-    }
+			// Create unique jsonpFunction name
+			const copyPlugin = config.plugins.find((x) => x && x.copyWebpackPluginPatterns);
+			const manifestJsonPath = path.join(copyPlugin.copyWebpackPluginPatterns[0].context, "manifest.json");
+			const manifest: ExtensionManifest = JSON.parse(fs.readFileSync(manifestJsonPath, "utf-8"));
+			config.output.jsonpFunction = `vcdJsonp#${moduleName}#${manifest.urn}`;
 
-    // Zip the result
-    config.plugins.push(
-      new ZipPlugin({
-        filename: 'plugin.zip',
-        exclude: [/\.html$/]
-      }),
-    );
+			// Configure the vendor chunks
+			config.optimization.splitChunks = {
+				chunks: "all",
+				cacheGroups: {
+					vendor: {
+						test(mod) {
+							if (!mod.context) {
+								return false;
+							}
+						
+							// Only node_modules are needed and these which are defiend in the librariesConfig
+							if (
+								!mod.context.includes('node_modules') ||
+								!Object.keys(options.librariesConfig).some((key) => {
+									return mod.context.includes(key)
+								})
+							) {
+								return false;
+							}
 
-    return config;
-  }
+							return true;
+						},
+						name(module) {
+							return splitVendorsIntoChunks(module, config.context, (packageName: string) => {
+								packageName = packageName.replace(VCD_CUSTOM_LIB_SEPARATOR, "/");
+								self.pluginLibsBundles.set(packageName, `${packageName}.bundle.js`)
+							});
+						},
+					},
+				},
+			};
 
-  run(
-    builderConfig: BuilderConfiguration<PluginBuilderSchema>
-  ): Observable<BuildEvent> {
-    this.options = builderConfig.options;
-    this.options.fileReplacements = this.options.fileReplacements && this.options.fileReplacements.length ? this.options.fileReplacements : [];
-    this.options.styles = this.options.styles && this.options.styles.length ? this.options.styles : [];
-    this.options.scripts = this.options.scripts && this.options.scripts.length ? this.options.scripts : [];
-    // I don't want to write it in my scripts every time so I keep it here
-    builderConfig.options.deleteOutputPath = false;
+			// Transform manifest json file.
+			copyPlugin.copyWebpackPluginPatterns[0].transform = processManifestJsonFile(
+				options.librariesConfig || {},
+				this.pluginLibsBundles,
+				config.output.jsonpFunction
+			);
+		}
 
-    return super.run(builderConfig).pipe(
-      tap(() => {
-        // clear entry point so our main.ts is always empty
-        this.patchEntryPoint('');
-      })
-    );
-  }
+		// preserve path to entry point
+		// so that we can clear use it within `run` method to clear that file
+		this.entryPointPath = config.entry.main[0];
+		this.entryPointOriginalContent = fs.readFileSync(this.entryPointPath, "utf-8");
+			
+		// Export the plugin module
+		modulePath = modulePath.substr(0, modulePath.indexOf(".ts"));
+		const entryPointContents = `export * from '${modulePath}';`;
+		this.patchEntryPoint(entryPointContents);
+
+		// Define amd lib
+		config.output.filename = `bundle.js`;
+		config.output.library = moduleName;
+		config.output.libraryTarget = 'amd';
+		// workaround to support bundle on nodejs
+		config.output.globalObject = `(typeof self !== 'undefined' ? self : this)`;
+
+		// Reset angular compiler entry module, in order to compile our plugin.
+		const ngCompilerPluginInstance = config.plugins.find(
+			x => x.constructor && x.constructor.name === 'AngularCompilerPlugin'
+		);
+
+		if (ngCompilerPluginInstance) {
+			ngCompilerPluginInstance._entryModule = modulePath;
+		}
+
+		if (options.vcdVersion === "10.2") {
+			config.plugins.push(
+				new ConcatWebpackPlugin({
+					concat: [
+						{
+							inputs: [
+								"bundle.js",
+								"vendors~main.bundle.js"
+							],
+							output: "bundle.js"
+						}
+					]
+				})
+			);
+		}
+
+		// Zip the result
+		config.plugins.push(
+			new ZipPlugin({
+				filename: 'plugin.zip',
+				exclude: [/\.html$/]
+			}),
+		);
+
+		return config;
+	}
+
+	run(
+		builderConfig: BuilderConfiguration<PluginBuilderSchema>
+	): Observable<BuildEvent> {
+		this.options = builderConfig.options;
+		this.options.fileReplacements = this.options.fileReplacements && this.options.fileReplacements.length ? this.options.fileReplacements : [];
+		this.options.styles = this.options.styles && this.options.styles.length ? this.options.styles : [];
+		this.options.scripts = this.options.scripts && this.options.scripts.length ? this.options.scripts : [];
+			
+		// To avoid writing it in my scripts every time keep it here
+		builderConfig.options.deleteOutputPath = false;
+
+		return super.run(builderConfig).pipe(
+			tap(() => {
+				// clear entry point so our main.ts (or any other entry file) to remain untouched.
+				this.patchEntryPoint(this.entryPointOriginalContent);
+			})
+		);
+	}
 }

--- a/typescript/api-client/projects/vcd/plugin-builders/src/lib/base/interfaces.ts
+++ b/typescript/api-client/projects/vcd/plugin-builders/src/lib/base/interfaces.ts
@@ -1,0 +1,154 @@
+export interface LibrariesConfig {
+    [libName:string]: {
+        version: string;
+        scope: LibraryConfigScopeTypes,
+        location: string;
+    }
+}
+
+export type LibraryConfigScopeTypes = "provided" | "runtime" | "self";
+export const LibraryConfigScopes = ["provided", "runtime", "self"];
+
+/**
+ * The contents of a third party extension's manifest.json file.
+ */
+export interface ExtensionManifest {
+    /**
+     * The version of the manifest
+     */
+    manifestVersion: string;
+
+    /**
+     * Unique URN used an ID for the extension.
+     */
+    urn: string;
+
+    /**
+     * Human readable name for the extension.
+     */
+    name: string;
+
+    /**
+     * The minimum supported version of VCD UI.
+     * TODO: Not currently used.
+     */
+    containerVersion: string;
+
+    /**
+     * Versions of VCD that the plugin claims compatibility with.
+     */
+    productVersions: string[];
+
+    /**
+     * The version of the extension.
+     */
+    version: string;
+
+    /**
+     * Scopes that the extension may be used under (e.g. tenant, service-provider).
+     */
+    scope: ExtensionScope[];
+
+    /**
+     * Minimum permissions required for the extension to be loaded.
+     */
+    permissions: string[];
+
+    /**
+     * Human readable description for the extension.
+     */
+    description: string;
+
+    /**
+     * Human readable vendor name for the extension.
+     */
+    vendor: string;
+
+    /**
+     * Human readable license information for the extension.
+     */
+    license: string;
+
+    /**
+     * Support URL for the extension.
+     */
+    link: string;
+
+    /**
+     * The symbol to be imported as an Angular 4 module from the
+     * the extension's AMD bundle.
+     */
+    module: string;
+
+    /**
+     * The base route the extension's routes will be registered under.
+     */
+    route: string;
+
+    /**
+     * Formal extension points.
+     */
+    extensionPoints?: ExtensionPointManifest[];
+
+    /**
+     * Extension locales for the manifest.
+     * Supported by manifest v2.0.0 and higher.
+     */
+    locales: {
+        [key: string]: string
+    };
+
+    externals?: {
+        libs?: {
+            [libName: string]: {
+                version: string;
+                scope: ExtensionLibScope;
+                location: string;
+            };
+        };
+        jsonpFunction?: string;
+    };
+}
+
+export type ExtensionLibScope = "provided" | "runtime" | "self";
+
+/**
+ * This defines a formal extension point.  An extension point is a declarative way for an extension manifest
+ * to describe how the VCD application behaviour is extended or modified by the extension.
+ */
+export interface ExtensionPointManifest {
+    /**
+     * Universally unique URN that identifies this Extension Point.  It is suggested to preprend the extension's URN.
+     */
+    readonly urn: string;
+
+    /**
+     * The type of Extension Point being defined from a supported list.  This list will increase over time.
+     */
+    readonly type: string;
+
+    /**
+     * The name of the Extension Point, intended for display in extension management interfaces.
+     */
+    readonly name: string;
+
+    /**
+     * An overview of the Extension Point, intended for display in extension management interfaces.
+     */
+    readonly description: string;
+
+    /**
+     * The name of the module which will be registerd in the top-nav-level area.
+     */
+    readonly module?: string;
+
+    /**
+     * The route on which only top level extrension points will be registerd.
+     */
+    readonly route?: string;
+}
+
+/**
+ * Supported extension scopes.
+ */
+export type ExtensionScope = "tenant" | "service-provder";

--- a/typescript/api-client/projects/vcd/plugin-builders/src/lib/base/schema.json
+++ b/typescript/api-client/projects/vcd/plugin-builders/src/lib/base/schema.json
@@ -1,10 +1,29 @@
 {
     "type": "object",
     "properties": {
+        "vcdVersion": {
+            "type": "string",
+            "description": "Based on the vCloud Director version some features will be turned on or off.",
+            "default": ""
+        },
         "modulePath": {
             "type": "string",
             "description": "Path to module like loadChildren",
             "default": ""
+        },
+        "externalLibs": {
+            "type": "array",
+            "description": "The list of the libraries which will be provided by the vCloud Director Core UI. The list of strings will be converted to Regular Expression, defined by the JS. (The input supports strings only)",
+            "default": []
+        },
+        "librariesConfig": {
+            "type": "object",
+            "description": "In this section you can define your libs name, version and scope (provided - Provided by the UI, runtime - If the library is bootstrapped already from somebody else use it, else request and bootstrap your library and also make it avaiable for other plugins, self - Use your specific version no matter what)."
+        },
+        "ignoreDefaultExternals": {
+            "type": "boolean",
+            "description": "By setting this value to 'true' you will disable the default list of external libraries, and you have to provide your own in 'externalLibs' list.",
+            "default": false
         }
     }
 }

--- a/typescript/api-client/projects/vcd/plugin-builders/src/lib/base/utilites.ts
+++ b/typescript/api-client/projects/vcd/plugin-builders/src/lib/base/utilites.ts
@@ -1,0 +1,106 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { LibrariesConfig, LibraryConfigScopeTypes, LibraryConfigScopes, ExtensionManifest } from "./interfaces";
+
+export const VCD_CUSTOM_LIB_SEPARATOR = ":";
+
+/**
+ * Convert string defined regex to regex object.
+ */
+export function extractExternalRegExps(externalLibs: string[] = []) {
+	return externalLibs.map((libStr) => new RegExp(libStr))
+}
+
+/**
+ * Search for package json file
+ */
+export function takeChunkPackageJson(chunk: any, basePath: string) {
+	// get the name. E.g. node_modules/packageName/not/this/part.js
+	// or node_modules/packageName
+
+	const result: string[] = chunk.context.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/);
+
+	if (!result.length) {
+		return;
+	}
+
+	let packageName: string = result[1];
+
+	if (packageName.startsWith("@")) {
+		const name = /[\\/]node_modules[\\/](.*?)([\\/])(.*?)([\\/])|$/.exec(chunk.context)[0].split("/node_modules/")[1];
+		packageName = name.substr(0, name.length - 1);
+	}
+
+	const packageJsonPath = path.join(basePath, "node_modules", packageName, "package.json");
+
+	return JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+}
+
+/**
+ * This function in combination with webpack optimization.splitChunks.cacheGroups.[funcName]
+ * will split all the vendors in named chunks per library. The name of the chunk will contain
+ * the library name and version.
+ * @param module Node Module
+ * @param basePath Project Root
+ */
+export function splitVendorsIntoChunks(module: any, basePath: string, vendorTracker?: (packageName: string) => any) {
+	const packageJson = takeChunkPackageJson(module, basePath);
+
+	let packageJsonName: string = packageJson.name;
+	// This is needed because otherwise webpack will create dir with subdirs
+	if (packageJsonName.includes("/")) {
+		packageJsonName = packageJsonName.replace("/", VCD_CUSTOM_LIB_SEPARATOR);
+	}
+
+	const packageName = `${packageJsonName}@${packageJson.version}`;
+
+	if (vendorTracker) {
+		vendorTracker(packageName);
+	}
+
+	return packageName;
+}
+
+export function processManifestJsonFile(
+	librariesConfig: LibrariesConfig,
+	libsBundles: Map<string, string>,
+	jsonpFunction: string
+) {
+	return function (content, absolutePath) {
+		if (!absolutePath.includes("manifest.json")) {
+			return content;
+		}
+	
+		const manifest: ExtensionManifest = JSON.parse(content.toString("utf-8"));
+		manifest.externals = {};
+		manifest.externals.libs = {};
+		manifest.externals.jsonpFunction = jsonpFunction;
+
+		Object.keys(librariesConfig).forEach((libName) => {
+			const version = librariesConfig[libName].version;
+			const preDefinedLocation = librariesConfig[libName].location;
+			const location = libsBundles.get(`${libName}@${version}`);
+			const scope: LibraryConfigScopeTypes = librariesConfig[libName].scope;
+
+			if (!version || !version.length) {
+				throw Error(`${libName} has incorrect version defined! Current version ${version}`)
+			}
+
+			if (!scope || LibraryConfigScopes.indexOf(scope) === -1) {
+				throw Error(`${libName} with version ${version} has incorrect scope defined! Current scope ${scope}.`)
+			}
+
+			if (!preDefinedLocation && (!location || !location.length)) {
+				throw Error(`${libName} with version ${version} was not found in the list of built vendor bundles. Please make sure you passed the correct lib name and version in your angular.json builder config section.`);
+			}
+
+			manifest.externals.libs[libName] = {
+				version,
+				scope,
+				location: preDefinedLocation || location.replace("/", VCD_CUSTOM_LIB_SEPARATOR),
+			};
+		});
+
+		return Buffer.from(JSON.stringify(manifest, null, 4));
+	}
+}

--- a/typescript/api-client/projects/vcd/plugin-builders/src/lib/new/index.ts
+++ b/typescript/api-client/projects/vcd/plugin-builders/src/lib/new/index.ts
@@ -1,3 +1,10 @@
+/**
+ * This new version of the builder shims the basics which
+ * has to be covered in future, additinal work is expected.
+ * Most of the functionallity which has to be implemented here is
+ * well described in the base plugin builder.
+ */
+
 // Angular builder
 import { executeBrowserBuilder } from '@angular-devkit/build-angular';
 import { buildBrowserWebpackConfigFromContext } from '@angular-devkit/build-angular/src/browser';

--- a/typescript/api-client/projects/vcd/plugin-builders/src/lib/schematics/ng-add/index.ts
+++ b/typescript/api-client/projects/vcd/plugin-builders/src/lib/schematics/ng-add/index.ts
@@ -36,6 +36,7 @@ function updateAngularJson(options: Schema): Rule {
         "polyfills": "src/polyfills.ts",
         "tsConfig": "src/tsconfig.app.json",
         "assets": [
+          // Attention! Order matters, 1st you have to define the folder which contains your manifest json file.
           { "glob": "**/*", "input": "./src/path/to/your/assets/folder", "output": "/" }
         ],
         "optimization": true,

--- a/typescript/api-client/projects/vcd/plugin-builders/tsconfig.json
+++ b/typescript/api-client/projects/vcd/plugin-builders/tsconfig.json
@@ -8,7 +8,7 @@
       "target": "es6",
       "skipLibCheck": true
     },
-    "files": [
-      "./src/lib/base/index.ts"
+    "include": [
+      "./src/lib/base/**/*.ts"
     ]
 }

--- a/typescript/api-client/projects/vcd/plugin-builders/tslint.json
+++ b/typescript/api-client/projects/vcd/plugin-builders/tslint.json
@@ -12,6 +12,13 @@
       "element",
       "lib",
       "kebab-case"
-    ]
+    ],
+    "ordered-imports": [
+      true,
+      {
+        "import-sources-order": "case-insensitive",
+        "named-imports-order": "case-insensitive"
+      }
+    ],
   }
 }


### PR DESCRIPTION
[VACE-2623] Add support for UI Plugins Incremental Loading in the @vcd/plugin-builders

Implement support for UI Plugin Incremental loading.
Update the readme for the plugin builders describing the new features.
Introduce new options:
- vcdVersion used to turn on/off the incremental loading and for future versioning decisions
- externalLibs allowing the user to specify his external deps
- librariesConfig incremental loading scoping and versioning
- ignoreDefaultExternals ignore the default list of external libraries

Testing Done
Create 2 plugins with incremental loading enabled
Verify the bundles are generated correctly
Verify the plugins work in the vcd ui
Verify the scoping works
Verify ignore defaut externals works
Verify define externals via angular.json works
Verify the plugins with turned off incremental loading work