### PR TITLE
Add Github Action for Typescript CI.

### DIFF
--- a/.github/workflows/ci-typescript-api-client.yml
+++ b/.github/workflows/ci-typescript-api-client.yml
@@ -1,0 +1,36 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+name: 'Typescript API client CI'
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - 'typescript/api-client/**'
+
+  pull_request:
+    branches:
+    - master
+    paths:
+    - 'typescript/api-client/**'
+
+defaults:
+  run:
+    working-directory: './typescript/api-client/'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm run test-ci 

--- a/typescript/api-client/angular.json
+++ b/typescript/api-client/angular.json
@@ -22,6 +22,11 @@
             "main": "projects/vcd/sdk/src/test.ts",
             "tsConfig": "projects/vcd/sdk/tsconfig.spec.json",
             "karmaConfig": "projects/vcd/sdk/karma.conf.js"
+          },
+          "configurations": {
+            "test-ci": {
+              "karmaConfig": "projects/vcd/sdk/karma.conf.ci.js"
+            }
           }
         },
         "lint": {

--- a/typescript/api-client/package.json
+++ b/typescript/api-client/package.json
@@ -25,6 +25,7 @@
     "schematics:copy:schemas": "cp -R ./projects/vcd/schematics/src/schematics ./dist/vcd/schematics",
     
     "test": "ng test",
+    "test-ci": "ng test --configuration=test-ci",
     "lint": "ng lint",
     "deploy": "cp .npmrc.dist . --rename=.npmrc && npm publish ./dist/vcd/sdk --access public && rimraf .npmrc"
   },

--- a/typescript/api-client/projects/vcd/sdk/karma.conf.ci.js
+++ b/typescript/api-client/projects/vcd/sdk/karma.conf.ci.js
@@ -1,0 +1,31 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage-istanbul-reporter'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    coverageIstanbulReporter: {
+      dir: require('path').join(__dirname, '../../../coverage/vcd/sdk'),
+      reports: ['html', 'lcovonly', 'text-summary'],
+      fixWebpackSourcePaths: true
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: false,
+    browsers: ['ChromeHeadless'],
+    singleRun: true
+  });
+};

--- a/typescript/api-client/projects/vcd/sdk/tsconfig.spec.json
+++ b/typescript/api-client/projects/vcd/sdk/tsconfig.spec.json
@@ -5,7 +5,8 @@
     "types": [
       "jasmine",
       "node"
-    ]
+    ],
+    "skipLibCheck": true
   },
   "files": [
     "src/test.ts"


### PR DESCRIPTION
This change introduces a new YAML to define the build process for
Typescript projects. This is intended to be a replacement for Travis
integration.

The idea is to run this action on all pull requests and pushes to master
that contain Typescript changes. A future revision will add publishing
capabilities to this action.

A CI-specific karma configuration was added to use a headless
environment and to exit upon completion. This allows the existing `ng
test` to work in an ongoing way for local development.

Testing done:
- Ran `npm test` locally, verified test execution using Chrome
- Ran `npm run test-ci` locally, verified test execution and completion
using headless Chrome.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>