### PR TITLE
[VACE-2650] Remove the polyfills from @vcd/plugin-builders ng add schema

### DIFF
--- a/typescript/api-client/projects/vcd/plugin-builders/src/lib/schematics/ng-add/index.ts
+++ b/typescript/api-client/projects/vcd/plugin-builders/src/lib/schematics/ng-add/index.ts
@@ -33,7 +33,6 @@ function updateAngularJson(options: Schema): Rule {
         "outputPath": "dist/",
         "index": "src/index.html",
         "main": "src/<CREATE_EMPTY_FILE>.ts",
-        "polyfills": "src/polyfills.ts",
         "tsConfig": "src/tsconfig.app.json",
         "assets": [
           { "glob": "**/*", "input": "./src/path/to/your/assets/folder", "output": "/" }


### PR DESCRIPTION
Remove polyfills from the ng add.

Testing done:
- Verify plugin builder still works and there are no polyfills