### PR TITLE
[VACE-2595] Fix Customize Portal UI Plugin

### DIFF
--- a/typescript/api-client/projects/vcd/sdk/src/client/vcd.api.client.spec.ts
+++ b/typescript/api-client/projects/vcd/sdk/src/client/vcd.api.client.spec.ts
@@ -235,7 +235,7 @@ describe('API client pre-request validation', () => {
         };
 
         const mockResult: QueryResultRecordsType = {page: 1, total: 25, record: []};
-        apiClient.query(Query.Builder.ofType('test')).subscribe(result => {
+        apiClient.query(Query.Builder.ofType('test')).subscribe((result: QueryResultRecordsType) => {
             expect(apiClient.version).toBe(VcdApiClient.CANDIDATE_VERSIONS[0]);
             expect(result.total).toBe(mockResult.total);
         });


### PR DESCRIPTION
Improve request heaaders interceptor in order to
provie the links, coming from the headers, in the object body.

Testing Done:
- Verify customize portal plugin is able, to receive the header links,
in the object's body.