### PR TITLE
Force npm publish to make a public package.

### DIFF
--- a/.github/workflows/ci-angular-api-client.yml
+++ b/.github/workflows/ci-angular-api-client.yml
@@ -10,7 +10,7 @@ on:
 
   pull_request:
     branches:
-    - angular
+    - angular-main
     paths:
     - 'api-client/**'
 

--- a/.github/workflows/publish-angular-api-client.yml
+++ b/.github/workflows/publish-angular-api-client.yml
@@ -25,7 +25,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build:${{ matrix.packages }} --if-present
-      - run: npm publish dist/vcd/${{ matrix.packages }} --dry-run
+      - run: npm publish dist/vcd/${{ matrix.packages }} --dry-run --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
   publish-npm-packages:
@@ -45,6 +45,6 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build:${{ matrix.packages }} --if-present
-      - run: npm publish dist/vcd/${{ matrix.packages }}
+      - run: npm publish dist/vcd/${{ matrix.packages }} --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
We don't want a private package, we don't pay for private packages. The
Github action defaults to a private access which fails. This change
forces public access, and fixes a branch matching pattern in
the CI action.

Signed-off-by: Jeff Moroski <jmoroski@vmware.com>