### PR TITLE
[VACE-2733] [@vcd/schematics] Automate Building Process

### DIFF
--- a/packages/angular/projects/vcd/plugin-builders/src/lib/schematics/ng-add/index.d.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/schematics/ng-add/index.d.ts
@@ -1,3 +1,5 @@
 import { Rule } from '@angular-devkit/schematics';
 import { Schema } from './schema';
 export declare function ngAdd(options: Schema): Rule;
+export declare function updateAngularJson(options: Schema): Rule;
+export declare function parsePluginName(name: string): string;

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/schematics/ng-add/schema.d.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/schematics/ng-add/schema.d.ts
@@ -1,3 +1,7 @@
 export interface Schema {
     projectName: string;
+    pluginName: string;
+    pluginMainModuleName: string;
+    pluginMainFolderPath: string;
+    pluginPublicFolderPath: string;
 }

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/schematics/ng-add/schema.json
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/schematics/ng-add/schema.json
@@ -5,6 +5,21 @@
             "type": "string",
             "default": "cloud-director-container",
             "x-prompt": "What is the name of your project?"
+        },
+        "pluginName": {
+            "type": "string",
+            "default": "my-new-plugin",
+            "x-prompt": "What is your plugin main folder name?"
+        },
+        "pluginMainFolderPath": {
+            "type": "string",
+            "default": "src/plugins/my-new-plugin/src/main/my-new-plugin.ts#MyNewPluginModule",
+            "x-prompt": "What is your plugin main folder path?"
+        },
+        "pluginPublicFolderPath": {
+            "type": "string",
+            "default": "src/plugins/my-new-plugin/src/public",
+            "x-prompt": "What is your plugin public folder path?"
         }
     }
 }

--- a/packages/angular/projects/vcd/schematics/src/schematics/plugin-seed/index.d.ts
+++ b/packages/angular/projects/vcd/schematics/src/schematics/plugin-seed/index.d.ts
@@ -1,3 +1,17 @@
-import { Rule } from '@angular-devkit/schematics';
+import { Rule, SchematicContext, FileEntry } from '@angular-devkit/schematics';
 import { Schema } from "./schema";
+import { SourceFile } from "@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript";
+import { InsertChange } from "@schematics/angular/utility/change";
 export declare function pluginSeed(options: Schema): Rule;
+export declare function createDirectoryAndFiles(options: Schema): Rule;
+export declare function updateAngularJson(options: Schema): Rule;
+export declare function updatePluginRegistrations(options: Schema): Rule;
+export declare function addNewPlugin(options: Schema, pluginConfig: SourceFile): InsertChange;
+export declare function installPluginBuilders(options: Schema): Rule;
+export declare function triggerInstallTask(packageJsonRaw: FileEntry | null, options: Schema, context: SchematicContext): import("@angular-devkit/schematics").TaskId | undefined;
+export declare function isVulcan(version: string): boolean;
+export declare function isWellingtonOrXendi(version: string): boolean;
+export declare function getUIPluginMainFolderPath(pluginName: string): string;
+export declare function getUIPluginPublicFolderPath(pluginName: string): string;
+export declare function dasherizeModuleFileName(moduleName: string): string;
+export declare function classifyModulName(moduleName: string): string;

--- a/packages/angular/projects/vcd/schematics/src/schematics/plugin-seed/schema.d.ts
+++ b/packages/angular/projects/vcd/schematics/src/schematics/plugin-seed/schema.d.ts
@@ -3,4 +3,5 @@ export interface Schema {
     vcdVersion: string;
     module: string;
     vendor: string;
+    pluginBuildersVersion: string;
 }

--- a/packages/angular/projects/vcd/schematics/src/schematics/plugin-seed/schema.json
+++ b/packages/angular/projects/vcd/schematics/src/schematics/plugin-seed/schema.json
@@ -31,6 +31,13 @@
             "type": "string",
             "minLength": 1,
             "x-prompt": "What is the name of the plugin vendor?"
+        },
+        "pluginBuildersVersion": {
+            "description": "Version of @vcd/plugin-builders",
+            "type": "string",
+            "minLength": 5,
+            "default": "0.12.0",
+            "x-prompt": "What plugin builders version you want to ues?"
         }
     },
     "required": [


### PR DESCRIPTION
Include @vcd/plugin-builders installation in the plugin seed
to reduce the stepps needed to bring the things up and running.

Testing Done:
- Verify when the user name comntains spaces they are converted to "-"
- Verify plugin builders are installed on plugin seed and not if the package
is already installed, i.e it's in the package json.
- Verify if the version of the builders is different then this specified in
the schematis options, the version specifeid, will be installed and the old
one will be overrided.
- Verify the standalone plugin builders package works with the new
ng add schema
- Verify on each run individual plugin builder config is generated

Signed-off-by: Nikola Vladimirov Iliev <nvladimirovi@vmware.com>