### PR TITLE
Allow exporting non defined entity types and interfaces

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vcd/ext-compiler",
   "description": "VMware Cloud Director Extension Compiler",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "author": "mslavov@vmware.com",
   "dependencies": {
     "glob": "^7.1.3",
@@ -20,8 +20,7 @@
   "license": "MIT",
   "main": "lib/index.js",
   "scripts": {
-    "build": "tsc",
-    "setup-dev": "npm link"
+    "build": "tsc"
   },
   "types": "lib/index.d.ts"
 }

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./Compiler"
+export * from "./model/AccessControl"

--- a/packages/compiler/src/model/AccessControl.ts
+++ b/packages/compiler/src/model/AccessControl.ts
@@ -1,0 +1,9 @@
+export function AccessControl(value: string) {
+    return function (
+        target: any,
+        propertyKey: string,
+        descriptor: PropertyDescriptor
+    ) {
+        //does nothing
+    };
+}

--- a/packages/compiler/src/visitors/ClassVisitor.ts
+++ b/packages/compiler/src/visitors/ClassVisitor.ts
@@ -3,7 +3,10 @@ import VisitorContext from '../VisitorContext';
 import TypeVisitor from './TypeVisitor';
 import InterfaceVisitor from './InterfaceVisitor';
 
+const TAGS: string[] = ["definedEntityType", "definedEntityInterface"];
+
 export default class ClassVisitor {
+
 
     constructor(private context: VisitorContext) { }
 
@@ -14,8 +17,14 @@ export default class ClassVisitor {
         );
     }
 
+    private isExtensibilityType(node: ts.Node): boolean {
+        return ts.getJSDocTags(node).some(jsDocTag => {
+            return TAGS.indexOf(jsDocTag.tagName ? jsDocTag.tagName.escapedText.toString() : "") > -1
+        })
+    }
+
     visit(node: ts.Node) {
-        if (!this.isNodeExported(node as ts.Declaration)) {
+        if (!this.isNodeExported(node as ts.Declaration) || !this.isExtensibilityType(node)) {
             return;
         }
         if (ts.isClassDeclaration(node) && node.name) {


### PR DESCRIPTION
 - Updated the compiler to look for explict annotations to compile classes and interfaces
 - Extract the AccessControl annotation from the Autoscale code and expose it through the compiler

Testing Done:
Locally by splitting the Autoscale ScaleGroup class
Signed-off-by: Milko Slavov <mslavov@vmware.com>