### PR TITLE
Types compile and deploy improvements

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vcd/ext-cli",
   "description": "CLI tool for working with Cloud Director extensions",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "mslavov@vmware.com",
   "bin": {
     "vcd-ext": "./bin/run"
@@ -10,7 +10,7 @@
     "@oclif/command": "^1.5.19",
     "@oclif/config": "^1.13.3",
     "@oclif/plugin-help": "^2.2.1",
-    "@vcd/ext-compiler": "0.0.1",
+    "@vcd/ext-compiler": "0.0.2",
     "@vcd/node-client": "0.0.2",
     "adm-zip": "^0.4.16",
     "camelcase": "^6.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vcd/ext-cli",
   "description": "CLI tool for working with Cloud Director extensions",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": "mslavov@vmware.com",
   "bin": {
     "vcd-ext": "./bin/run"

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -14,6 +14,7 @@ export default class Build extends Command {
 
     static flags = {
         help: flags.help({ char: 'h' }),
+        additionalProperties: flags.boolean({ required: false })
     }
 
     async run() {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -22,6 +22,7 @@ export default class Deploy extends Command {
     static flags = {
         help: flags.help({ char: 'h' }),
         force: flags.boolean({ char: 'f', default: false }),
+        only: flags.string({ required: false, default: "" })
     }
 
     static args = [{ name: 'name', required: false }]
@@ -42,10 +43,11 @@ export default class Deploy extends Command {
         }
         this.debug(`Loaded CARE package root: ${carePackage.packageRoot}`)
         this.debug(`Elements: ${JSON.stringify(carePackage.elements, null, 2)}`)
+        const only = flags.only ? flags.only.split(",") : null;
         try {
             const apiConfig = CloudDirectorConfig.fromDefault()
             this.debug(`Creating from default config ${apiConfig}`)
-            return await new Deployer(apiConfig, flags.force).deploy(carePackage)
+            return await new Deployer(apiConfig, flags.force, only).deploy(carePackage)
         } catch (e) {
             this.debug('Error deploying', e)
             throw e

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -43,7 +43,7 @@ export default class Deploy extends Command {
         }
         this.debug(`Loaded CARE package root: ${carePackage.packageRoot}`)
         this.debug(`Elements: ${JSON.stringify(carePackage.elements, null, 2)}`)
-        const only = flags.only ? flags.only.split(",") : null;
+        const only = flags.only ? flags.only.split(",").map(p => p.trim()) : null;
         try {
             const apiConfig = CloudDirectorConfig.fromDefault()
             this.debug(`Creating from default config ${apiConfig}`)

--- a/packages/cli/src/deployer/deployer.ts
+++ b/packages/cli/src/deployer/deployer.ts
@@ -10,9 +10,9 @@ import { UIPluginComponentDeployer } from './uiPlugin';
 const log = debug('vcd:ext:deployer')
 
 export class Deployer {
-    objectDeployers: {[componentType: string]: ComponentDeployer}
+    objectDeployers: { [componentType: string]: ComponentDeployer }
 
-    constructor(private apiConfig: CloudDirectorConfig, private force: boolean) {
+    constructor(private apiConfig: CloudDirectorConfig, private force: boolean, private only: string[] | null) {
         this.objectDeployers = {
             types: new TypesComponentDeployer(this.apiConfig),
             uiPlugin: new UIPluginComponentDeployer(this.apiConfig)
@@ -25,16 +25,22 @@ export class Deployer {
             // application specific logging, throwing an error, or other logic here
         });
 
+        log(`Deploying with args force: ${this.force}; only: ${this.only}`)
         if (this.force) {
             log("Force option set to true. Cleaning up...")
-            await carePackage.elements.reverse().reduce(async (prevPromise, ele) => {
-                await prevPromise;
-                return this.objectDeployers[ele.type].clean(path.join(carePackage.packageRoot, ele.location)).catch(e => log(e))
-            }, Promise.resolve()).catch(e => log(e))
+            await carePackage.elements
+                .filter(ele => !this.only || this.only.indexOf(ele.location.split(path.sep)[1]) > -1)
+                .reverse()
+                .reduce(async (prevPromise, ele) => {
+                    await prevPromise;
+                    return this.objectDeployers[ele.type].clean(path.join(carePackage.packageRoot, ele.location)).catch(e => log(e))
+                }, Promise.resolve()).catch(e => log(e))
         }
-        return (carePackage.elements as Element[]).reduce(async (prevPromise: Promise<any>, ele: Element) => {
-            await prevPromise;
-            return this.objectDeployers[ele.type].deploy(path.join(carePackage.packageRoot, ele.location)).catch(e => log(e))
-        }, Promise.resolve()).catch(e => log(e))
+        return (carePackage.elements as Element[])
+            .filter(ele => !this.only || this.only.indexOf(ele.location.split(path.sep)[1]) > -1)
+            .reduce(async (prevPromise: Promise<any>, ele: Element) => {
+                await prevPromise;
+                return this.objectDeployers[ele.type].deploy(path.join(carePackage.packageRoot, ele.location)).catch(e => log(e))
+            }, Promise.resolve()).catch(e => log(e))
     }
 }

--- a/packages/cli/src/deployer/types/interfaces.ts
+++ b/packages/cli/src/deployer/types/interfaces.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import * as debug from 'debug';
 import { CloudDirectorConfig, DefinedInterfaceApi, DefinedInterfaceBehaviorsApi } from '@vcd/node-client';
 import { BaseTypesDeployer } from './base';
@@ -72,7 +73,8 @@ export class InterfacesDeployer extends BaseTypesDeployer {
         }))
     }
     fileFilter(file: string): boolean {
-        return file.indexOf('interfaces/') > -1
+        return file.split(path.sep).reverse().find(pathElement => 
+            pathElement === "types" || pathElement === "interfaces") === 'interfaces'
     }
 
     async clean(location: string) {

--- a/packages/cli/src/deployer/types/types.ts
+++ b/packages/cli/src/deployer/types/types.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import * as debug from 'debug';
 import { CloudDirectorConfig, DefinedEntityTypeApi, DefinedInterfaceBehaviorsApi, BehaviorAccess, BehaviorAccesses } from '@vcd/node-client';
 import { BaseTypesDeployer } from './base';
@@ -51,7 +52,8 @@ export class TypesDeployer extends BaseTypesDeployer {
         return Promise.resolve();
     }
     fileFilter(file: string): boolean {
-        return file.indexOf('types/') > -1
+        return file.split(path.sep).reverse().find(pathElement => 
+            pathElement === "types" || pathElement === "interfaces") === 'types'
     }
 
     async clean(location: string) {

--- a/packages/cli/src/generators/new.ts
+++ b/packages/cli/src/generators/new.ts
@@ -92,6 +92,7 @@ export default class New extends Generator {
         this.answers.components.forEach((component: string) => {
             this.components[component] = {
                 name: `${this.name}-${this.answers[`${component}Name`]}`,
+                componentName: this.answers[`${component}Name`],
                 version: this.answers.version,
                 description: this.description,
                 vendor: this.answers.vendor,

--- a/packages/cli/templates/types/package.json
+++ b/packages/cli/templates/types/package.json
@@ -9,13 +9,13 @@
   ],
   "scripts": {
     "build": "vcd-ext build",
-    "deploy": "vcd-ext deploy --only=<%- components.types.name %>"
+    "deploy": "vcd-ext deploy --only=<%- components.types.componentName %>"
   },
   "author": "vCloud Directory Extensions CLI",
   "license": "<%- answers.license %>",
   "devDependencies": {
-    "@vcd/ext-cli": "0.0.7",
-    "typescript": "~3.6.3"
+    "@vcd/ext-cli": "0.0.8",
+    "typescript": "~4.0.3"
   },
   "dependencies": {},
   "files": [

--- a/packages/cli/templates/types/package.json
+++ b/packages/cli/templates/types/package.json
@@ -9,12 +9,12 @@
   ],
   "scripts": {
     "build": "vcd-ext build",
-    "deploy": "vcd-ext deploy"
+    "deploy": "vcd-ext deploy --only=<%- components.types.name %>"
   },
   "author": "vCloud Directory Extensions CLI",
   "license": "<%- answers.license %>",
   "devDependencies": {
-    "@vcd/ext-cli": "0.0.6",
+    "@vcd/ext-cli": "0.0.7",
     "typescript": "~3.6.3"
   },
   "dependencies": {},

--- a/packages/cli/templates/uiPlugin/package.json
+++ b/packages/cli/templates/uiPlugin/package.json
@@ -7,7 +7,8 @@
     "lint": "ng lint",
     "build": "ng build",
     "serve": "vcd-ext serve",
-    "ng:serve": "ng serve"
+    "ng:serve": "ng serve",
+    "deploy": "vcd-ext deploy --only=<%- components.types.name %>"
   },
   "license": "<%- answers.license %>",
   "dependencies": {
@@ -49,7 +50,7 @@
     "@types/jasmine": "2.8.8",
     "@types/jasminewd2": "2.0.3",
     "@types/node": "8.9.4",
-    "@vcd/ext-cli": "0.0.5",
+    "@vcd/ext-cli": "0.0.7",
     "@vcd/plugin-builders": "0.12.1",
     "@vcd/ui-emulator": "0.0.5",
     "codelyzer": "4.3.0",

--- a/packages/cli/templates/uiPlugin/package.json
+++ b/packages/cli/templates/uiPlugin/package.json
@@ -8,7 +8,7 @@
     "build": "ng build",
     "serve": "vcd-ext serve",
     "ng:serve": "ng serve",
-    "deploy": "vcd-ext deploy --only=<%- components.types.name %>"
+    "deploy": "vcd-ext deploy --only=<%- components.uiPlugin.componentName %>"
   },
   "license": "<%- answers.license %>",
   "dependencies": {
@@ -50,7 +50,7 @@
     "@types/jasmine": "2.8.8",
     "@types/jasminewd2": "2.0.3",
     "@types/node": "8.9.4",
-    "@vcd/ext-cli": "0.0.7",
+    "@vcd/ext-cli": "0.0.8",
     "@vcd/plugin-builders": "0.12.1",
     "@vcd/ui-emulator": "0.0.5",
     "codelyzer": "4.3.0",

--- a/packages/compiler/package-lock.json
+++ b/packages/compiler/package-lock.json
@@ -4,6 +4,12 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@types/debug": {
+			"version": "4.1.5",
+			"resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@types/debug/-/debug-4.1.5.tgz",
+			"integrity": "sha1-sU76iFK3do2JiQZhPCP2iHE+As0=",
+			"dev": true
+		},
 		"@types/events": {
 			"version": "3.0.0",
 			"resolved": "http://0.0.0.0:4873/@types%2fevents/-/events-3.0.0.tgz",
@@ -65,20 +71,33 @@
 			"dev": true
 		},
 		"commander": {
-			"version": "3.0.2",
-			"resolved": "http://0.0.0.0:4873/commander/-/commander-3.0.2.tgz",
-			"integrity": "sha1-aDfD+2d62ZM9HPukLdFNURfWs54="
+			"version": "6.1.0",
+			"resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/commander/-/commander-6.1.0.tgz",
+			"integrity": "sha1-+Ncit4EDFBAGtm9Me6HpcxW6dbw="
 		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "http://0.0.0.0:4873/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
+		"debug": {
+			"version": "4.2.0",
+			"resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-4.2.0.tgz",
+			"integrity": "sha1-fxUPk5IOlMWPVXTC/QGjEQ7/5/E=",
+			"requires": {
+				"ms": "2.1.2"
+			}
+		},
 		"diff": {
 			"version": "4.0.2",
 			"resolved": "http://0.0.0.0:4873/diff/-/diff-4.0.2.tgz",
 			"integrity": "sha1-YPOuy4nV+uUgwRqhnvwruYKq3n0=",
 			"dev": true
+		},
+		"fast-json-stable-stringify": {
+			"version": "2.1.0",
+			"resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM="
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
@@ -139,6 +158,11 @@
 				"brace-expansion": "^1.1.7"
 			}
 		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "http://0.0.0.0:4873/once/-/once-1.4.0.tgz",
@@ -169,15 +193,23 @@
 			}
 		},
 		"ts-json-schema-generator": {
-			"version": "0.53.0",
-			"resolved": "http://0.0.0.0:4873/ts-json-schema-generator/-/ts-json-schema-generator-0.53.0.tgz",
-			"integrity": "sha1-RUjfyh0/nMouwkOM2myl0HE9Xg0=",
+			"version": "0.76.1",
+			"resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/ts-json-schema-generator/-/ts-json-schema-generator-0.76.1.tgz",
+			"integrity": "sha1-BMi4IC63RGB2MNyBCvCV9iyM+EA=",
 			"requires": {
-				"@types/json-schema": "^7.0.3",
-				"commander": "~3.0.1",
-				"glob": "~7.1.4",
+				"@types/json-schema": "^7.0.6",
+				"commander": "^6.1.0",
+				"fast-json-stable-stringify": "^2.1.0",
+				"glob": "^7.1.6",
 				"json-stable-stringify": "^1.0.1",
-				"typescript": "~3.6.3"
+				"typescript": "~4.0.3"
+			},
+			"dependencies": {
+				"typescript": {
+					"version": "4.0.3",
+					"resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/typescript/-/typescript-4.0.3.tgz",
+					"integrity": "sha1-FTu9Ro7wdyXB35x36LRT+NNqu6U="
+				}
 			}
 		},
 		"ts-node": {
@@ -199,9 +231,10 @@
 			"integrity": "sha1-yIHhPMcBWJTtkUhi0nZDb6mkcEM="
 		},
 		"typescript": {
-			"version": "3.6.5",
-			"resolved": "http://0.0.0.0:4873/typescript/-/typescript-3.6.5.tgz",
-			"integrity": "sha1-2uIBFKe0/0vWQtucjGmfKVPou9s="
+			"version": "4.0.3",
+			"resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/typescript/-/typescript-4.0.3.tgz",
+			"integrity": "sha1-FTu9Ro7wdyXB35x36LRT+NNqu6U=",
+			"dev": true
 		},
 		"wrappy": {
 			"version": "1.0.2",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,18 +1,20 @@
 {
   "name": "@vcd/ext-compiler",
   "description": "VMware Cloud Director Extension Compiler",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "mslavov@vmware.com",
   "dependencies": {
     "glob": "^7.1.3",
-    "ts-json-schema-generator": "^0.53.0",
+    "ts-json-schema-generator": "^0.76.1",
+    "debug": "^4.1.1",
     "tslib": "^1.10.0"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.5",
     "@types/glob": "^5.0.36",
     "@types/node": "^10.14.20",
     "ts-node": "^8.4.1",
-    "typescript": "~3.6.3"
+    "typescript": "~4.0.3"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/packages/compiler/src/Compiler.ts
+++ b/packages/compiler/src/Compiler.ts
@@ -5,6 +5,13 @@ import { sync as globSync } from "glob";
 import ClassVisitor from './visitors/ClassVisitor';
 import VisitorContext from './VisitorContext';
 
+const SCHEMA_GENERATOR_PROPERTIES = [
+    "sortProps",
+    "strictTuples",
+    "skipTypeCheck",
+    "encodeRefs",
+    "additionalProperties"
+]
 
 export class Compiler {
     rootDir: string;
@@ -14,6 +21,7 @@ export class Compiler {
     output: any[] = [];
     config: any;
     vendorPrefix: string;
+    schemaGeneratorConfig: any = {}
 
     constructor(files: string[], flags: any) {
         this.config = flags;
@@ -22,6 +30,13 @@ export class Compiler {
         this.fileNames = files && files.length
             ? files.map(file => path.resolve(this.rootDir, file))
             : globSync(path.resolve(this.rootDir, 'src', "**/*.ts"));
+        
+        this.schemaGeneratorConfig = Object.keys(flags)
+            .filter(key => SCHEMA_GENERATOR_PROPERTIES.indexOf(key) > -1)
+            .reduce((acc: any, key: string) => {
+                acc[key] = flags[key]
+                return acc
+            }, this.schemaGeneratorConfig)
     }
 
     private logDiagnostics(diagnostics: readonly ts.Diagnostic[]): void {
@@ -110,7 +125,8 @@ export class Compiler {
             name,
             pjson.nssPrefix,
             pjson.vendor,
-            pjson.version
+            pjson.version,
+            this.schemaGeneratorConfig
         );
         const visitor = new ClassVisitor(context);
 

--- a/packages/compiler/src/VisitorContext.ts
+++ b/packages/compiler/src/VisitorContext.ts
@@ -1,5 +1,8 @@
 import * as ts from "typescript";
 import * as sg from 'ts-json-schema-generator';
+import debug from 'debug';
+
+const log = debug('vcd:ext:compiler:visitorcontext')
 
 export default class VisitorContext {
     output = {
@@ -13,7 +16,8 @@ export default class VisitorContext {
                 public name: string,
                 public nssPrefix: string,
                 public vendor: string,
-                public version: string){
+                public version: string,
+                private schemaGeneratorConfig: sg.Config = {}){
         this.typeChecker = program.getTypeChecker();
     }
 
@@ -23,10 +27,12 @@ export default class VisitorContext {
                 topRef: true,
                 expose: 'export',
                 jsDoc: 'extended',
-                extraJsonTags: []
+                extraTags: [],
+                ...this.schemaGeneratorConfig
             }
+            log("Creating schema generator with config", config);
             const parser = sg.createParser(this.program, config);
-            this.sg = new sg.SchemaGenerator(this.program, parser, sg.createFormatter());
+            this.sg = new sg.SchemaGenerator(this.program, parser, sg.createFormatter(config));
         }
         return this.sg;
     }

--- a/packages/compiler/tsconfig.json
+++ b/packages/compiler/tsconfig.json
@@ -7,7 +7,8 @@
     "outDir": "lib",
     "rootDir": "src",
     "strict": false,
-    "target": "es6"
+    "target": "es6",
+    "esModuleInterop": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
 - Add schema generator config as optional to the compiler
 - Expose the `--additionalProperties` flag to switch between allowing and disallowing additionalProperties
 - Updated the deploy command to support `--only` flag to allow only a subcomponent to be deployed
 - Fixed the filter function in `types` and `interfaces` processing
 - Added the missing `index.ts` file in the `src` folder of the `types` template

Testing Done:
Locally build and deployed the autoscale solution

Signed-off-by: Milko Slavov <mslavov@vmware.com>