### PR TITLE
[VACE-2623] Add support for UI Plugins Incremental Loading in the @vcd/plugin-builders

### DIFF
--- a/packages/angular/package-lock.json
+++ b/packages/angular/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "api-client",
+  "name": "@vcd/angular-sdk",
   "version": "0.12.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -434,8 +434,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -456,14 +455,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -478,20 +475,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -608,8 +602,7 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -621,7 +614,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -636,7 +628,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -644,14 +635,12 @@
             "minimist": {
               "version": "1.2.5",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -670,7 +659,6 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -732,8 +720,7 @@
             "npm-normalize-package-bin": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -761,8 +748,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -774,7 +760,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -852,8 +837,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -889,7 +873,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -909,7 +892,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -953,14 +935,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -7550,8 +7530,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -7572,14 +7551,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -7594,20 +7571,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -7724,8 +7698,7 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -7737,7 +7710,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -7752,7 +7724,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -7760,14 +7731,12 @@
             "minimist": {
               "version": "1.2.5",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -7786,7 +7755,6 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -7848,8 +7816,7 @@
             "npm-normalize-package-bin": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -7877,8 +7844,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7890,7 +7856,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7968,8 +7933,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -8005,7 +7969,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -8025,7 +7988,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -8069,14 +8031,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -13055,8 +13015,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -13077,14 +13036,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -13099,20 +13056,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -13229,8 +13183,7 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -13242,7 +13195,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -13257,7 +13209,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -13265,14 +13216,12 @@
             "minimist": {
               "version": "1.2.5",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -13291,7 +13240,6 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -13353,8 +13301,7 @@
             "npm-normalize-package-bin": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -13382,8 +13329,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -13395,7 +13341,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -13473,8 +13418,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -13510,7 +13454,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -13530,7 +13473,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -13574,14 +13516,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -13890,8 +13830,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -13912,14 +13851,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -13934,20 +13871,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -14064,8 +13998,7 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -14077,7 +14010,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -14092,7 +14024,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -14100,14 +14031,12 @@
             "minimist": {
               "version": "1.2.5",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -14126,7 +14055,6 @@
               "version": "0.5.3",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -14188,8 +14116,7 @@
             "npm-normalize-package-bin": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "npm-packlist": {
               "version": "1.4.8",
@@ -14217,8 +14144,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -14230,7 +14156,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -14308,8 +14233,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -14345,7 +14269,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -14365,7 +14288,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -14409,14 +14331,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -18,7 +18,7 @@
     "plugin-builders:build": "tsc --build ./projects/vcd/plugin-builders/tsconfig.json && npm run plugin-builders:cpy:schema && npm run plugin-builders:cpy:builders && npm run plugin-builders:build:schematics && npm run plugin-builders:copy:schemas",
     "plugin-builders:cpy:schema": "cp ./projects/vcd/plugin-builders/src/lib/base/schema.json ./dist/vcd/plugin-builders",
     "plugin-builders:cpy:builders": "cp ./projects/vcd/plugin-builders/builders.json ./dist/vcd/plugin-builders",
-    "plugin-builders:install:dev:dep": "cd ./projects/vcd/plugin-builders && npm i && cd ../../",
+    "plugin-builders:install:dev:dep": "cd ./projects/vcd/plugin-builders && npm i && cd ./src/lib/new && npm i",
 
     "schematics:build": "tsc -p ./projects/vcd/schematics/tsconfig.json",
     "schematics:build:prod": "npm run schematics:build && npm run schematics:copy:schemas",

--- a/packages/angular/projects/vcd/plugin-builders/README.md
+++ b/packages/angular/projects/vcd/plugin-builders/README.md
@@ -6,55 +6,55 @@ The @vcd/plugin-builders package contains an angular builder which you can use t
 
 ## How to use it?
 
-> **Note:** This version of the plugin builder is supported by angular 7.3.8^.
+> **Note:** This version of the plugin builder is supported by angular 6.x.x.
 
 1. Download the package
-```bash
-npm i @vcd/plugin-builders
-```
-2. In your `angular.json` file
-```json
-{
-	"$schema": "./node_modules/@angular/cli/lib/config/schema.json",
-	...
-	"projects": {
-		"your-project": {
-			...
-			"architect": {
-				# Note that the only thing which this builder expects is the modulePath, all other options are up to you.
-				"your-plugin-builder-config": {
-					"builder": "@vcd/plugin-builders:plugin-builder",
-					"options": {
-					"modulePath": "./path/to/your/module",
-					"outputPath": "./path/to/your/dist/folder",
-					# The index is not really neaded but have to stay there because of the angular validation.
-					"index": "src/index.html",
-					"main": "src/main.ts",
-					"tsConfig": "src/tsconfig.app.json",
-					"assets": [
-						# Include the paths to your plugin manifest and i18n json files here.
-					],
-					"optimization": true,
-					"outputHashing": "none",
-					"sourceMap": false,
-					"extractCss": true,
-					"namedChunks": false,
-					"aot": true,
-					"extractLicenses": true,
-					"vendorChunk": false,
-					"buildOptimizer": true
-					}
-				}
-			}
-		}
-		...
-	}
-}
-```
+    ```bash
+    npm i @vcd/plugin-builders
+    ```
+2. In your `angular.json` file or you can run `ng add @vcd/plugin-builders --projectName=cloud-director-container`
+    ```json
+    {
+    	"$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+    	...
+    	"projects": {
+    		"your-project": {
+    			...
+    			"architect": {
+    				# Note that the only thing which this builder expects is the modulePath, all other options are up to you.
+    				"your-plugin-builder-config": {
+    					"builder": "@vcd/plugin-builders:plugin-builder",
+    					"options": {
+    					"modulePath": "./path/to/your/module",
+    					"outputPath": "./path/to/your/dist/folder",
+    					# The index is not really neaded but have to stay there because of the angular validation.
+    					"index": "src/index.html",
+    					"main": "src/main.ts",
+    					"tsConfig": "src/tsconfig.app.json",
+    					"assets": [
+    						# Include the paths to your public folder here.
+    					],
+    					"optimization": true,
+    					"outputHashing": "none",
+    					"sourceMap": false,
+    					"extractCss": false,
+    					"namedChunks": false,
+    					"aot": false,
+    					"extractLicenses": true,
+    					"vendorChunk": false,
+    					"buildOptimizer": false
+    					}
+    				}
+    			}
+    		}
+    		...
+    	}
+    }
+    ```
 3. Run the builder through ng cli
-```bash
-ng run your-project:your-plugin-builder-config
-```
+    ```bash
+    ng run your-project:your-plugin-builder-config
+    ```
 
 ## Build
 ```bash
@@ -69,6 +69,29 @@ npm i
 npm run build
 ```
 
+## For UI Plugins with UI Runtime Dependecy Management allowed
+1. Download the package
+    ```bash
+    npm i @vcd/plugin-builders
+    ```
+2. Run `ng add @vcd/plugin-builders --projectName=cloud-director-container`
+3. Open your `angular.json`
+4. Find the config
+5. If you want to split your plugin and its dependencies into chunks you have to add `librariesConfig` in your plugin builder options object. Each library has name, version, scope and locaton (location is automatically populated but if you want you can specify it on your own). The name and the version are standard as in your package.json file, scope on other hand tells to vCloud Director Core UI what to do with your dependecies:
+    - External - this dependecy will be provided by the vCloud Director Core UI.
+    - Bundled - your dependecy will be shared with other plugins which use the same version of it. This will reduce the loading time of the product significantly.
+    ```json
+    "options": {
+        "librariesConfig": {
+            "libName": {
+                "version": "x.x.x",
+                "scope": "external or bundled"
+              },
+              ...
+        }
+    }
+6. In the plugin builder's `options` object add `"enableRuntimeDependecyManagement": true` to enable the functionality described above.
+7. In order to make the feature work you've to set the optimization property in your angular.json to false.
 ## Contributing
 
 The vcd-ext-samples project team welcomes contributions from the community. Before you start working with vcd-ext-samples, please read our [Developer Certificate of Origin](https://cla.vmware.com/dco). All contributions to this repository must be signed as described on that page. Your signature certifies that you wrote the patch or have the right to pass it on as an open-source patch. For more detailed information, refer to [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/packages/angular/projects/vcd/plugin-builders/builders.json
+++ b/packages/angular/projects/vcd/plugin-builders/builders.json
@@ -1,7 +1,7 @@
 {
     "builders": {
         "plugin-builder": {
-            "class": "./index.js",
+            "class": "./base/index.js",
             "schema": "./schema.json",
             "description": "Build vCloud Director UI Plugin for version 9.1 - 10.0"
         }

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/base/schema.json
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/base/schema.json
@@ -1,10 +1,29 @@
 {
     "type": "object",
     "properties": {
+        "enableRuntimeDependecyManagement": {
+            "type": "boolean",
+            "description": "Based on the this some features will be turned on or off.",
+            "default": ""
+        },
         "modulePath": {
             "type": "string",
             "description": "Path to module like loadChildren",
             "default": ""
+        },
+        "externalLibs": {
+            "type": "array",
+            "description": "The list of the libraries which will be provided by the vCloud Director Core UI. The list of strings will be converted to Regular Expression, defined by the JS. (The input supports strings only)",
+            "default": []
+        },
+        "librariesConfig": {
+            "type": "object",
+            "description": "In this section you can define your libs name, version and scope (provided - Provided by the UI, runtime - If the library is bootstrapped already from somebody else use it, else request and bootstrap your library and also make it avaiable for other plugins, self - Use your specific version no matter what)."
+        },
+        "ignoreDefaultExternals": {
+            "type": "boolean",
+            "description": "By setting this value to 'true' you will disable the default list of external libraries, and you have to provide your own in 'externalLibs' list.",
+            "default": false
         }
     }
 }

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/concat.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/concat.ts
@@ -1,0 +1,65 @@
+import { RawSource } from "webpack-sources";
+
+export interface ConcatWebpackPluginOptions {
+    concat: {
+        inputs: string[],
+        output: string,
+    }[];
+}
+
+/**
+ * Webpack Plugin for Concatenation
+ */
+export class ConcatWebpackPlugin {
+    private options: ConcatWebpackPluginOptions;
+
+    constructor(options: ConcatWebpackPluginOptions) {
+        this.options = options;
+    }
+
+    /**
+     * Called by Webpack
+     * @param compiler Webpack compiler
+     * see https://webpack.js.org/api/compiler-hooks/ for more detials.
+     */
+    apply(compiler) {
+        // Hook for on emit
+        compiler.hooks.emit.tapAsync('vCloud Director Concat Plugin', (
+            compilation,
+            callback
+        ) => {
+            if (compilation.compiler.isChild()) {
+                callback();
+                return;
+            }
+
+            // Cocnat files
+            this.options.concat
+                .map((obj) => {
+                    // Take sources which has to concatenated
+                    const sourcesToConcat = obj.inputs.map((input) => {
+                        const source = compilation.assets[input].source();
+                        delete compilation.assets[input];
+                        return Buffer.isBuffer(source) ? source : new Buffer(source)
+                    });
+
+                    return {
+                        output: obj.output,
+                        sourcesToConcat
+                    }
+                })
+                .map((asset) => {
+                    return {
+                        output: asset.output,
+                        source: Buffer.concat(asset.sourcesToConcat),
+                    };
+                })
+                .forEach((asset) => {
+                    // Output the result
+                    compilation.assets[asset.output] = new RawSource(asset.source as any);
+                });
+
+            callback();
+        });
+    }
+}

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/interfaces.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/interfaces.ts
@@ -1,0 +1,182 @@
+export interface LibrariesConfig {
+    [libName:string]: {
+        version: string;
+        scope: LibraryConfigScopeTypes,
+        location: string;
+        // In most of the cases your lib is located in node_modules of the current project,
+        // but sometimes you project could become more complex with multiple projeccts inside it,
+        // respectivly with multiple node_modules in each sub project.
+        // The context is used to define in whihc sub project the builder has to search for
+        // your library.
+        context: string;
+    }
+}
+
+export type LibraryConfigScopeTypes = "external" | "bundled" | "isolated";
+export const LibraryConfigScopes = ["external", "bundled", "isolated"];
+
+/**
+ * The contents of a third party extension's manifest.json file.
+ */
+export interface ExtensionManifest {
+    /**
+     * The version of the manifest
+     */
+    manifestVersion: string;
+
+    /**
+     * Unique URN used an ID for the extension.
+     */
+    urn: string;
+
+    /**
+     * Human readable name for the extension.
+     */
+    name: string;
+
+    /**
+     * The minimum supported version of VCD UI.
+     * TODO: Not currently used.
+     */
+    containerVersion: string;
+
+    /**
+     * Versions of VCD that the plugin claims compatibility with.
+     */
+    productVersions: string[];
+
+    /**
+     * The version of the extension.
+     */
+    version: string;
+
+    /**
+     * Scopes that the extension may be used under (e.g. tenant, service-provider).
+     */
+    scope: ExtensionScope[];
+
+    /**
+     * Minimum permissions required for the extension to be loaded.
+     */
+    permissions: string[];
+
+    /**
+     * Human readable description for the extension.
+     */
+    description: string;
+
+    /**
+     * Human readable vendor name for the extension.
+     */
+    vendor: string;
+
+    /**
+     * Human readable license information for the extension.
+     */
+    license: string;
+
+    /**
+     * Support URL for the extension.
+     */
+    link: string;
+
+    /**
+     * The symbol to be imported as an Angular 4 module from the
+     * the extension's AMD bundle.
+     */
+    module: string;
+
+    /**
+     * The base route the extension's routes will be registered under.
+     */
+    route: string;
+
+    /**
+     * Formal extension points.
+     */
+    extensionPoints?: ExtensionPointManifest[];
+
+    /**
+     * Extension locales for the manifest.
+     * Supported by manifest v2.0.0 and higher.
+     */
+    locales: {
+        [key: string]: string
+    };
+
+    externals?: {
+        libs?: {
+            [libName: string]: {
+                version: string;
+                scope: ExtensionLibScope;
+                location: string;
+            };
+        };
+        jsonpFunction?: string;
+    };
+}
+
+export type ExtensionLibScope = "external" | "bundled" | "isolated";
+
+/**
+ * This defines a formal extension point.  An extension point is a declarative way for an extension manifest
+ * to describe how the VCD application behaviour is extended or modified by the extension.
+ */
+export interface ExtensionPointManifest {
+    /**
+     * Universally unique URN that identifies this Extension Point.  It is suggested to preprend the extension's URN.
+     */
+    readonly urn: string;
+
+    /**
+     * The type of Extension Point being defined from a supported list.  This list will increase over time.
+     */
+    readonly type: string;
+
+    /**
+     * The name of the Extension Point, intended for display in extension management interfaces.
+     */
+    readonly name: string;
+
+    /**
+     * An overview of the Extension Point, intended for display in extension management interfaces.
+     */
+    readonly description: string;
+
+    /**
+     * The name of the module which will be registerd in the top-nav-level area.
+     */
+    readonly module?: string;
+
+    /**
+     * The route on which only top level extrension points will be registerd.
+     */
+    readonly route?: string;
+}
+
+/**
+ * Supported extension scopes.
+ */
+export type ExtensionScope = "tenant" | "service-provder";
+
+export interface BasePluginBuilderSchema {
+    enableRuntimeDependecyManagement: boolean;
+  	/**
+	 * A string of the form `path/to/file#exportName`
+		 * that acts as a path to include to bundle.
+	 */
+	modulePath: string;
+	/**
+	 * List of external libraries defined by the user.
+	 */
+	externalLibs: string[];
+	/**
+	 * Will disable the default external libraries,
+	 * allowing the user to define his own thanks to externalLibs property.
+	 */
+	ignoreDefaultExternals: boolean;
+	/**
+	 * List of libraries determining thier version, scope and file name (location). 
+	 */
+	librariesConfig: LibrariesConfig;
+}

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/utilites.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/utilites.ts
@@ -1,0 +1,146 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { LibrariesConfig, LibraryConfigScopeTypes, LibraryConfigScopes, ExtensionManifest, BasePluginBuilderSchema } from "./interfaces";
+
+export const VCD_CUSTOM_LIB_SEPARATOR = ":";
+
+/**
+ * Convert string defined regex to regex object.
+ */
+export function extractExternalRegExps(externalLibs: string[] = []) {
+	return externalLibs.map((libStr) => new RegExp(libStr))
+}
+
+export function takePackageNameFromPath(path: string) {
+	// get the name. E.g. node_modules/packageName/not/this/part.js
+	// or node_modules/packageName
+	const result: string[] = path.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/);
+
+	if (!result.length) {
+		return;
+	}
+
+	let packageName: string = result[1];
+
+	if (packageName.startsWith("@")) {
+		const name = /[\\/]node_modules[\\/](.*?)([\\/])(.*?)([\\/])|$/.exec(path)[0].split("/node_modules/")[1];
+		packageName = name.substr(0, name.length - 1);
+	}
+
+	return packageName;
+}
+
+/**
+ * Search for package json file
+ */
+export function takeChunkPackageJson(chunk: any, defaultBasePath: string, librariesConfig: LibrariesConfig) {
+	const packageName = takePackageNameFromPath(chunk.context as string);
+	const packageJsonPath = path.join(librariesConfig[packageName].context || defaultBasePath, "node_modules", packageName, "package.json");
+
+	return JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+}
+
+/**
+ * This function in combination with webpack optimization.splitChunks.cacheGroups.[funcName]
+ * will split all the vendors in named chunks per library. The name of the chunk will contain
+ * the library name and version.
+ * @param module Node Module
+ * @param defaultBasePath Project Root
+ */
+export function splitVendorsIntoChunks(module: any, defaultBasePath: string, librariesConfig, vendorTracker?: (packageName: string) => any) {
+	const packageJson = takeChunkPackageJson(module, defaultBasePath, librariesConfig);
+
+	let packageJsonName: string = packageJson.name;
+	// This is needed because otherwise webpack will create dir with subdirs
+	if (packageJsonName.includes("/")) {
+		packageJsonName = packageJsonName.replace("/", VCD_CUSTOM_LIB_SEPARATOR);
+	}
+
+	const packageName = `${packageJsonName}@${packageJson.version}`;
+
+	if (vendorTracker) {
+		vendorTracker(packageName);
+	}
+
+	return packageName;
+}
+
+export function processManifestJsonFile(
+	librariesConfig: LibrariesConfig,
+	libsBundles: Map<string, string>,
+	jsonpFunction: string
+) {
+	return function (content, absolutePath) {
+		if (!absolutePath.includes("manifest.json")) {
+			return content;
+		}
+	
+		const manifest: ExtensionManifest = JSON.parse(content.toString("utf-8"));
+		manifest.externals = {};
+		manifest.externals.libs = {};
+		manifest.externals.jsonpFunction = jsonpFunction;
+
+		Object.keys(librariesConfig).forEach((libName) => {
+			const version = librariesConfig[libName].version;
+			const preDefinedLocation = librariesConfig[libName].location;
+			const location = libsBundles.get(`${libName}@${version}`);
+			const scope: LibraryConfigScopeTypes = librariesConfig[libName].scope;
+
+			if (!version || !version.length) {
+				throw Error(`${libName} has incorrect version defined! Current version ${version}`)
+			}
+
+			if (!scope || LibraryConfigScopes.indexOf(scope) === -1) {
+				throw Error(`${libName} with version ${version} has incorrect scope defined! Current scope ${scope}.`)
+			}
+
+			if (!preDefinedLocation && (!location || !location.length)) {
+				throw Error(`${libName} with version ${version} was not found in the list of built vendor bundles. Please make sure you passed the correct lib name and version in your angular.json builder config section.`);
+			}
+
+			manifest.externals.libs[libName] = {
+				version,
+				scope,
+				location: preDefinedLocation || location.replace("/", VCD_CUSTOM_LIB_SEPARATOR),
+			};
+		});
+
+		return Buffer.from(JSON.stringify(manifest, null, 4));
+	}
+}
+
+/**
+ * Filter the node_modules and extract
+ * those which has to be bundled with the plugin.
+ */
+export function filterRuntimeModules(options: BasePluginBuilderSchema) {
+	return function(mod) {
+		if (!mod.context) {
+			return false;
+		}
+	
+		// Only node_modules are needed and these which are defiend in the librariesConfig
+		if (
+			!mod.context.includes('node_modules') ||
+			!Object.keys(options.librariesConfig).some((key) => {
+				return mod.context.includes(key)
+			})
+		) {
+			return false;
+		}
+	
+		return true;
+	};
+}
+
+/**
+ * Name the result bundles after the filtering phase.
+ */
+export function nameVendorFile(config: any, options: BasePluginBuilderSchema, pluginLibsBundles: Map<string, string>) {
+	return function(module) {
+		return splitVendorsIntoChunks(module, config.context, options.librariesConfig, (packageName: string) => {
+			packageName = packageName.replace(VCD_CUSTOM_LIB_SEPARATOR, "/");
+			pluginLibsBundles.set(packageName, `${packageName}.bundle.js`)
+		});
+	};
+}

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/new/index.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/new/index.ts
@@ -1,3 +1,10 @@
+/**
+ * This new version of the builder shims the basics which
+ * has to be covered in future, additinal work is expected.
+ * Most of the functionallity which has to be implemented here is
+ * well described in the base plugin builder.
+ */
+
 // Angular builder
 import { executeBrowserBuilder } from '@angular-devkit/build-angular';
 import { buildBrowserWebpackConfigFromContext } from '@angular-devkit/build-angular/src/browser';
@@ -6,23 +13,51 @@ import * as path from 'path';
 // Builder bootstrap dependencies
 import { BuilderContext, BuilderOutput, createBuilder } from '@angular-devkit/architect';
 import { NormalizedBrowserBuilderSchema } from '@angular-devkit/build-angular/src/utils/normalize-builder-schema';
+import { ExtensionManifest, BasePluginBuilderSchema } from "../common/interfaces";
+import {
+	extractExternalRegExps,
+	processManifestJsonFile,
+	VCD_CUSTOM_LIB_SEPARATOR,
+	filterRuntimeModules,
+	nameVendorFile
+} from "../common/utilites";
+import { ConcatWebpackPlugin } from "../common/concat";
 import * as ZipPlugin from 'zip-webpack-plugin';
 
-interface Options extends NormalizedBrowserBuilderSchema {
-  /**
-   * A string of the form `path/to/file#exportName` that acts as a path to include to bundle
-   */
-  modulePath: string;
+export interface PluginBuilderSchema7X extends NormalizedBrowserBuilderSchema, BasePluginBuilderSchema {}
+
+export const defaultExternals = {
+	common: [
+		/^@angular\/.+$/,
+		/^@ngrx\/.+$/,
+		/^@vcd\/common$/,
+		/^@vcd-ui\/common$/,
+		{
+			reselect: 'reselect'
+		}
+	],
+	["9.7-10.0"]: [
+		/^rxjs(\/.+)?$/,
+		/^@clr\/.+$/,
+		{
+			'clarity-angular': 'clarity-angular',
+		}
+	]
 }
 
 export default createBuilder(commandBuilder as () => Promise<BuilderOutput>);
 
 async function commandBuilder(
-  options: Options,
+  options: PluginBuilderSchema7X,
   context: BuilderContext,
   ): Promise<BuilderOutput> {
+    if (!options.modulePath) {
+			throw Error('Please define modulePath!');
+		}
+
     // Build webpack configurtion
-    const configs = await buildBrowserWebpackConfigFromContext(options, context);
+		const configs = await buildBrowserWebpackConfigFromContext(options, context);
+		const pluginLibsBundles = new Map<string, string>();
 
     // Get the configuration
     const config = configs.config[0];
@@ -35,34 +70,59 @@ async function commandBuilder(
     delete config.entry["polyfills-es5"];
 
     // List the external libraries which will be provided by vcd
-    config.externals = [
-      /^rxjs(\/.+)?$/,
-      /^@angular\/.+$/,
-      /^@clr\/.+$/,
-      /^@ngrx\/.+$/,
-      /^@vcd\/common$/,
-      /^@vcd-ui\/common$/,
-      {
-        'clarity-angular': 'clarity-angular',
-        reselect: 'reselect'
-      }
-    ];
+		config.externals = [
+			...(options.ignoreDefaultExternals ? [] : defaultExternals.common),
+			...(!options.enableRuntimeDependecyManagement && !options.ignoreDefaultExternals ? defaultExternals["9.7-10.0"] : []),
+			...extractExternalRegExps(options.externalLibs),
+		];
 
     // preserve path to entry point
     // so that we can clear use it within `run` method to clear that file
     const entryPointPath = config.entry.main[0];
-
+    const entryPointOriginalContent = fs.readFileSync(entryPointPath, "utf-8");
+    
     // Patch the main.ts file to point to the plugin which will be compiled
     // tslint:disable-next-line:prefer-const
     let [modulePath, moduleName] = options.modulePath.split('#');
-    modulePath = path.join(context.workspaceRoot, modulePath);
-    const entryPointContents = `export * from '${modulePath.substr(0, modulePath.indexOf(".ts"))}';`;
+
+    if (options.enableRuntimeDependecyManagement) {
+			// Create unique jsonpFunction name
+			const copyPlugin = config.plugins.find((x) => x && x.patterns);
+			const manifestJsonPath = path.join(copyPlugin.patterns[0].context, "manifest.json");
+			const manifest: ExtensionManifest = JSON.parse(fs.readFileSync(manifestJsonPath, "utf-8"));
+			config.output.jsonpFunction = `vcdJsonp#${moduleName}#${manifest.urn}`;
+
+			// Configure the vendor chunks
+			config.optimization.splitChunks = {
+				chunks: "all",
+				cacheGroups: {
+					vendor: {
+						test: filterRuntimeModules(options),
+						name: nameVendorFile(config, options, pluginLibsBundles),
+					},
+				},
+			};
+
+			// Transform manifest json file.
+			copyPlugin.patterns[0].transform = processManifestJsonFile(
+				options.librariesConfig || {},
+				pluginLibsBundles,
+				config.output.jsonpFunction
+			);
+		}
+
+    // Export the plugin module
+    modulePath = modulePath.substr(0, modulePath.indexOf(".ts"));
+    const entryPointContents = `export * from '${modulePath}';`;
     patchEntryPoint(entryPointPath, entryPointContents);
 
+		// Define amd lib
     config.output.filename = 'bundle.js';
     config.output.library = moduleName;
     config.output.libraryTarget = 'amd';
-
+    // workaround to support bundle on nodejs
+    config.output.globalObject = `(typeof self !== 'undefined' ? self : this)`;
+    
     if (!config.plugins || !config.plugins.length) {
       config.plugins = [];
     }
@@ -72,16 +132,43 @@ async function commandBuilder(
       x => x.constructor && x.constructor.name === 'AngularCompilerPlugin'
     );
     if (ngCompilerPluginInstance) {
-      ngCompilerPluginInstance._entryModule = modulePath;
+      ngCompilerPluginInstance._compilerOptions.enableIvy = false;
+			ngCompilerPluginInstance._entryModule = `${modulePath}#${moduleName}`;
     }
 
+    if (options.enableRuntimeDependecyManagement) {
+			config.plugins.push(
+				new ConcatWebpackPlugin({
+					concat: [
+						{
+							inputs: [
+								"bundle.js",
+								"vendors~main.bundle.js"
+							],
+							output: "bundle.js"
+						}
+					]
+				})
+			);
+		}
+
     // Zip the result
-    config.plugins.push(
-      new ZipPlugin({
-        filename: 'plugin.zip',
-        exclude: [/\.html$/]
-      }),
-    );
+		config.plugins.push(
+			new ZipPlugin({
+				filename: 'plugin.zip',
+				exclude: [
+					/\.html$/,
+					...Object.keys(options.librariesConfig)
+					.filter((key) => {
+						return options.librariesConfig[key].scope === "external";
+					})
+					.map((key) => {
+						const libBundleName = `${key.replace("/", VCD_CUSTOM_LIB_SEPARATOR)}@${options.librariesConfig[key].version}.bundle.js`
+						return libBundleName
+					})
+				]
+			}),
+		);
 
     options.fileReplacements = options.fileReplacements && options.fileReplacements.length ? options.fileReplacements : [];
     options.styles = options.styles && options.styles.length ? options.styles : [];
@@ -93,12 +180,12 @@ async function commandBuilder(
     })
     .toPromise()
     .then(() => {
-      patchEntryPoint(entryPointPath, '');
+      patchEntryPoint(entryPointPath, entryPointOriginalContent);
       return Promise.resolve({ success: true });
     })
     .catch((e) => {
       console.error(e);
-      patchEntryPoint(entryPointPath, '');
+      patchEntryPoint(entryPointPath, entryPointOriginalContent);
       context.logger.error(e);
       return Promise.reject({ success: false });
     });

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/new/package-lock.json
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/new/package-lock.json
@@ -1,0 +1,8743 @@
+{
+    "requires": true,
+    "lockfileVersion": 1,
+    "dependencies": {
+        "@angular-devkit/architect": {
+            "version": "0.803.29",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@angular-devkit/architect/-/architect-0.803.29.tgz",
+            "integrity": "sha1-A5mWkIesd4drjkKcsm7r0gWWYHs=",
+            "dev": true,
+            "requires": {
+                "@angular-devkit/core": "8.3.29",
+                "rxjs": "6.4.0"
+            }
+        },
+        "@angular-devkit/build-angular": {
+            "version": "0.803.29",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@angular-devkit/build-angular/-/build-angular-0.803.29.tgz",
+            "integrity": "sha1-TMLst8TKSDifBdHgXUcI+CyMd2c=",
+            "dev": true,
+            "requires": {
+                "@angular-devkit/architect": "0.803.29",
+                "@angular-devkit/build-optimizer": "0.803.29",
+                "@angular-devkit/build-webpack": "0.803.29",
+                "@angular-devkit/core": "8.3.29",
+                "@babel/core": "7.8.7",
+                "@babel/preset-env": "7.8.7",
+                "@ngtools/webpack": "8.3.29",
+                "ajv": "6.12.3",
+                "autoprefixer": "9.6.1",
+                "browserslist": "4.10.0",
+                "cacache": "12.0.2",
+                "caniuse-lite": "1.0.30001035",
+                "circular-dependency-plugin": "5.2.0",
+                "clean-css": "4.2.1",
+                "copy-webpack-plugin": "6.0.3",
+                "core-js": "3.6.4",
+                "coverage-istanbul-loader": "2.0.3",
+                "file-loader": "4.2.0",
+                "find-cache-dir": "3.0.0",
+                "glob": "7.1.4",
+                "jest-worker": "24.9.0",
+                "karma-source-map-support": "1.4.0",
+                "less": "3.9.0",
+                "less-loader": "5.0.0",
+                "license-webpack-plugin": "2.1.2",
+                "loader-utils": "1.2.3",
+                "mini-css-extract-plugin": "0.8.0",
+                "minimatch": "3.0.4",
+                "open": "6.4.0",
+                "parse5": "4.0.0",
+                "postcss": "7.0.17",
+                "postcss-import": "12.0.1",
+                "postcss-loader": "3.0.0",
+                "raw-loader": "3.1.0",
+                "regenerator-runtime": "0.13.3",
+                "rxjs": "6.4.0",
+                "sass": "1.22.9",
+                "sass-loader": "7.2.0",
+                "semver": "6.3.0",
+                "source-map": "0.7.3",
+                "source-map-loader": "0.2.4",
+                "source-map-support": "0.5.13",
+                "speed-measure-webpack-plugin": "1.3.1",
+                "style-loader": "1.0.0",
+                "stylus": "0.54.5",
+                "stylus-loader": "3.0.2",
+                "terser": "4.6.3",
+                "terser-webpack-plugin": "3.0.3",
+                "tree-kill": "1.2.2",
+                "webpack": "4.39.2",
+                "webpack-dev-middleware": "3.7.2",
+                "webpack-dev-server": "3.11.0",
+                "webpack-merge": "4.2.1",
+                "webpack-sources": "1.4.3",
+                "webpack-subresource-integrity": "1.1.0-rc.6",
+                "worker-plugin": "3.2.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.7.3",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.7.3.tgz",
+                    "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
+                    "dev": true
+                }
+            }
+        },
+        "@angular-devkit/build-optimizer": {
+            "version": "0.803.29",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@angular-devkit/build-optimizer/-/build-optimizer-0.803.29.tgz",
+            "integrity": "sha1-kcAz5qszE9M47Jw9TEDWTOGzJLw=",
+            "dev": true,
+            "requires": {
+                "loader-utils": "1.2.3",
+                "source-map": "0.7.3",
+                "tslib": "1.10.0",
+                "typescript": "3.5.3",
+                "webpack-sources": "1.4.3"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.7.3",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.7.3.tgz",
+                    "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
+                    "dev": true
+                },
+                "tslib": {
+                    "version": "1.10.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tslib/-/tslib-1.10.0.tgz",
+                    "integrity": "sha1-w8GflZc/sKYpc/sJ2Q2WHuQ+XIo=",
+                    "dev": true
+                }
+            }
+        },
+        "@angular-devkit/build-webpack": {
+            "version": "0.803.29",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@angular-devkit/build-webpack/-/build-webpack-0.803.29.tgz",
+            "integrity": "sha1-zq7mWPC3Gg/uTxC1dLSeGS0zOnw=",
+            "dev": true,
+            "requires": {
+                "@angular-devkit/architect": "0.803.29",
+                "@angular-devkit/core": "8.3.29",
+                "rxjs": "6.4.0"
+            }
+        },
+        "@angular-devkit/core": {
+            "version": "8.3.29",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@angular-devkit/core/-/core-8.3.29.tgz",
+            "integrity": "sha1-NHft1kWGU/g+bXhoSxAMG++BOC8=",
+            "dev": true,
+            "requires": {
+                "ajv": "6.12.3",
+                "fast-json-stable-stringify": "2.0.0",
+                "magic-string": "0.25.3",
+                "rxjs": "6.4.0",
+                "source-map": "0.7.3"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.7.3",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.7.3.tgz",
+                    "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/code-frame": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/code-frame/-/code-frame-7.10.4.tgz",
+            "integrity": "sha1-Fo2ho26Q2miujUnA8bSMfGJJITo=",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.10.4"
+            }
+        },
+        "@babel/compat-data": {
+            "version": "7.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/compat-data/-/compat-data-7.12.0.tgz",
+            "integrity": "sha1-RDrqB6WuunlCywZ95rgnLyqza54=",
+            "dev": true
+        },
+        "@babel/core": {
+            "version": "7.8.7",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/core/-/core-7.8.7.tgz",
+            "integrity": "sha1-tpAX0iHM3rIDFFrp2iadcs8QLzs=",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.8.3",
+                "@babel/generator": "^7.8.7",
+                "@babel/helpers": "^7.8.4",
+                "@babel/parser": "^7.8.7",
+                "@babel/template": "^7.8.6",
+                "@babel/traverse": "^7.8.6",
+                "@babel/types": "^7.8.7",
+                "convert-source-map": "^1.7.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.1",
+                "json5": "^2.1.0",
+                "lodash": "^4.17.13",
+                "resolve": "^1.3.2",
+                "semver": "^5.4.1",
+                "source-map": "^0.5.0"
+            },
+            "dependencies": {
+                "json5": {
+                    "version": "2.1.3",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/json5/-/json5-2.1.3.tgz",
+                    "integrity": "sha1-ybD3+pIzv+WAf+ZvzzpWF+1ZfUM=",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/generator": {
+            "version": "7.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/generator/-/generator-7.12.0.tgz",
+            "integrity": "sha1-kaRfHBjKjYlaNaBNoaTPfqPzf5g=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.12.0",
+                "jsesc": "^2.5.1",
+                "source-map": "^0.5.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-annotate-as-pure": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+            "integrity": "sha1-W/DUlaP3V6w72ki1vzs7ownHK6M=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-builder-binary-assignment-operator-visitor": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+            "integrity": "sha1-uwt18xv5jL+f8UPBrleLhydK4aM=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-explode-assignable-expression": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-compilation-targets": {
+            "version": "7.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.0.tgz",
+            "integrity": "sha1-xHfYmh9NYmyBSbm4iAL3jWbQyZo=",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.12.0",
+                "@babel/helper-validator-option": "^7.12.0",
+                "browserslist": "^4.12.0",
+                "semver": "^5.5.0"
+            },
+            "dependencies": {
+                "browserslist": {
+                    "version": "4.14.5",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/browserslist/-/browserslist-4.14.5.tgz",
+                    "integrity": "sha1-HHUUYaEC3cYOQJk2ObcJvn8sQBU=",
+                    "dev": true,
+                    "requires": {
+                        "caniuse-lite": "^1.0.30001135",
+                        "electron-to-chromium": "^1.3.571",
+                        "escalade": "^3.1.0",
+                        "node-releases": "^1.1.61"
+                    }
+                },
+                "caniuse-lite": {
+                    "version": "1.0.30001148",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30001148.tgz",
+                    "integrity": "sha1-3JfH7ZGKszv4cG3dXjhyh+AV1jc=",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-create-regexp-features-plugin": {
+            "version": "7.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.0.tgz",
+            "integrity": "sha1-hYzvVwOfOzqQEic1lyiKceHf+Mo=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-regex": "^7.10.4",
+                "regexpu-core": "^4.7.1"
+            }
+        },
+        "@babel/helper-define-map": {
+            "version": "7.10.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+            "integrity": "sha1-tTwQ23imQIABUmkrEzkxR6y5uzA=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/types": "^7.10.5",
+                "lodash": "^4.17.19"
+            }
+        },
+        "@babel/helper-explode-assignable-expression": {
+            "version": "7.11.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.11.4.tgz",
+            "integrity": "sha1-LY40cCUswXq6kX7eeAPUp6J2pBs=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+            "integrity": "sha1-0tOyDFmtjEcRL6fSqUvAnV74Lxo=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+            "integrity": "sha1-mMHL6g4jMvM/mkZhuM4VBbLBm6I=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-hoist-variables": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
+            "integrity": "sha1-1JsAHR1aaMpeZgTdoBpil/fJOB4=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-member-expression-to-functions": {
+            "version": "7.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.0.tgz",
+            "integrity": "sha1-SPYF+oAXZPPlsuMB5J01/hggxPM=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.12.0"
+            }
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+            "integrity": "sha1-TFxUvgS9MWcKc4J5fXW5+i5bViA=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-module-transforms": {
+            "version": "7.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-module-transforms/-/helper-module-transforms-7.12.0.tgz",
+            "integrity": "sha1-isfZ6HFvlFSaQuV3xUKTkZUOM/M=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/helper-replace-supers": "^7.12.0",
+                "@babel/helper-simple-access": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.12.0",
+                "@babel/types": "^7.12.0",
+                "lodash": "^4.17.19"
+            }
+        },
+        "@babel/helper-optimise-call-expression": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+            "integrity": "sha1-UNyWQT1ZT5lad5BZBbBYk813lnM=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-plugin-utils": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+            "integrity": "sha1-L3WoMSadT2d95JmG3/WZJ1M883U=",
+            "dev": true
+        },
+        "@babel/helper-regex": {
+            "version": "7.10.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+            "integrity": "sha1-Mt+7eYmQc8QVVXBToZvQVarlCuA=",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.19"
+            }
+        },
+        "@babel/helper-remap-async-to-generator": {
+            "version": "7.11.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.11.4.tgz",
+            "integrity": "sha1-RHTqn3Q48YV14wsMrHhARbQCoS0=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-wrap-function": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-replace-supers": {
+            "version": "7.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-replace-supers/-/helper-replace-supers-7.12.0.tgz",
+            "integrity": "sha1-mNPz63eXUuWcdCKrOHybREMjvmA=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-member-expression-to-functions": "^7.12.0",
+                "@babel/helper-optimise-call-expression": "^7.10.4",
+                "@babel/traverse": "^7.12.0",
+                "@babel/types": "^7.12.0"
+            }
+        },
+        "@babel/helper-simple-access": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+            "integrity": "sha1-D1zNopRSd6KnotOoIeFTle3PNGE=",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helper-skip-transparent-expression-wrappers": {
+            "version": "7.11.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.11.0.tgz",
+            "integrity": "sha1-7sFi8RLC9Y068K8SXju1dmUUZyk=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.11.0"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.11.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+            "integrity": "sha1-+KSRJErPamdhWKxCBykRuoOtCZ8=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.11.0"
+            }
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+            "integrity": "sha1-p4x6clHgH2FlEtMbEK3PUq2l4NI=",
+            "dev": true
+        },
+        "@babel/helper-validator-option": {
+            "version": "7.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-validator-option/-/helper-validator-option-7.12.0.tgz",
+            "integrity": "sha1-HR/Eiptpdj2mG4kndLDfia7hyWk=",
+            "dev": true
+        },
+        "@babel/helper-wrap-function": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
+            "integrity": "sha1-im9wHqsP8592W1oc/vQJmQ5iS4c=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/helpers": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helpers/-/helpers-7.10.4.tgz",
+            "integrity": "sha1-Kr6w1yGv98Cpc3a54fb2XXpHUEQ=",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.10.4",
+                "@babel/traverse": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/highlight/-/highlight-7.10.4.tgz",
+            "integrity": "sha1-fRvf1ldTU4+r5sOFls23bZrGAUM=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "chalk": "^2.0.0",
+                "js-tokens": "^4.0.0"
+            }
+        },
+        "@babel/parser": {
+            "version": "7.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/parser/-/parser-7.12.0.tgz",
+            "integrity": "sha1-KtOI85YARbIvm31L+F6AsVocnjo=",
+            "dev": true
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+            "version": "7.10.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
+            "integrity": "sha1-NJHKvy98F5q4IGBs7Cf+0V4OhVg=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-remap-async-to-generator": "^7.10.4",
+                "@babel/plugin-syntax-async-generators": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-dynamic-import": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.4.tgz",
+            "integrity": "sha1-uleibLmLN3QenVvKG4sN34KR8X4=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-json-strings": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz",
+            "integrity": "sha1-WT5ZxjUoFgIzvTIbGuvgggwjQds=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-json-strings": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-nullish-coalescing-operator": {
+            "version": "7.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.0.tgz",
+            "integrity": "sha1-2CF0pTEwXfTXB5zjeCJps1uBC4I=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+            "version": "7.11.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz",
+            "integrity": "sha1-vYH5Wh90Z2DqQ7bC09YrEXkK0K8=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+                "@babel/plugin-transform-parameters": "^7.10.4"
+            }
+        },
+        "@babel/plugin-proposal-optional-catch-binding": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz",
+            "integrity": "sha1-Mck4MJ0kp4pJ1o/av/qoY3WFVN0=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-optional-chaining": {
+            "version": "7.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.0.tgz",
+            "integrity": "sha1-AVm1SfFlAW/J8oS4YHpYo3o7cf4=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+            }
+        },
+        "@babel/plugin-proposal-unicode-property-regex": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz",
+            "integrity": "sha1-RIPNpTBBzjQTt/4vAAImZd36p10=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-async-generators": {
+            "version": "7.8.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+            "integrity": "sha1-qYP7Gusuw/btBCohD2QOkOeG/g0=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-dynamic-import": {
+            "version": "7.8.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+            "integrity": "sha1-Yr+Ysto80h1iYVT8lu5bPLaOrLM=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-json-strings": {
+            "version": "7.8.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+            "integrity": "sha1-AcohtmjNghjJ5kDLbdiMVBKyyWo=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-nullish-coalescing-operator": {
+            "version": "7.8.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+            "integrity": "sha1-Fn7XA2iIYIH3S1w2xlqIwDtm0ak=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+            "version": "7.8.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+            "integrity": "sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-catch-binding": {
+            "version": "7.8.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+            "integrity": "sha1-YRGiZbz7Ag6579D9/X0mQCue1sE=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-chaining": {
+            "version": "7.8.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+            "integrity": "sha1-T2nCq5UWfgGAzVM2YT+MV4j31Io=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-top-level-await": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz",
+            "integrity": "sha1-S764kXtU/PdoNk4KgfVg4zo+9X0=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-arrow-functions": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz",
+            "integrity": "sha1-4ilg135pfHT0HFAdRNc9v4pqZM0=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz",
+            "integrity": "sha1-QaUBfknrbzzak5KlHu8pQFskWjc=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-remap-async-to-generator": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-block-scoped-functions": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz",
+            "integrity": "sha1-GvpZV0T3XkOpGvc7DZmOz+Trwug=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-block-scoping": {
+            "version": "7.11.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz",
+            "integrity": "sha1-W37+mIUr741lLAsoFEzZOp5LUhU=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-classes": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz",
+            "integrity": "sha1-QFE2rys+IYvEoZJiKLyRerGgrcc=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-define-map": "^7.10.4",
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-optimise-call-expression": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-replace-supers": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.10.4",
+                "globals": "^11.1.0"
+            }
+        },
+        "@babel/plugin-transform-computed-properties": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
+            "integrity": "sha1-ne2DqBboLe0o1S1LTsvdgQzfwOs=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-destructuring": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
+            "integrity": "sha1-cN3Ss9G+qD0BUJ6bsl3bOnT8heU=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-dotall-regex": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.4.tgz",
+            "integrity": "sha1-RpwgYhBcHragQOr0+sS0iAeDle4=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz",
+            "integrity": "sha1-aX5Qyf7hQ4D+hD0fMGspVhdDHkc=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-exponentiation-operator": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.4.tgz",
+            "integrity": "sha1-WuM4xX+M9AAb2zVgeuZrktZlry4=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-for-of": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz",
+            "integrity": "sha1-wIiS6IGdOl2ykDGxFa9RHbv+uuk=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-function-name": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz",
+            "integrity": "sha1-akZ4gOD8ljhRS6NpERgR3b4mRLc=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-literals": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz",
+            "integrity": "sha1-n0K6CEEQChNfInEtDjkcRi9XHzw=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-member-expression-literals": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz",
+            "integrity": "sha1-sexE/PGVr8uNssYs2OVRyIG6+Lc=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-modules-amd": {
+            "version": "7.10.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz",
+            "integrity": "sha1-G5zdrwXZ6Is6rTOcs+RFxPAgqbE=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.10.5",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
+            }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz",
+            "integrity": "sha1-ZmZ8Pu2h6/eJbUHx8WsXEFovvKA=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-simple-access": "^7.10.4",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
+            }
+        },
+        "@babel/plugin-transform-modules-systemjs": {
+            "version": "7.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.0.tgz",
+            "integrity": "sha1-vKhC22mAz8mK59DyyQfJsd8/h04=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-hoist-variables": "^7.10.4",
+                "@babel/helper-module-transforms": "^7.12.0",
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
+            }
+        },
+        "@babel/plugin-transform-modules-umd": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.4.tgz",
+            "integrity": "sha1-moSB/oG4JGVLOgtl2j34nz0hg54=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-named-capturing-groups-regex": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.10.4.tgz",
+            "integrity": "sha1-eLTZeIELbzvPA/njGPL8DtQa7LY=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-regexp-features-plugin": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-new-target": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz",
+            "integrity": "sha1-kJfXU8t7Aky3OBo7LlLpUTqcaIg=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-object-super": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz",
+            "integrity": "sha1-1xRsTROUM+emUm+IjGZ+MUoJOJQ=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-replace-supers": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-parameters": {
+            "version": "7.10.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
+            "integrity": "sha1-WdM51Y0LGVBDX0BD504lEABeLEo=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-property-literals": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz",
+            "integrity": "sha1-9v5UtlkDUimHhbg+3YFdIUxC48A=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-regenerator": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz",
+            "integrity": "sha1-IBXlnYOQdOdoON4hWdtCGWb9i2M=",
+            "dev": true,
+            "requires": {
+                "regenerator-transform": "^0.14.2"
+            }
+        },
+        "@babel/plugin-transform-reserved-words": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz",
+            "integrity": "sha1-jyaCvNzvntMn4bCGFYXXAT+KVN0=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",
+            "integrity": "sha1-n9Jexc3VVbt/Rz5ebuHJce7eTdY=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-spread": {
+            "version": "7.11.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.11.0.tgz",
+            "integrity": "sha1-+oTTAPXk9XdS/kGm0bPFVPE/F8w=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0"
+            }
+        },
+        "@babel/plugin-transform-sticky-regex": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz",
+            "integrity": "sha1-jziJ7oZXWBEwop2cyR18c7fEoo0=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/helper-regex": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-template-literals": {
+            "version": "7.10.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz",
+            "integrity": "sha1-eLxdYmpmQtszEtnQ8AH152Of3ow=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-typeof-symbol": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz",
+            "integrity": "sha1-lQnxp+7DHE7b/+E3wWzDP/C8W/w=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz",
+            "integrity": "sha1-5W1x+SgvrG2wnIJ0IFVXbV5tgKg=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/preset-env": {
+            "version": "7.8.7",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/preset-env/-/preset-env-7.8.7.tgz",
+            "integrity": "sha1-H8fYnH910tcMK2do3mwuBJs8uds=",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.8.6",
+                "@babel/helper-compilation-targets": "^7.8.7",
+                "@babel/helper-module-imports": "^7.8.3",
+                "@babel/helper-plugin-utils": "^7.8.3",
+                "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
+                "@babel/plugin-proposal-dynamic-import": "^7.8.3",
+                "@babel/plugin-proposal-json-strings": "^7.8.3",
+                "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
+                "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-proposal-optional-chaining": "^7.8.3",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+                "@babel/plugin-syntax-async-generators": "^7.8.0",
+                "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+                "@babel/plugin-syntax-json-strings": "^7.8.0",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+                "@babel/plugin-syntax-top-level-await": "^7.8.3",
+                "@babel/plugin-transform-arrow-functions": "^7.8.3",
+                "@babel/plugin-transform-async-to-generator": "^7.8.3",
+                "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
+                "@babel/plugin-transform-block-scoping": "^7.8.3",
+                "@babel/plugin-transform-classes": "^7.8.6",
+                "@babel/plugin-transform-computed-properties": "^7.8.3",
+                "@babel/plugin-transform-destructuring": "^7.8.3",
+                "@babel/plugin-transform-dotall-regex": "^7.8.3",
+                "@babel/plugin-transform-duplicate-keys": "^7.8.3",
+                "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
+                "@babel/plugin-transform-for-of": "^7.8.6",
+                "@babel/plugin-transform-function-name": "^7.8.3",
+                "@babel/plugin-transform-literals": "^7.8.3",
+                "@babel/plugin-transform-member-expression-literals": "^7.8.3",
+                "@babel/plugin-transform-modules-amd": "^7.8.3",
+                "@babel/plugin-transform-modules-commonjs": "^7.8.3",
+                "@babel/plugin-transform-modules-systemjs": "^7.8.3",
+                "@babel/plugin-transform-modules-umd": "^7.8.3",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+                "@babel/plugin-transform-new-target": "^7.8.3",
+                "@babel/plugin-transform-object-super": "^7.8.3",
+                "@babel/plugin-transform-parameters": "^7.8.7",
+                "@babel/plugin-transform-property-literals": "^7.8.3",
+                "@babel/plugin-transform-regenerator": "^7.8.7",
+                "@babel/plugin-transform-reserved-words": "^7.8.3",
+                "@babel/plugin-transform-shorthand-properties": "^7.8.3",
+                "@babel/plugin-transform-spread": "^7.8.3",
+                "@babel/plugin-transform-sticky-regex": "^7.8.3",
+                "@babel/plugin-transform-template-literals": "^7.8.3",
+                "@babel/plugin-transform-typeof-symbol": "^7.8.4",
+                "@babel/plugin-transform-unicode-regex": "^7.8.3",
+                "@babel/types": "^7.8.7",
+                "browserslist": "^4.8.5",
+                "core-js-compat": "^3.6.2",
+                "invariant": "^2.2.2",
+                "levenary": "^1.1.1",
+                "semver": "^5.5.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/runtime": {
+            "version": "7.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/runtime/-/runtime-7.12.0.tgz",
+            "integrity": "sha1-mL12ZhhpacBL6JPXR89KbGyPprA=",
+            "dev": true,
+            "requires": {
+                "regenerator-runtime": "^0.13.4"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.13.7",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+                    "integrity": "sha1-ysLazIoepnX+qrrriugziYrkb1U=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/template": {
+            "version": "7.10.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/template/-/template-7.10.4.tgz",
+            "integrity": "sha1-MlGZbEIA68cdGo/EBfupQPNrong=",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/parser": "^7.10.4",
+                "@babel/types": "^7.10.4"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/traverse/-/traverse-7.12.0.tgz",
+            "integrity": "sha1-7TGVPW5wjN00RD3i/NtV9yzfsmY=",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/generator": "^7.12.0",
+                "@babel/helper-function-name": "^7.10.4",
+                "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/parser": "^7.12.0",
+                "@babel/types": "^7.12.0",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.19"
+            }
+        },
+        "@babel/types": {
+            "version": "7.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/types/-/types-7.12.0.tgz",
+            "integrity": "sha1-trSfQl7lkEP7yJxhsRoT1erntcY=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.10.4",
+                "lodash": "^4.17.19",
+                "to-fast-properties": "^2.0.0"
+            }
+        },
+        "@istanbuljs/schema": {
+            "version": "0.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@istanbuljs/schema/-/schema-0.1.2.tgz",
+            "integrity": "sha1-JlIL8Jq+SlZEzVQU43ElqJVCQd0=",
+            "dev": true
+        },
+        "@ngtools/webpack": {
+            "version": "8.3.29",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@ngtools/webpack/-/webpack-8.3.29.tgz",
+            "integrity": "sha1-e2mEzczWM91ofpQTqJotnhNg92w=",
+            "dev": true,
+            "requires": {
+                "@angular-devkit/core": "8.3.29",
+                "enhanced-resolve": "4.1.0",
+                "rxjs": "6.4.0",
+                "tree-kill": "1.2.2",
+                "webpack-sources": "1.4.3"
+            }
+        },
+        "@nodelib/fs.scandir": {
+            "version": "2.1.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+            "integrity": "sha1-Olgr21OATGum0UZXnEblITDPSjs=",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "2.0.3",
+                "run-parallel": "^1.1.9"
+            }
+        },
+        "@nodelib/fs.stat": {
+            "version": "2.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+            "integrity": "sha1-NNxfTKu8cg9OYPdadH5+zWwXW9M=",
+            "dev": true
+        },
+        "@nodelib/fs.walk": {
+            "version": "1.2.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+            "integrity": "sha1-ARuSAqcKY2bkNspcBlhEUoqwSXY=",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.scandir": "2.1.3",
+                "fastq": "^1.6.0"
+            }
+        },
+        "@npmcli/move-file": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@npmcli/move-file/-/move-file-1.0.1.tgz",
+            "integrity": "sha1-3hAwcNrA9IzknPZpPCOvWcD3BGQ=",
+            "dev": true,
+            "requires": {
+                "mkdirp": "^1.0.4"
+            },
+            "dependencies": {
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
+                    "dev": true
+                }
+            }
+        },
+        "@types/glob": {
+            "version": "7.1.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@types/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha1-5rqA82t9qtLGhazZJmOC5omFwYM=",
+            "dev": true,
+            "requires": {
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/json-schema": {
+            "version": "7.0.6",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@types/json-schema/-/json-schema-7.0.6.tgz",
+            "integrity": "sha1-9MfsQ+gbMZqYFRFQMXCfJph4kfA=",
+            "dev": true
+        },
+        "@types/minimatch": {
+            "version": "3.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@types/minimatch/-/minimatch-3.0.3.tgz",
+            "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0=",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "14.11.8",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@types/node/-/node-14.11.8.tgz",
+            "integrity": "sha1-/iAS8jVeTOCLykSus6u7Ic+I0z8=",
+            "dev": true
+        },
+        "@types/source-list-map": {
+            "version": "0.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@types/source-list-map/-/source-list-map-0.1.2.tgz",
+            "integrity": "sha1-AHiDYGP/rxdBI0m7o2QIfgrALsk=",
+            "dev": true
+        },
+        "@types/webpack-sources": {
+            "version": "0.1.8",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@types/webpack-sources/-/webpack-sources-0.1.8.tgz",
+            "integrity": "sha1-B411QQQ1mT7IoKKFXohwbz91H4E=",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "@types/source-list-map": "*",
+                "source-map": "^0.6.1"
+            }
+        },
+        "@webassemblyjs/ast": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+            "integrity": "sha1-UbHF/mV2o0lTv0slPfnw1JDZ41k=",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/helper-module-context": "1.8.5",
+                "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+                "@webassemblyjs/wast-parser": "1.8.5"
+            }
+        },
+        "@webassemblyjs/floating-point-hex-parser": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+            "integrity": "sha1-G6kmopI2E+3OSW/VsC6M6KX0lyE=",
+            "dev": true
+        },
+        "@webassemblyjs/helper-api-error": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+            "integrity": "sha1-xJ2tIvZFInxe22EL25aX8aq3Ifc=",
+            "dev": true
+        },
+        "@webassemblyjs/helper-buffer": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+            "integrity": "sha1-/qk+Qphj3V5DOFVfQikjhaZT8gQ=",
+            "dev": true
+        },
+        "@webassemblyjs/helper-code-frame": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+            "integrity": "sha1-mnQP9I4/qjAisd/1RCPfmqKTwl4=",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/wast-printer": "1.8.5"
+            }
+        },
+        "@webassemblyjs/helper-fsm": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+            "integrity": "sha1-ugt9Oz9+RzPaYFnJMyJ12GBwJFI=",
+            "dev": true
+        },
+        "@webassemblyjs/helper-module-context": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+            "integrity": "sha1-3vS5knsBAdyMu9jR7bW3ucguskU=",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "mamacro": "^0.0.3"
+            }
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+            "integrity": "sha1-U3p1Dt31weky83RCBlUckcG5PmE=",
+            "dev": true
+        },
+        "@webassemblyjs/helper-wasm-section": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+            "integrity": "sha1-dMpqa8vhnlCjtrRihH5pUD5r/L8=",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "@webassemblyjs/helper-buffer": "1.8.5",
+                "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+                "@webassemblyjs/wasm-gen": "1.8.5"
+            }
+        },
+        "@webassemblyjs/ieee754": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+            "integrity": "sha1-cSMp2+8kDza/V70ve4+5v0FUQh4=",
+            "dev": true,
+            "requires": {
+                "@xtuc/ieee754": "^1.2.0"
+            }
+        },
+        "@webassemblyjs/leb128": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+            "integrity": "sha1-BE7es06mefPgTNT9mCTV41dnrhA=",
+            "dev": true,
+            "requires": {
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@webassemblyjs/utf8": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+            "integrity": "sha1-qL87XY/+mGx8Hjc8y9wqCRXwztw=",
+            "dev": true
+        },
+        "@webassemblyjs/wasm-edit": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+            "integrity": "sha1-li2hKqWswcExyBxCMpkcgs5W4Bo=",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "@webassemblyjs/helper-buffer": "1.8.5",
+                "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+                "@webassemblyjs/helper-wasm-section": "1.8.5",
+                "@webassemblyjs/wasm-gen": "1.8.5",
+                "@webassemblyjs/wasm-opt": "1.8.5",
+                "@webassemblyjs/wasm-parser": "1.8.5",
+                "@webassemblyjs/wast-printer": "1.8.5"
+            }
+        },
+        "@webassemblyjs/wasm-gen": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+            "integrity": "sha1-VIQHZsLBAC62TtGr5yCt7XFPmLw=",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+                "@webassemblyjs/ieee754": "1.8.5",
+                "@webassemblyjs/leb128": "1.8.5",
+                "@webassemblyjs/utf8": "1.8.5"
+            }
+        },
+        "@webassemblyjs/wasm-opt": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+            "integrity": "sha1-sk2fa6UDlK8TSfUQr6j/y4pj0mQ=",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "@webassemblyjs/helper-buffer": "1.8.5",
+                "@webassemblyjs/wasm-gen": "1.8.5",
+                "@webassemblyjs/wasm-parser": "1.8.5"
+            }
+        },
+        "@webassemblyjs/wasm-parser": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+            "integrity": "sha1-IVdvDsiLkUJzV7hTY4NmjvfGa40=",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "@webassemblyjs/helper-api-error": "1.8.5",
+                "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+                "@webassemblyjs/ieee754": "1.8.5",
+                "@webassemblyjs/leb128": "1.8.5",
+                "@webassemblyjs/utf8": "1.8.5"
+            }
+        },
+        "@webassemblyjs/wast-parser": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+            "integrity": "sha1-4Q7s1ULQ5705T2gnxJ899tTu+4w=",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "@webassemblyjs/floating-point-hex-parser": "1.8.5",
+                "@webassemblyjs/helper-api-error": "1.8.5",
+                "@webassemblyjs/helper-code-frame": "1.8.5",
+                "@webassemblyjs/helper-fsm": "1.8.5",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@webassemblyjs/wast-printer": {
+            "version": "1.8.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+            "integrity": "sha1-EUu8SB/RDKDiOzVg+oEnSLC65bw=",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "@webassemblyjs/wast-parser": "1.8.5",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@xtuc/ieee754": {
+            "version": "1.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "integrity": "sha1-7vAUoxRa5Hehy8AM0eVSM23Ot5A=",
+            "dev": true
+        },
+        "@xtuc/long": {
+            "version": "4.2.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@xtuc/long/-/long-4.2.2.tgz",
+            "integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0=",
+            "dev": true
+        },
+        "accepts": {
+            "version": "1.3.7",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/accepts/-/accepts-1.3.7.tgz",
+            "integrity": "sha1-UxvHJlF6OytB+FACHGzBXqq1B80=",
+            "dev": true,
+            "requires": {
+                "mime-types": "~2.1.24",
+                "negotiator": "0.6.2"
+            }
+        },
+        "acorn": {
+            "version": "6.4.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/acorn/-/acorn-6.4.2.tgz",
+            "integrity": "sha1-NYZv1xBSjpLeEM8GAWSY5H454eY=",
+            "dev": true
+        },
+        "aggregate-error": {
+            "version": "3.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
+            "dev": true,
+            "requires": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+            }
+        },
+        "ajv": {
+            "version": "6.12.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv/-/ajv-6.12.3.tgz",
+            "integrity": "sha1-GMWvOKER3etPJpe9eNaKvByr1wY=",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ajv-errors": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv-errors/-/ajv-errors-1.0.1.tgz",
+            "integrity": "sha1-81mGrOuRr63sQQL72FAUlQzvpk0=",
+            "dev": true
+        },
+        "ajv-keywords": {
+            "version": "3.5.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+            "integrity": "sha1-MfKdpatuANHC0yms97WSlhTVAU0=",
+            "dev": true
+        },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true
+        },
+        "ansi-colors": {
+            "version": "3.2.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ansi-colors/-/ansi-colors-3.2.4.tgz",
+            "integrity": "sha1-46PaS/uubIapwoViXeEkojQCb78=",
+            "dev": true
+        },
+        "ansi-html": {
+            "version": "0.0.7",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ansi-html/-/ansi-html-0.0.7.tgz",
+            "integrity": "sha1-gTWEAhliqenm/QOflA0S9WynhZ4=",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "anymatch": {
+            "version": "3.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/anymatch/-/anymatch-3.1.1.tgz",
+            "integrity": "sha1-xV7PAhheJGklk5kxDBc84xIzsUI=",
+            "dev": true,
+            "requires": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            }
+        },
+        "aproba": {
+            "version": "1.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/aproba/-/aproba-1.2.0.tgz",
+            "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "arr-diff": {
+            "version": "4.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/arr-diff/-/arr-diff-4.0.0.tgz",
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+            "dev": true
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+            "dev": true
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+            "dev": true
+        },
+        "array-flatten": {
+            "version": "2.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/array-flatten/-/array-flatten-2.1.2.tgz",
+            "integrity": "sha1-JO+AoowaiTYX4hSbDG0NeIKTsJk=",
+            "dev": true
+        },
+        "array-union": {
+            "version": "2.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0=",
+            "dev": true
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
+        "array-unique": {
+            "version": "0.3.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/array-unique/-/array-unique-0.3.2.tgz",
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+            "dev": true
+        },
+        "asap": {
+            "version": "2.0.6",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+            "dev": true,
+            "optional": true
+        },
+        "asn1": {
+            "version": "0.2.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "asn1.js": {
+            "version": "5.4.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/asn1.js/-/asn1.js-5.4.1.tgz",
+            "integrity": "sha1-EamAuE67kXgc41sP3C7ilON4Pwc=",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "safer-buffer": "^2.1.0"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+                    "dev": true
+                }
+            }
+        },
+        "assert": {
+            "version": "1.5.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/assert/-/assert-1.5.0.tgz",
+            "integrity": "sha1-VcEJqvbgrv2z3EtxJAxwv1dLGOs=",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.1.1",
+                "util": "0.10.3"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/inherits/-/inherits-2.0.1.tgz",
+                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                    "dev": true
+                },
+                "util": {
+                    "version": "0.10.3",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/util/-/util-0.10.3.tgz",
+                    "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.1"
+                    }
+                }
+            }
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
+        },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+            "dev": true
+        },
+        "async": {
+            "version": "2.6.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/async/-/async-2.6.3.tgz",
+            "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.14"
+            }
+        },
+        "async-each": {
+            "version": "1.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/async-each/-/async-each-1.0.3.tgz",
+            "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8=",
+            "dev": true
+        },
+        "async-limiter": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/async-limiter/-/async-limiter-1.0.1.tgz",
+            "integrity": "sha1-3TeelPDbgxCwgpH51kwyCXZmF/0=",
+            "dev": true
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true,
+            "optional": true
+        },
+        "atob": {
+            "version": "2.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha1-bZUX654DDSQ2ZmZR6GvZ9vE1M8k=",
+            "dev": true
+        },
+        "autoprefixer": {
+            "version": "9.6.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/autoprefixer/-/autoprefixer-9.6.1.tgz",
+            "integrity": "sha1-UZZ6AtLSMAuwGGbBYR7INI01Wkc=",
+            "dev": true,
+            "requires": {
+                "browserslist": "^4.6.3",
+                "caniuse-lite": "^1.0.30000980",
+                "chalk": "^2.4.2",
+                "normalize-range": "^0.1.2",
+                "num2fraction": "^1.2.2",
+                "postcss": "^7.0.17",
+                "postcss-value-parser": "^4.0.0"
+            }
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true,
+            "optional": true
+        },
+        "aws4": {
+            "version": "1.10.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/aws4/-/aws4-1.10.1.tgz",
+            "integrity": "sha1-4eguTz6Zniz9YbFhKA0WoRH4ZCg=",
+            "dev": true,
+            "optional": true
+        },
+        "babel-plugin-dynamic-import-node": {
+            "version": "2.3.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+            "integrity": "sha1-hP2hnJduxcbe/vV/lCez3vZuF6M=",
+            "dev": true,
+            "requires": {
+                "object.assign": "^4.1.0"
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "base": {
+            "version": "0.11.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/base/-/base-0.11.2.tgz",
+            "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+            "dev": true,
+            "requires": {
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "base64-js": {
+            "version": "1.3.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/base64-js/-/base64-js-1.3.1.tgz",
+            "integrity": "sha1-WOzoy3XdB+ce0IxzarxfrE2/jfE=",
+            "dev": true
+        },
+        "batch": {
+            "version": "0.6.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/batch/-/batch-0.6.1.tgz",
+            "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+            "dev": true
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "tweetnacl": "^0.14.3"
+            }
+        },
+        "big.js": {
+            "version": "5.2.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/big.js/-/big.js-5.2.2.tgz",
+            "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
+            "dev": true
+        },
+        "binary-extensions": {
+            "version": "2.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/binary-extensions/-/binary-extensions-2.1.0.tgz",
+            "integrity": "sha1-MPpAyef+B9vIlWeM0ocCTeokHdk=",
+            "dev": true
+        },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha1-EDU8npRTNLwFEabZCzj7x8nFBN8=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
+        "bluebird": {
+            "version": "3.7.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bluebird/-/bluebird-3.7.2.tgz",
+            "integrity": "sha1-nyKcFb4nJFT/qXOs4NvueaGww28=",
+            "dev": true
+        },
+        "bn.js": {
+            "version": "5.1.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-5.1.3.tgz",
+            "integrity": "sha1-vsoAVAj2Quvr6oCwQrTRjSrA7ms=",
+            "dev": true
+        },
+        "body-parser": {
+            "version": "1.19.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/body-parser/-/body-parser-1.19.0.tgz",
+            "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
+            "dev": true,
+            "requires": {
+                "bytes": "3.1.0",
+                "content-type": "~1.0.4",
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "http-errors": "1.7.2",
+                "iconv-lite": "0.4.24",
+                "on-finished": "~2.3.0",
+                "qs": "6.7.0",
+                "raw-body": "2.4.0",
+                "type-is": "~1.6.17"
+            },
+            "dependencies": {
+                "bytes": {
+                    "version": "3.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bytes/-/bytes-3.1.0.tgz",
+                    "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.7.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/qs/-/qs-6.7.0.tgz",
+                    "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
+                    "dev": true
+                }
+            }
+        },
+        "bonjour": {
+            "version": "3.5.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bonjour/-/bonjour-3.5.0.tgz",
+            "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+            "dev": true,
+            "requires": {
+                "array-flatten": "^2.1.0",
+                "deep-equal": "^1.0.1",
+                "dns-equal": "^1.0.0",
+                "dns-txt": "^2.0.2",
+                "multicast-dns": "^6.0.1",
+                "multicast-dns-service-types": "^1.1.0"
+            }
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "braces": {
+            "version": "3.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+            "dev": true,
+            "requires": {
+                "fill-range": "^7.0.1"
+            }
+        },
+        "brorand": {
+            "version": "1.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+            "dev": true
+        },
+        "browserify-aes": {
+            "version": "1.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/browserify-aes/-/browserify-aes-1.2.0.tgz",
+            "integrity": "sha1-Mmc0ZC9APavDADIJhTu3CtQo70g=",
+            "dev": true,
+            "requires": {
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "browserify-cipher": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+            "integrity": "sha1-jWR0wbhwv9q807z8wZNKEOlPFfA=",
+            "dev": true,
+            "requires": {
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
+            }
+        },
+        "browserify-des": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/browserify-des/-/browserify-des-1.0.2.tgz",
+            "integrity": "sha1-OvTx9Zg5QDVy8cZiBDdfen9wPpw=",
+            "dev": true,
+            "requires": {
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "browserify-rsa": {
+            "version": "4.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.1.0",
+                "randombytes": "^2.0.1"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+                    "dev": true
+                }
+            }
+        },
+        "browserify-sign": {
+            "version": "4.2.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/browserify-sign/-/browserify-sign-4.2.1.tgz",
+            "integrity": "sha1-6vSt1G3VS+O7OzbAzxWrvrp5VsM=",
+            "dev": true,
+            "requires": {
+                "bn.js": "^5.1.1",
+                "browserify-rsa": "^4.0.1",
+                "create-hash": "^1.2.0",
+                "create-hmac": "^1.1.7",
+                "elliptic": "^6.5.3",
+                "inherits": "^2.0.4",
+                "parse-asn1": "^5.1.5",
+                "readable-stream": "^3.6.0",
+                "safe-buffer": "^5.2.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+                    "dev": true
+                }
+            }
+        },
+        "browserify-zlib": {
+            "version": "0.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+            "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
+            "dev": true,
+            "requires": {
+                "pako": "~1.0.5"
+            }
+        },
+        "browserslist": {
+            "version": "4.10.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/browserslist/-/browserslist-4.10.0.tgz",
+            "integrity": "sha1-8XlzeRPq8NK5jkkmrBymoVy8xqk=",
+            "dev": true,
+            "requires": {
+                "caniuse-lite": "^1.0.30001035",
+                "electron-to-chromium": "^1.3.378",
+                "node-releases": "^1.1.52",
+                "pkg-up": "^3.1.0"
+            }
+        },
+        "buffer": {
+            "version": "4.9.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha1-Iw6tNEACmIZEhBqwJEr4xEu+Pvg=",
+            "dev": true,
+            "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
+        "buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+            "dev": true
+        },
+        "buffer-indexof": {
+            "version": "1.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
+            "integrity": "sha1-Uvq8xqYG0aADAoAmSO9o9jnaJow=",
+            "dev": true
+        },
+        "buffer-xor": {
+            "version": "1.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/buffer-xor/-/buffer-xor-1.0.3.tgz",
+            "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+            "dev": true
+        },
+        "builtin-status-codes": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+            "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+            "dev": true
+        },
+        "bytes": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bytes/-/bytes-3.0.0.tgz",
+            "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+            "dev": true
+        },
+        "cacache": {
+            "version": "12.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cacache/-/cacache-12.0.2.tgz",
+            "integrity": "sha1-jbAyBeNgiaPfaVTGbOklQUQaxGw=",
+            "dev": true,
+            "requires": {
+                "bluebird": "^3.5.5",
+                "chownr": "^1.1.1",
+                "figgy-pudding": "^3.5.1",
+                "glob": "^7.1.4",
+                "graceful-fs": "^4.1.15",
+                "infer-owner": "^1.0.3",
+                "lru-cache": "^5.1.1",
+                "mississippi": "^3.0.0",
+                "mkdirp": "^0.5.1",
+                "move-concurrently": "^1.0.1",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^2.6.3",
+                "ssri": "^6.0.1",
+                "unique-filename": "^1.1.1",
+                "y18n": "^4.0.0"
+            }
+        },
+        "cache-base": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+            "dev": true,
+            "requires": {
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
+            }
+        },
+        "caller-callsite": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/caller-callsite/-/caller-callsite-2.0.0.tgz",
+            "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+            "dev": true,
+            "requires": {
+                "callsites": "^2.0.0"
+            }
+        },
+        "caller-path": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/caller-path/-/caller-path-2.0.0.tgz",
+            "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+            "dev": true,
+            "requires": {
+                "caller-callsite": "^2.0.0"
+            }
+        },
+        "callsites": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/callsites/-/callsites-2.0.0.tgz",
+            "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+            "dev": true
+        },
+        "camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+            "dev": true
+        },
+        "caniuse-lite": {
+            "version": "1.0.30001035",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz",
+            "integrity": "sha1-K7U7iqRxay7QjgiNTcgWpf4Imh4=",
+            "dev": true
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true,
+            "optional": true
+        },
+        "chalk": {
+            "version": "2.4.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            }
+        },
+        "chokidar": {
+            "version": "3.4.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/chokidar/-/chokidar-3.4.3.tgz",
+            "integrity": "sha1-wd84IxRI5FykrFiObHlXO6alfVs=",
+            "dev": true,
+            "requires": {
+                "anymatch": "~3.1.1",
+                "braces": "~3.0.2",
+                "fsevents": "~2.1.2",
+                "glob-parent": "~5.1.0",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.5.0"
+            }
+        },
+        "chownr": {
+            "version": "1.1.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/chownr/-/chownr-1.1.4.tgz",
+            "integrity": "sha1-b8nXtC0ypYNZYzdmbn0ICE2izGs=",
+            "dev": true
+        },
+        "chrome-trace-event": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+            "integrity": "sha1-I0CQ7pfH1K0aLEvq4nUF3v/GCKQ=",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.9.0"
+            }
+        },
+        "cipher-base": {
+            "version": "1.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cipher-base/-/cipher-base-1.0.4.tgz",
+            "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "circular-dependency-plugin": {
+            "version": "5.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/circular-dependency-plugin/-/circular-dependency-plugin-5.2.0.tgz",
+            "integrity": "sha1-4J28LdPikoRCQD4tRbQc6ga8CpM=",
+            "dev": true
+        },
+        "class-utils": {
+            "version": "0.3.6",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+            "dev": true,
+            "requires": {
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "clean-css": {
+            "version": "4.2.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/clean-css/-/clean-css-4.2.1.tgz",
+            "integrity": "sha1-LUEe92uFabbQyEBo2r6FsKpeXBc=",
+            "dev": true,
+            "requires": {
+                "source-map": "~0.6.0"
+            }
+        },
+        "clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs=",
+            "dev": true
+        },
+        "cliui": {
+            "version": "5.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cliui/-/cliui-5.0.0.tgz",
+            "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
+            "dev": true,
+            "requires": {
+                "string-width": "^3.1.0",
+                "strip-ansi": "^5.2.0",
+                "wrap-ansi": "^5.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "clone": {
+            "version": "2.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/clone/-/clone-2.1.2.tgz",
+            "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+            "dev": true
+        },
+        "clone-deep": {
+            "version": "4.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/clone-deep/-/clone-deep-4.0.1.tgz",
+            "integrity": "sha1-wZ/Zvbv4WUK0/ZechNz31fB8I4c=",
+            "dev": true,
+            "requires": {
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.2",
+                "shallow-clone": "^3.0.0"
+            }
+        },
+        "collection-visit": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/collection-visit/-/collection-visit-1.0.0.tgz",
+            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "dev": true,
+            "requires": {
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
+        "commander": {
+            "version": "2.20.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+            "dev": true
+        },
+        "commondir": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+            "dev": true
+        },
+        "component-emitter": {
+            "version": "1.3.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/component-emitter/-/component-emitter-1.3.0.tgz",
+            "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
+            "dev": true
+        },
+        "compressible": {
+            "version": "2.0.18",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/compressible/-/compressible-2.0.18.tgz",
+            "integrity": "sha1-r1PMprBw1MPAdQ+9dyhqbXzEb7o=",
+            "dev": true,
+            "requires": {
+                "mime-db": ">= 1.43.0 < 2"
+            }
+        },
+        "compression": {
+            "version": "1.7.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/compression/-/compression-1.7.4.tgz",
+            "integrity": "sha1-lVI+/xcMpXwpoMpB5v4TH0Hlu48=",
+            "dev": true,
+            "requires": {
+                "accepts": "~1.3.5",
+                "bytes": "3.0.0",
+                "compressible": "~2.0.16",
+                "debug": "2.6.9",
+                "on-headers": "~1.0.2",
+                "safe-buffer": "5.1.2",
+                "vary": "~1.1.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            }
+        },
+        "connect-history-api-fallback": {
+            "version": "1.6.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+            "integrity": "sha1-izIIk1kwjRERFdgcrT/Oq4iPl7w=",
+            "dev": true
+        },
+        "console-browserify": {
+            "version": "1.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/console-browserify/-/console-browserify-1.2.0.tgz",
+            "integrity": "sha1-ZwY871fOts9Jk6KrOlWECujEkzY=",
+            "dev": true
+        },
+        "constants-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/constants-browserify/-/constants-browserify-1.0.0.tgz",
+            "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+            "dev": true
+        },
+        "content-disposition": {
+            "version": "0.5.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/content-disposition/-/content-disposition-0.5.3.tgz",
+            "integrity": "sha1-4TDK9+cnkIfFYWwgB9BIVpiYT70=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.2"
+            }
+        },
+        "content-type": {
+            "version": "1.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/content-type/-/content-type-1.0.4.tgz",
+            "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
+            "dev": true
+        },
+        "convert-source-map": {
+            "version": "1.7.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/convert-source-map/-/convert-source-map-1.7.0.tgz",
+            "integrity": "sha1-F6LLiC1/d9NJBYXizmxSRCSjpEI=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
+        },
+        "cookie": {
+            "version": "0.4.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cookie/-/cookie-0.4.0.tgz",
+            "integrity": "sha1-vrQ35wIrO21JAZ0IhmUwPr6cFLo=",
+            "dev": true
+        },
+        "cookie-signature": {
+            "version": "1.0.6",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+            "dev": true
+        },
+        "copy-concurrently": {
+            "version": "1.0.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+            "integrity": "sha1-kilzmMrjSTf8r9bsgTnBgFHwteA=",
+            "dev": true,
+            "requires": {
+                "aproba": "^1.1.1",
+                "fs-write-stream-atomic": "^1.0.8",
+                "iferr": "^0.1.5",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.0"
+            }
+        },
+        "copy-descriptor": {
+            "version": "0.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+            "dev": true
+        },
+        "copy-webpack-plugin": {
+            "version": "6.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/copy-webpack-plugin/-/copy-webpack-plugin-6.0.3.tgz",
+            "integrity": "sha1-Kz0r/GhhuWQypl8BSXIK29kCBAs=",
+            "dev": true,
+            "requires": {
+                "cacache": "^15.0.4",
+                "fast-glob": "^3.2.4",
+                "find-cache-dir": "^3.3.1",
+                "glob-parent": "^5.1.1",
+                "globby": "^11.0.1",
+                "loader-utils": "^2.0.0",
+                "normalize-path": "^3.0.0",
+                "p-limit": "^3.0.1",
+                "schema-utils": "^2.7.0",
+                "serialize-javascript": "^4.0.0",
+                "webpack-sources": "^1.4.3"
+            },
+            "dependencies": {
+                "cacache": {
+                    "version": "15.0.5",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cacache/-/cacache-15.0.5.tgz",
+                    "integrity": "sha1-aRYoM9opFw1nMjNGQ8YOAF9fF9A=",
+                    "dev": true,
+                    "requires": {
+                        "@npmcli/move-file": "^1.0.1",
+                        "chownr": "^2.0.0",
+                        "fs-minipass": "^2.0.0",
+                        "glob": "^7.1.4",
+                        "infer-owner": "^1.0.4",
+                        "lru-cache": "^6.0.0",
+                        "minipass": "^3.1.1",
+                        "minipass-collect": "^1.0.2",
+                        "minipass-flush": "^1.0.5",
+                        "minipass-pipeline": "^1.2.2",
+                        "mkdirp": "^1.0.3",
+                        "p-map": "^4.0.0",
+                        "promise-inflight": "^1.0.1",
+                        "rimraf": "^3.0.2",
+                        "ssri": "^8.0.0",
+                        "tar": "^6.0.2",
+                        "unique-filename": "^1.1.1"
+                    }
+                },
+                "chownr": {
+                    "version": "2.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/chownr/-/chownr-2.0.0.tgz",
+                    "integrity": "sha1-Fb++U9LqtM9w8YqM1o6+Wzyx3s4=",
+                    "dev": true
+                },
+                "emojis-list": {
+                    "version": "3.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/emojis-list/-/emojis-list-3.0.0.tgz",
+                    "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
+                    "dev": true
+                },
+                "find-cache-dir": {
+                    "version": "3.3.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+                    "integrity": "sha1-ibM/rUpGcNqpT4Vff74x1thP6IA=",
+                    "dev": true,
+                    "requires": {
+                        "commondir": "^1.0.1",
+                        "make-dir": "^3.0.2",
+                        "pkg-dir": "^4.1.0"
+                    }
+                },
+                "json5": {
+                    "version": "2.1.3",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/json5/-/json5-2.1.3.tgz",
+                    "integrity": "sha1-ybD3+pIzv+WAf+ZvzzpWF+1ZfUM=",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.5"
+                    }
+                },
+                "loader-utils": {
+                    "version": "2.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/loader-utils/-/loader-utils-2.0.0.tgz",
+                    "integrity": "sha1-5MrOW4FtQloWa18JfhDNErNgZLA=",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^2.1.2"
+                    }
+                },
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
+                    "dev": true
+                },
+                "p-limit": {
+                    "version": "3.0.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-limit/-/p-limit-3.0.2.tgz",
+                    "integrity": "sha1-FmTgEK88rcaBuq/T4qQ3vnsPtf4=",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^2.0.0"
+                    }
+                },
+                "rimraf": {
+                    "version": "3.0.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "ssri": {
+                    "version": "8.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ssri/-/ssri-8.0.0.tgz",
+                    "integrity": "sha1-ecp04h+M6u3fy0uQFDxFi42YiAg=",
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^3.1.1"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
+                    "dev": true
+                }
+            }
+        },
+        "core-js": {
+            "version": "3.6.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/core-js/-/core-js-3.6.4.tgz",
+            "integrity": "sha1-RAqDU2tFgRS5yyrBWAujd9xHBkc=",
+            "dev": true
+        },
+        "core-js-compat": {
+            "version": "3.6.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/core-js-compat/-/core-js-compat-3.6.5.tgz",
+            "integrity": "sha1-KlHZpOJd/W5pAlGqgfmePAVIHxw=",
+            "dev": true,
+            "requires": {
+                "browserslist": "^4.8.5",
+                "semver": "7.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-7.0.0.tgz",
+                    "integrity": "sha1-XzyjV2HkfgWyBsba/yz4FPAxa44=",
+                    "dev": true
+                }
+            }
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "cosmiconfig": {
+            "version": "5.2.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+            "integrity": "sha1-BA9yaAnFked6F8CjYmykW08Wixo=",
+            "dev": true,
+            "requires": {
+                "import-fresh": "^2.0.0",
+                "is-directory": "^0.3.1",
+                "js-yaml": "^3.13.1",
+                "parse-json": "^4.0.0"
+            }
+        },
+        "coverage-istanbul-loader": {
+            "version": "2.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/coverage-istanbul-loader/-/coverage-istanbul-loader-2.0.3.tgz",
+            "integrity": "sha1-h9QvA/oP0/qHQ+x2lF2dZ/EFcio=",
+            "dev": true,
+            "requires": {
+                "convert-source-map": "^1.7.0",
+                "istanbul-lib-instrument": "^4.0.0",
+                "loader-utils": "^1.2.3",
+                "merge-source-map": "^1.1.0",
+                "schema-utils": "^2.6.1"
+            }
+        },
+        "create-ecdh": {
+            "version": "4.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/create-ecdh/-/create-ecdh-4.0.4.tgz",
+            "integrity": "sha1-1uf0v/pmc2CFoHYv06YyaE2rzE4=",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.5.3"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+                    "dev": true
+                }
+            }
+        },
+        "create-hash": {
+            "version": "1.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/create-hash/-/create-hash-1.2.0.tgz",
+            "integrity": "sha1-iJB4rxGmN1a8+1m9IhmWvjqe8ZY=",
+            "dev": true,
+            "requires": {
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "md5.js": "^1.3.4",
+                "ripemd160": "^2.0.1",
+                "sha.js": "^2.4.0"
+            }
+        },
+        "create-hmac": {
+            "version": "1.1.7",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/create-hmac/-/create-hmac-1.1.7.tgz",
+            "integrity": "sha1-aRcMeLOrlXFHsriwRXLkfq0iQ/8=",
+            "dev": true,
+            "requires": {
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
+            }
+        },
+        "cross-spawn": {
+            "version": "6.0.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+            "dev": true,
+            "requires": {
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+                    "dev": true
+                }
+            }
+        },
+        "crypto-browserify": {
+            "version": "3.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+            "integrity": "sha1-OWz58xN/A+S45TLFj2mCVOAPgOw=",
+            "dev": true,
+            "requires": {
+                "browserify-cipher": "^1.0.0",
+                "browserify-sign": "^4.0.0",
+                "create-ecdh": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.0",
+                "diffie-hellman": "^5.0.0",
+                "inherits": "^2.0.1",
+                "pbkdf2": "^3.0.3",
+                "public-encrypt": "^4.0.0",
+                "randombytes": "^2.0.0",
+                "randomfill": "^1.0.3"
+            }
+        },
+        "css-parse": {
+            "version": "1.7.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/css-parse/-/css-parse-1.7.0.tgz",
+            "integrity": "sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs=",
+            "dev": true
+        },
+        "cyclist": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cyclist/-/cyclist-1.0.1.tgz",
+            "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
+            "dev": true
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "debug": {
+            "version": "4.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-4.2.0.tgz",
+            "integrity": "sha1-fxUPk5IOlMWPVXTC/QGjEQ7/5/E=",
+            "dev": true,
+            "requires": {
+                "ms": "2.1.2"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "dev": true
+        },
+        "deep-equal": {
+            "version": "1.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/deep-equal/-/deep-equal-1.1.1.tgz",
+            "integrity": "sha1-tcmMlCzv+vfLBR4k4UNKJaLmB2o=",
+            "dev": true,
+            "requires": {
+                "is-arguments": "^1.0.4",
+                "is-date-object": "^1.0.1",
+                "is-regex": "^1.0.4",
+                "object-is": "^1.0.1",
+                "object-keys": "^1.1.1",
+                "regexp.prototype.flags": "^1.2.0"
+            }
+        },
+        "default-gateway": {
+            "version": "4.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/default-gateway/-/default-gateway-4.2.0.tgz",
+            "integrity": "sha1-FnEEx1AMIRX23WmwpTa7jtcgVSs=",
+            "dev": true,
+            "requires": {
+                "execa": "^1.0.0",
+                "ip-regex": "^2.1.0"
+            }
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
+        },
+        "define-property": {
+            "version": "2.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/define-property/-/define-property-2.0.2.tgz",
+            "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+            "dev": true,
+            "requires": {
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
+            },
+            "dependencies": {
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "del": {
+            "version": "4.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/del/-/del-4.1.1.tgz",
+            "integrity": "sha1-no8RciLqRKMf86FWwEm5kFKp8LQ=",
+            "dev": true,
+            "requires": {
+                "@types/glob": "^7.1.1",
+                "globby": "^6.1.0",
+                "is-path-cwd": "^2.0.0",
+                "is-path-in-cwd": "^2.0.0",
+                "p-map": "^2.0.0",
+                "pify": "^4.0.1",
+                "rimraf": "^2.6.3"
+            },
+            "dependencies": {
+                "array-union": {
+                    "version": "1.0.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/array-union/-/array-union-1.0.2.tgz",
+                    "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                    "dev": true,
+                    "requires": {
+                        "array-uniq": "^1.0.1"
+                    }
+                },
+                "globby": {
+                    "version": "6.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/globby/-/globby-6.1.0.tgz",
+                    "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+                    "dev": true,
+                    "requires": {
+                        "array-union": "^1.0.1",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "2.3.0",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pify/-/pify-2.3.0.tgz",
+                            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                            "dev": true
+                        }
+                    }
+                },
+                "p-map": {
+                    "version": "2.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-map/-/p-map-2.1.0.tgz",
+                    "integrity": "sha1-MQko/u+cnsxltosXaTAYpmXOoXU=",
+                    "dev": true
+                }
+            }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "depd": {
+            "version": "1.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+            "dev": true
+        },
+        "des.js": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/des.js/-/des.js-1.0.1.tgz",
+            "integrity": "sha1-U4IULhvcU/hdhtU+X0qn3rkeCEM=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "destroy": {
+            "version": "1.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/destroy/-/destroy-1.0.4.tgz",
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+            "dev": true
+        },
+        "detect-node": {
+            "version": "2.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/detect-node/-/detect-node-2.0.4.tgz",
+            "integrity": "sha1-AU7o+PZpxcWAI9pkuBecCDooxGw=",
+            "dev": true
+        },
+        "diffie-hellman": {
+            "version": "5.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+            "integrity": "sha1-QOjumPVaIUlgcUaSHGPhrl89KHU=",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+                    "dev": true
+                }
+            }
+        },
+        "dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=",
+            "dev": true,
+            "requires": {
+                "path-type": "^4.0.0"
+            }
+        },
+        "dns-equal": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/dns-equal/-/dns-equal-1.0.0.tgz",
+            "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+            "dev": true
+        },
+        "dns-packet": {
+            "version": "1.3.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/dns-packet/-/dns-packet-1.3.1.tgz",
+            "integrity": "sha1-EqpCaYEHW+UAuRDu3NC0fdfe2lo=",
+            "dev": true,
+            "requires": {
+                "ip": "^1.1.0",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "dns-txt": {
+            "version": "2.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/dns-txt/-/dns-txt-2.0.2.tgz",
+            "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
+            "dev": true,
+            "requires": {
+                "buffer-indexof": "^1.0.0"
+            }
+        },
+        "domain-browser": {
+            "version": "1.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/domain-browser/-/domain-browser-1.2.0.tgz",
+            "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
+            "dev": true
+        },
+        "duplexify": {
+            "version": "3.7.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/duplexify/-/duplexify-3.7.1.tgz",
+            "integrity": "sha1-Kk31MX9sz9kfhtb9JdjYoQO4gwk=",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
+        "ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+            "dev": true
+        },
+        "electron-to-chromium": {
+            "version": "1.3.580",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/electron-to-chromium/-/electron-to-chromium-1.3.580.tgz",
+            "integrity": "sha1-6yeHPPoBLEPFPJ6RKQOLj9fLlk8=",
+            "dev": true
+        },
+        "elliptic": {
+            "version": "6.5.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/elliptic/-/elliptic-6.5.3.tgz",
+            "integrity": "sha1-y1nrLv2vc6C9eMzXAVpirW4Pk9Y=",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+                    "dev": true
+                }
+            }
+        },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+            "dev": true
+        },
+        "emojis-list": {
+            "version": "2.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/emojis-list/-/emojis-list-2.1.0.tgz",
+            "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+            "dev": true
+        },
+        "encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+            "dev": true
+        },
+        "end-of-stream": {
+            "version": "1.4.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+            "dev": true,
+            "requires": {
+                "once": "^1.4.0"
+            }
+        },
+        "enhanced-resolve": {
+            "version": "4.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
+            "integrity": "sha1-Qcfgv9/nSsH/4eV61qXGyfN0Kn8=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "memory-fs": "^0.4.0",
+                "tapable": "^1.0.0"
+            }
+        },
+        "errno": {
+            "version": "0.1.7",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/errno/-/errno-0.1.7.tgz",
+            "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
+            "dev": true,
+            "requires": {
+                "prr": "~1.0.1"
+            }
+        },
+        "error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/error-ex/-/error-ex-1.3.2.tgz",
+            "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "es-abstract": {
+            "version": "1.18.0-next.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+            "integrity": "sha1-bjoKS9pxflAjqzuOkL7DYQjSLGg=",
+            "dev": true,
+            "requires": {
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.2.2",
+                "is-negative-zero": "^2.0.0",
+                "is-regex": "^1.1.1",
+                "object-inspect": "^1.8.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.1",
+                "string.prototype.trimend": "^1.0.1",
+                "string.prototype.trimstart": "^1.0.1"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
+        "escalade": {
+            "version": "3.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
+            "dev": true
+        },
+        "escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "eslint-scope": {
+            "version": "4.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/eslint-scope/-/eslint-scope-4.0.3.tgz",
+            "integrity": "sha1-ygODMxD2iJoyZHgaqC5j65z+eEg=",
+            "dev": true,
+            "requires": {
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
+            }
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+            "dev": true
+        },
+        "esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
+            "dev": true,
+            "requires": {
+                "estraverse": "^5.2.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.2.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
+                    "dev": true
+                }
+            }
+        },
+        "estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
+            "dev": true
+        },
+        "etag": {
+            "version": "1.8.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "dev": true
+        },
+        "eventemitter3": {
+            "version": "4.0.7",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/eventemitter3/-/eventemitter3-4.0.7.tgz",
+            "integrity": "sha1-Lem2j2Uo1WRO9cWVJqG0oHMGFp8=",
+            "dev": true
+        },
+        "events": {
+            "version": "3.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/events/-/events-3.2.0.tgz",
+            "integrity": "sha1-k7h8GPjvzUICpGGuxN/AVWtjk3k=",
+            "dev": true
+        },
+        "eventsource": {
+            "version": "1.0.7",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/eventsource/-/eventsource-1.0.7.tgz",
+            "integrity": "sha1-j7xyyT/NNAiAkLwKTmT0tc7m2NA=",
+            "dev": true,
+            "requires": {
+                "original": "^1.0.0"
+            }
+        },
+        "evp_bytestokey": {
+            "version": "1.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+            "integrity": "sha1-f8vbGY3HGVlDLv4ThCaE4FJaywI=",
+            "dev": true,
+            "requires": {
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
+            }
+        },
+        "execa": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/execa/-/execa-1.0.0.tgz",
+            "integrity": "sha1-xiNqW7TfbW8V6I5/AXeYIWdJ3dg=",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^4.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+            }
+        },
+        "expand-brackets": {
+            "version": "2.1.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/expand-brackets/-/expand-brackets-2.1.4.tgz",
+            "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+            "dev": true,
+            "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "express": {
+            "version": "4.17.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/express/-/express-4.17.1.tgz",
+            "integrity": "sha1-RJH8OGBc9R+GKdOcK10Cb5ikwTQ=",
+            "dev": true,
+            "requires": {
+                "accepts": "~1.3.7",
+                "array-flatten": "1.1.1",
+                "body-parser": "1.19.0",
+                "content-disposition": "0.5.3",
+                "content-type": "~1.0.4",
+                "cookie": "0.4.0",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "finalhandler": "~1.1.2",
+                "fresh": "0.5.2",
+                "merge-descriptors": "1.0.1",
+                "methods": "~1.1.2",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.3",
+                "path-to-regexp": "0.1.7",
+                "proxy-addr": "~2.0.5",
+                "qs": "6.7.0",
+                "range-parser": "~1.2.1",
+                "safe-buffer": "5.1.2",
+                "send": "0.17.1",
+                "serve-static": "1.14.1",
+                "setprototypeof": "1.1.1",
+                "statuses": "~1.5.0",
+                "type-is": "~1.6.18",
+                "utils-merge": "1.0.1",
+                "vary": "~1.1.2"
+            },
+            "dependencies": {
+                "array-flatten": {
+                    "version": "1.1.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/array-flatten/-/array-flatten-1.1.1.tgz",
+                    "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.7.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/qs/-/qs-6.7.0.tgz",
+                    "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
+                    "dev": true
+                }
+            }
+        },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
+            "dev": true,
+            "optional": true
+        },
+        "extend-shallow": {
+            "version": "3.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "dev": true,
+            "requires": {
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "extglob": {
+            "version": "2.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extglob/-/extglob-2.0.4.tgz",
+            "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+            "dev": true,
+            "requires": {
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
+        "fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+            "dev": true
+        },
+        "fast-glob": {
+            "version": "3.2.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fast-glob/-/fast-glob-3.2.4.tgz",
+            "integrity": "sha1-0grvv5lXk4Pn88xmUpFYybmFVNM=",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.0",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.2",
+                "picomatch": "^2.2.1"
+            }
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "dev": true
+        },
+        "fastq": {
+            "version": "1.8.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fastq/-/fastq-1.8.0.tgz",
+            "integrity": "sha1-VQ4fn1m7xl/hhctqm02VNXEH9IE=",
+            "dev": true,
+            "requires": {
+                "reusify": "^1.0.4"
+            }
+        },
+        "faye-websocket": {
+            "version": "0.10.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/faye-websocket/-/faye-websocket-0.10.0.tgz",
+            "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
+            "dev": true,
+            "requires": {
+                "websocket-driver": ">=0.5.1"
+            }
+        },
+        "figgy-pudding": {
+            "version": "3.5.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+            "integrity": "sha1-tO7oFIq7Adzx0aw0Nn1Z4S+mHW4=",
+            "dev": true
+        },
+        "file-loader": {
+            "version": "4.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/file-loader/-/file-loader-4.2.0.tgz",
+            "integrity": "sha1-X7Ek0jadcHXXCppavs0S5gqVIV4=",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^1.2.3",
+                "schema-utils": "^2.0.0"
+            }
+        },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha1-VTp7hEb/b2hDWcRF8eN6BdrMM90=",
+            "dev": true,
+            "optional": true
+        },
+        "fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+            "dev": true,
+            "requires": {
+                "to-regex-range": "^5.0.1"
+            }
+        },
+        "finalhandler": {
+            "version": "1.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/finalhandler/-/finalhandler-1.1.2.tgz",
+            "integrity": "sha1-t+fQAP/RGTjQ/bBTUG9uur6fWH0=",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.3",
+                "statuses": "~1.5.0",
+                "unpipe": "~1.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "find-cache-dir": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-cache-dir/-/find-cache-dir-3.0.0.tgz",
+            "integrity": "sha1-zUt92Xtxhbfhfb/i1uQRXuPuuPw=",
+            "dev": true,
+            "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^3.0.0",
+                "pkg-dir": "^4.1.0"
+            }
+        },
+        "find-up": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
+            "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+            "dev": true,
+            "requires": {
+                "locate-path": "^3.0.0"
+            }
+        },
+        "flush-write-stream": {
+            "version": "1.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+            "integrity": "sha1-jdfYc6G6vCB9lOrQwuDkQnbr8ug=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.3.6"
+            }
+        },
+        "follow-redirects": {
+            "version": "1.13.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/follow-redirects/-/follow-redirects-1.13.0.tgz",
+            "integrity": "sha1-tC6Nk6Kn7qXtiGM2dtZZe8jjhNs=",
+            "dev": true
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true,
+            "optional": true
+        },
+        "form-data": {
+            "version": "2.3.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            }
+        },
+        "forwarded": {
+            "version": "0.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/forwarded/-/forwarded-0.1.2.tgz",
+            "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+            "dev": true
+        },
+        "fragment-cache": {
+            "version": "0.2.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "dev": true,
+            "requires": {
+                "map-cache": "^0.2.2"
+            }
+        },
+        "fresh": {
+            "version": "0.5.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+            "dev": true
+        },
+        "from2": {
+            "version": "2.3.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/from2/-/from2-2.3.0.tgz",
+            "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
+            }
+        },
+        "fs-minipass": {
+            "version": "2.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fs-minipass/-/fs-minipass-2.1.0.tgz",
+            "integrity": "sha1-f1A2/b8SxjwWkZDL5BmchSJx+fs=",
+            "dev": true,
+            "requires": {
+                "minipass": "^3.0.0"
+            }
+        },
+        "fs-write-stream-atomic": {
+            "version": "1.0.10",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+            "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "iferr": "^0.1.5",
+                "imurmurhash": "^0.1.4",
+                "readable-stream": "1 || 2"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "fsevents": {
+            "version": "2.1.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fsevents/-/fsevents-2.1.3.tgz",
+            "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
+            "dev": true,
+            "optional": true
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+            "dev": true
+        },
+        "gensync": {
+            "version": "1.0.0-beta.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/gensync/-/gensync-1.0.0-beta.1.tgz",
+            "integrity": "sha1-WPQ2H/mH5f9uHnohCCeqNx6qwmk=",
+            "dev": true
+        },
+        "get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+            "dev": true
+        },
+        "get-stream": {
+            "version": "4.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/get-stream/-/get-stream-4.1.0.tgz",
+            "integrity": "sha1-wbJVV189wh1Zv8ec09K0axw6VLU=",
+            "dev": true,
+            "requires": {
+                "pump": "^3.0.0"
+            }
+        },
+        "get-value": {
+            "version": "2.0.6",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/get-value/-/get-value-2.0.6.tgz",
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+            "dev": true
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "glob": {
+            "version": "7.1.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/glob/-/glob-7.1.4.tgz",
+            "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "glob-parent": {
+            "version": "5.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/glob-parent/-/glob-parent-5.1.1.tgz",
+            "integrity": "sha1-tsHvQXxOVmPqSY8cRa+saRa7wik=",
+            "dev": true,
+            "requires": {
+                "is-glob": "^4.0.1"
+            }
+        },
+        "globals": {
+            "version": "11.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+            "dev": true
+        },
+        "globby": {
+            "version": "11.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/globby/-/globby-11.0.1.tgz",
+            "integrity": "sha1-mivxB6Bo8//qvEmtcCx57ejP01c=",
+            "dev": true,
+            "requires": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.1.1",
+                "ignore": "^5.1.4",
+                "merge2": "^1.3.0",
+                "slash": "^3.0.0"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.2.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/graceful-fs/-/graceful-fs-4.2.4.tgz",
+            "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs=",
+            "dev": true
+        },
+        "handle-thing": {
+            "version": "2.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/handle-thing/-/handle-thing-2.0.1.tgz",
+            "integrity": "sha1-hX95zjWVgMNA1DCBzGSJcNC7I04=",
+            "dev": true
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true,
+            "optional": true
+        },
+        "har-validator": {
+            "version": "5.1.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/har-validator/-/har-validator-5.1.5.tgz",
+            "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "ajv": "^6.12.3",
+                "har-schema": "^2.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/has/-/has-1.0.3.tgz",
+            "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "has-symbols": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=",
+            "dev": true
+        },
+        "has-value": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/has-value/-/has-value-1.0.0.tgz",
+            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "dev": true,
+            "requires": {
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
+            }
+        },
+        "has-values": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/has-values/-/has-values-1.0.0.tgz",
+            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "dev": true,
+            "requires": {
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "hash-base": {
+            "version": "3.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/hash-base/-/hash-base-3.1.0.tgz",
+            "integrity": "sha1-VcOB2eBuHSmXqIO0o/3f5/DTrzM=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.6.0",
+                "safe-buffer": "^5.2.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+                    "dev": true
+                }
+            }
+        },
+        "hash.js": {
+            "version": "1.1.7",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha1-C6vKU46NTuSg+JiNaIZlN6ADz0I=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
+            }
+        },
+        "hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "dev": true,
+            "requires": {
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
+        "hpack.js": {
+            "version": "2.1.6",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/hpack.js/-/hpack.js-2.1.6.tgz",
+            "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "obuf": "^1.0.0",
+                "readable-stream": "^2.0.1",
+                "wbuf": "^1.1.0"
+            }
+        },
+        "html-entities": {
+            "version": "1.3.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/html-entities/-/html-entities-1.3.1.tgz",
+            "integrity": "sha1-+5oaS1sUxdq6gtPjTGrk/nAaDkQ=",
+            "dev": true
+        },
+        "http-deceiver": {
+            "version": "1.2.7",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/http-deceiver/-/http-deceiver-1.2.7.tgz",
+            "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+            "dev": true
+        },
+        "http-errors": {
+            "version": "1.7.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/http-errors/-/http-errors-1.7.2.tgz",
+            "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
+            "dev": true,
+            "requires": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.1",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.0"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                }
+            }
+        },
+        "http-proxy": {
+            "version": "1.18.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/http-proxy/-/http-proxy-1.18.1.tgz",
+            "integrity": "sha1-QBVB8FNIhLv5UmAzTnL4juOXZUk=",
+            "dev": true,
+            "requires": {
+                "eventemitter3": "^4.0.0",
+                "follow-redirects": "^1.0.0",
+                "requires-port": "^1.0.0"
+            }
+        },
+        "http-proxy-middleware": {
+            "version": "0.19.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz",
+            "integrity": "sha1-GDx9xKoUeRUDBkmMIQza+WCApDo=",
+            "dev": true,
+            "requires": {
+                "http-proxy": "^1.17.0",
+                "is-glob": "^4.0.0",
+                "lodash": "^4.17.11",
+                "micromatch": "^3.1.10"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "2.1.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
+                    }
+                }
+            }
+        },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            }
+        },
+        "https-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/https-browserify/-/https-browserify-1.0.0.tgz",
+            "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+            "dev": true
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+            "dev": true,
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha1-7BaFWOlaoYH9h9N/VcMrvLZwi4Q=",
+            "dev": true
+        },
+        "iferr": {
+            "version": "0.1.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/iferr/-/iferr-0.1.5.tgz",
+            "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+            "dev": true
+        },
+        "ignore": {
+            "version": "5.1.8",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ignore/-/ignore-5.1.8.tgz",
+            "integrity": "sha1-8VCotQo0KJsz4i9YiavU2AFvDlc=",
+            "dev": true
+        },
+        "image-size": {
+            "version": "0.5.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/image-size/-/image-size-0.5.5.tgz",
+            "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
+            "dev": true,
+            "optional": true
+        },
+        "import-cwd": {
+            "version": "2.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/import-cwd/-/import-cwd-2.1.0.tgz",
+            "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
+            "dev": true,
+            "requires": {
+                "import-from": "^2.1.0"
+            }
+        },
+        "import-fresh": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/import-fresh/-/import-fresh-2.0.0.tgz",
+            "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+            "dev": true,
+            "requires": {
+                "caller-path": "^2.0.0",
+                "resolve-from": "^3.0.0"
+            }
+        },
+        "import-from": {
+            "version": "2.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/import-from/-/import-from-2.1.0.tgz",
+            "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
+            "dev": true,
+            "requires": {
+                "resolve-from": "^3.0.0"
+            }
+        },
+        "import-local": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/import-local/-/import-local-2.0.0.tgz",
+            "integrity": "sha1-VQcL44pZk88Y72236WH1vuXFoJ0=",
+            "dev": true,
+            "requires": {
+                "pkg-dir": "^3.0.0",
+                "resolve-cwd": "^2.0.0"
+            },
+            "dependencies": {
+                "pkg-dir": {
+                    "version": "3.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pkg-dir/-/pkg-dir-3.0.0.tgz",
+                    "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
+            "dev": true
+        },
+        "infer-owner": {
+            "version": "1.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/infer-owner/-/infer-owner-1.0.4.tgz",
+            "integrity": "sha1-xM78qo5RBRwqQLos6KPScpWvlGc=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+            "dev": true
+        },
+        "internal-ip": {
+            "version": "4.3.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/internal-ip/-/internal-ip-4.3.0.tgz",
+            "integrity": "sha1-hFRSuq2dLKO2nGNaE3rLmg2tCQc=",
+            "dev": true,
+            "requires": {
+                "default-gateway": "^4.2.0",
+                "ipaddr.js": "^1.9.0"
+            }
+        },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.0.0"
+            }
+        },
+        "ip": {
+            "version": "1.1.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ip/-/ip-1.1.5.tgz",
+            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
+            "dev": true
+        },
+        "ip-regex": {
+            "version": "2.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ip-regex/-/ip-regex-2.1.0.tgz",
+            "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+            "dev": true
+        },
+        "ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha1-v/OFQ+64mEglB5/zoqjmy9RngbM=",
+            "dev": true
+        },
+        "is-absolute-url": {
+            "version": "3.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+            "integrity": "sha1-lsaiK2ojkpsR6gr7GDbDatSl1pg=",
+            "dev": true
+        },
+        "is-accessor-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "is-arguments": {
+            "version": "1.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-arguments/-/is-arguments-1.0.4.tgz",
+            "integrity": "sha1-P6+WbHy6D/Q3+zH2JQCC/PBEjPM=",
+            "dev": true
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
+            "dev": true,
+            "requires": {
+                "binary-extensions": "^2.0.0"
+            }
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+            "dev": true
+        },
+        "is-callable": {
+            "version": "1.2.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-callable/-/is-callable-1.2.2.tgz",
+            "integrity": "sha1-x8ZxXNItTdtI0+GZcCI6zquwgNk=",
+            "dev": true
+        },
+        "is-data-descriptor": {
+            "version": "0.1.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "is-date-object": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-date-object/-/is-date-object-1.0.2.tgz",
+            "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4=",
+            "dev": true
+        },
+        "is-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-descriptor/-/is-descriptor-0.1.6.tgz",
+            "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+            "dev": true,
+            "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0=",
+                    "dev": true
+                }
+            }
+        },
+        "is-directory": {
+            "version": "0.3.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-directory/-/is-directory-0.3.1.tgz",
+            "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+            "dev": true
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "4.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-glob/-/is-glob-4.0.1.tgz",
+            "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^2.1.1"
+            }
+        },
+        "is-negative-zero": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+            "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+            "dev": true
+        },
+        "is-number": {
+            "version": "7.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+            "dev": true
+        },
+        "is-path-cwd": {
+            "version": "2.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+            "integrity": "sha1-Z9Q7gmZKe1GR/ZEZEn6zAASKn9s=",
+            "dev": true
+        },
+        "is-path-in-cwd": {
+            "version": "2.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+            "integrity": "sha1-v+Lcomxp85cmWkAJljYCk1oFOss=",
+            "dev": true,
+            "requires": {
+                "is-path-inside": "^2.1.0"
+            }
+        },
+        "is-path-inside": {
+            "version": "2.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-path-inside/-/is-path-inside-2.1.0.tgz",
+            "integrity": "sha1-fJgQWH1lmkDSe8201WFuqwWUlLI=",
+            "dev": true,
+            "requires": {
+                "path-is-inside": "^1.0.2"
+            }
+        },
+        "is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+            "dev": true
+        },
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.1"
+            }
+        },
+        "is-regex": {
+            "version": "1.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-regex/-/is-regex-1.1.1.tgz",
+            "integrity": "sha1-xvmKrMVG9s7FRooHt7FTq1ZKV7k=",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.1"
+            }
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
+        },
+        "is-symbol": {
+            "version": "1.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-symbol/-/is-symbol-1.0.3.tgz",
+            "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.1"
+            }
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true,
+            "optional": true
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
+            "dev": true
+        },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "isobject": {
+            "version": "3.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+            "dev": true
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true,
+            "optional": true
+        },
+        "istanbul-lib-coverage": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+            "integrity": "sha1-9ZRKN8cLVQsCp4pcOyBVsoDOyOw=",
+            "dev": true
+        },
+        "istanbul-lib-instrument": {
+            "version": "4.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+            "integrity": "sha1-hzxv/4l0UBGCIndGlqPyiQLXfB0=",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.7.5",
+                "@istanbuljs/schema": "^0.1.2",
+                "istanbul-lib-coverage": "^3.0.0",
+                "semver": "^6.3.0"
+            }
+        },
+        "jest-worker": {
+            "version": "24.9.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/jest-worker/-/jest-worker-24.9.0.tgz",
+            "integrity": "sha1-Xb/bWy0yLphWeJgjipaXvM5ns+U=",
+            "dev": true,
+            "requires": {
+                "merge-stream": "^2.0.0",
+                "supports-color": "^6.1.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.14.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/js-yaml/-/js-yaml-3.14.0.tgz",
+            "integrity": "sha1-p6NBcPJqIbsWJCTYray0ETpp5II=",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true
+        },
+        "jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+            "dev": true
+        },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+            "dev": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true,
+            "optional": true
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+            "dev": true
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true,
+            "optional": true
+        },
+        "json3": {
+            "version": "3.3.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/json3/-/json3-3.3.3.tgz",
+            "integrity": "sha1-f8EON1/FrkLEcFpcwKpvYr4wW4E=",
+            "dev": true
+        },
+        "json5": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/json5/-/json5-1.0.1.tgz",
+            "integrity": "sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.0"
+            }
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "karma-source-map-support": {
+            "version": "1.4.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/karma-source-map-support/-/karma-source-map-support-1.4.0.tgz",
+            "integrity": "sha1-WFJs7M9+hzDlbv/Zek3o1xKsDWs=",
+            "dev": true,
+            "requires": {
+                "source-map-support": "^0.5.5"
+            }
+        },
+        "killable": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/killable/-/killable-1.0.1.tgz",
+            "integrity": "sha1-TIzkQRh6Bhx0dPuHygjipjgZSJI=",
+            "dev": true
+        },
+        "kind-of": {
+            "version": "6.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
+            "dev": true
+        },
+        "less": {
+            "version": "3.9.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/less/-/less-3.9.0.tgz",
+            "integrity": "sha1-t1EcQ/N89X3Iff/ZiD7BISibFHQ=",
+            "dev": true,
+            "requires": {
+                "clone": "^2.1.2",
+                "errno": "^0.1.1",
+                "graceful-fs": "^4.1.2",
+                "image-size": "~0.5.0",
+                "mime": "^1.4.1",
+                "mkdirp": "^0.5.0",
+                "promise": "^7.1.1",
+                "request": "^2.83.0",
+                "source-map": "~0.6.0"
+            }
+        },
+        "less-loader": {
+            "version": "5.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/less-loader/-/less-loader-5.0.0.tgz",
+            "integrity": "sha1-SY3eOmxsT4h0WO6e0/CGoSrRtGY=",
+            "dev": true,
+            "requires": {
+                "clone": "^2.1.1",
+                "loader-utils": "^1.1.0",
+                "pify": "^4.0.1"
+            }
+        },
+        "leven": {
+            "version": "3.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/leven/-/leven-3.1.0.tgz",
+            "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=",
+            "dev": true
+        },
+        "levenary": {
+            "version": "1.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/levenary/-/levenary-1.1.1.tgz",
+            "integrity": "sha1-hCqe6Y0gdap/ru2+MmeekgX0b3c=",
+            "dev": true,
+            "requires": {
+                "leven": "^3.1.0"
+            }
+        },
+        "license-webpack-plugin": {
+            "version": "2.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/license-webpack-plugin/-/license-webpack-plugin-2.1.2.tgz",
+            "integrity": "sha1-Y/fFcVN6RQ7EfcmPXV/9vKezsU8=",
+            "dev": true,
+            "requires": {
+                "@types/webpack-sources": "^0.1.5",
+                "webpack-sources": "^1.2.0"
+            }
+        },
+        "loader-runner": {
+            "version": "2.4.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/loader-runner/-/loader-runner-2.4.0.tgz",
+            "integrity": "sha1-7UcGa/5TTX6ExMe5mYwqdWB9k1c=",
+            "dev": true
+        },
+        "loader-utils": {
+            "version": "1.2.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/loader-utils/-/loader-utils-1.2.3.tgz",
+            "integrity": "sha1-H/XcaRHJ8KBiUxpMBLYJQGEIwsc=",
+            "dev": true,
+            "requires": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^2.0.0",
+                "json5": "^1.0.1"
+            }
+        },
+        "locate-path": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+            "dev": true,
+            "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+            }
+        },
+        "lodash": {
+            "version": "4.17.20",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/lodash/-/lodash-4.17.20.tgz",
+            "integrity": "sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI=",
+            "dev": true
+        },
+        "lodash.clonedeep": {
+            "version": "4.5.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+            "dev": true
+        },
+        "loglevel": {
+            "version": "1.7.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/loglevel/-/loglevel-1.7.0.tgz",
+            "integrity": "sha1-coFmhVp0DVnTjbAc9G8ELKoEG7A=",
+            "dev": true
+        },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
+            "dev": true,
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
+        },
+        "lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/lru-cache/-/lru-cache-5.1.1.tgz",
+            "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
+            "dev": true,
+            "requires": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "magic-string": {
+            "version": "0.25.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/magic-string/-/magic-string-0.25.3.tgz",
+            "integrity": "sha1-NLjSosf+ydm9+ZKaP9gdJx7zW+k=",
+            "dev": true,
+            "requires": {
+                "sourcemap-codec": "^1.4.4"
+            }
+        },
+        "make-dir": {
+            "version": "3.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
+            "dev": true,
+            "requires": {
+                "semver": "^6.0.0"
+            }
+        },
+        "mamacro": {
+            "version": "0.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mamacro/-/mamacro-0.0.3.tgz",
+            "integrity": "sha1-rSyVdhl8nxq/MI0Hh4Zb2XWj8+Q=",
+            "dev": true
+        },
+        "map-cache": {
+            "version": "0.2.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/map-cache/-/map-cache-0.2.2.tgz",
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+            "dev": true
+        },
+        "map-visit": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/map-visit/-/map-visit-1.0.0.tgz",
+            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "dev": true,
+            "requires": {
+                "object-visit": "^1.0.0"
+            }
+        },
+        "md5.js": {
+            "version": "1.3.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/md5.js/-/md5.js-1.3.5.tgz",
+            "integrity": "sha1-tdB7jjIW4+J81yjXL3DR5qNCAF8=",
+            "dev": true,
+            "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "media-typer": {
+            "version": "0.3.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+            "dev": true
+        },
+        "memory-fs": {
+            "version": "0.4.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/memory-fs/-/memory-fs-0.4.1.tgz",
+            "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+            "dev": true,
+            "requires": {
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
+            }
+        },
+        "merge-descriptors": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+            "dev": true
+        },
+        "merge-source-map": {
+            "version": "1.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/merge-source-map/-/merge-source-map-1.1.0.tgz",
+            "integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
+            "dev": true,
+            "requires": {
+                "source-map": "^0.6.1"
+            }
+        },
+        "merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+            "dev": true
+        },
+        "merge2": {
+            "version": "1.4.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha1-Q2iJL4hekHRVpv19xVwMnUBJkK4=",
+            "dev": true
+        },
+        "methods": {
+            "version": "1.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/methods/-/methods-1.1.2.tgz",
+            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+            "dev": true
+        },
+        "micromatch": {
+            "version": "4.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/micromatch/-/micromatch-4.0.2.tgz",
+            "integrity": "sha1-T8sJmb+fvC/L3SEvbWKbmlbDklk=",
+            "dev": true,
+            "requires": {
+                "braces": "^3.0.1",
+                "picomatch": "^2.0.5"
+            }
+        },
+        "miller-rabin": {
+            "version": "4.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/miller-rabin/-/miller-rabin-4.0.1.tgz",
+            "integrity": "sha1-8IA1HIZbDcViqEYpZtqlNUPHik0=",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+                    "dev": true
+                }
+            }
+        },
+        "mime": {
+            "version": "1.6.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE=",
+            "dev": true
+        },
+        "mime-db": {
+            "version": "1.44.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mime-db/-/mime-db-1.44.0.tgz",
+            "integrity": "sha1-+hHF6wrKEzS0Izy01S8QxaYnL5I=",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.27",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mime-types/-/mime-types-2.1.27.tgz",
+            "integrity": "sha1-R5SfmOJ56lMRn1ci4PNOUpvsAJ8=",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.44.0"
+            }
+        },
+        "mini-css-extract-plugin": {
+            "version": "0.8.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.0.tgz",
+            "integrity": "sha1-gdQexP5YxxOpatfHI82y0L1NcOE=",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^1.1.0",
+                "normalize-url": "1.9.1",
+                "schema-utils": "^1.0.0",
+                "webpack-sources": "^1.1.0"
+            },
+            "dependencies": {
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                }
+            }
+        },
+        "minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha1-LhlN4ERibUoQ5/f7wAznPoPk1cc=",
+            "dev": true
+        },
+        "minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
+            "dev": true
+        },
+        "minipass": {
+            "version": "3.1.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/minipass/-/minipass-3.1.3.tgz",
+            "integrity": "sha1-fUL/HzljVILhX5zbUxhN7r1YFf0=",
+            "dev": true,
+            "requires": {
+                "yallist": "^4.0.0"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
+                    "dev": true
+                }
+            }
+        },
+        "minipass-collect": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/minipass-collect/-/minipass-collect-1.0.2.tgz",
+            "integrity": "sha1-IrgTv3Rdxu26JXa5QAIq1u3Ixhc=",
+            "dev": true,
+            "requires": {
+                "minipass": "^3.0.0"
+            }
+        },
+        "minipass-flush": {
+            "version": "1.0.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/minipass-flush/-/minipass-flush-1.0.5.tgz",
+            "integrity": "sha1-gucTXX6JpQ/+ZGEKeHlTxMTLs3M=",
+            "dev": true,
+            "requires": {
+                "minipass": "^3.0.0"
+            }
+        },
+        "minipass-pipeline": {
+            "version": "1.2.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+            "integrity": "sha1-aEcveXEcCEZXwGfFxq2Tzd6oIUw=",
+            "dev": true,
+            "requires": {
+                "minipass": "^3.0.0"
+            }
+        },
+        "minizlib": {
+            "version": "2.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/minizlib/-/minizlib-2.1.2.tgz",
+            "integrity": "sha1-6Q00Zrogm5MkUVCKEc49NjIUWTE=",
+            "dev": true,
+            "requires": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
+                    "dev": true
+                }
+            }
+        },
+        "mississippi": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mississippi/-/mississippi-3.0.0.tgz",
+            "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
+            "dev": true,
+            "requires": {
+                "concat-stream": "^1.5.0",
+                "duplexify": "^3.4.2",
+                "end-of-stream": "^1.1.0",
+                "flush-write-stream": "^1.0.0",
+                "from2": "^2.1.0",
+                "parallel-transform": "^1.1.0",
+                "pump": "^3.0.0",
+                "pumpify": "^1.3.3",
+                "stream-each": "^1.1.0",
+                "through2": "^2.0.0"
+            }
+        },
+        "mixin-deep": {
+            "version": "1.3.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mixin-deep/-/mixin-deep-1.3.2.tgz",
+            "integrity": "sha1-ESC0PcNZp4Xc5ltVuC4lfM9HlWY=",
+            "dev": true,
+            "requires": {
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "mkdirp": {
+            "version": "0.5.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.5"
+            }
+        },
+        "move-concurrently": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/move-concurrently/-/move-concurrently-1.0.1.tgz",
+            "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+            "dev": true,
+            "requires": {
+                "aproba": "^1.1.1",
+                "copy-concurrently": "^1.0.0",
+                "fs-write-stream-atomic": "^1.0.8",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.3"
+            }
+        },
+        "ms": {
+            "version": "2.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+            "dev": true
+        },
+        "multicast-dns": {
+            "version": "6.2.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/multicast-dns/-/multicast-dns-6.2.3.tgz",
+            "integrity": "sha1-oOx72QVcQoL3kMPIL04o2zsxsik=",
+            "dev": true,
+            "requires": {
+                "dns-packet": "^1.3.1",
+                "thunky": "^1.0.2"
+            }
+        },
+        "multicast-dns-service-types": {
+            "version": "1.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
+            "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
+            "dev": true
+        },
+        "nan": {
+            "version": "2.14.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/nan/-/nan-2.14.2.tgz",
+            "integrity": "sha1-9TdkAGlRaPTMaUrJOT0MlYXu6hk=",
+            "dev": true,
+            "optional": true
+        },
+        "nanomatch": {
+            "version": "1.2.13",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/nanomatch/-/nanomatch-1.2.13.tgz",
+            "integrity": "sha1-uHqKpPwN6P5r6IiVs4mD/yZb0Rk=",
+            "dev": true,
+            "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            }
+        },
+        "negotiator": {
+            "version": "0.6.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/negotiator/-/negotiator-0.6.2.tgz",
+            "integrity": "sha1-/qz3zPUlp3rpY0Q2pkiD/+yjRvs=",
+            "dev": true
+        },
+        "neo-async": {
+            "version": "2.6.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/neo-async/-/neo-async-2.6.2.tgz",
+            "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
+            "dev": true
+        },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+            "dev": true
+        },
+        "node-forge": {
+            "version": "0.10.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/node-forge/-/node-forge-0.10.0.tgz",
+            "integrity": "sha1-Mt6ir7Ppkm8C7lzoeUkCaRpna/M=",
+            "dev": true
+        },
+        "node-libs-browser": {
+            "version": "2.2.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+            "integrity": "sha1-tk9RPRgzhiX5A0bSew0jXmMfZCU=",
+            "dev": true,
+            "requires": {
+                "assert": "^1.1.1",
+                "browserify-zlib": "^0.2.0",
+                "buffer": "^4.3.0",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "^1.0.0",
+                "crypto-browserify": "^3.11.0",
+                "domain-browser": "^1.1.1",
+                "events": "^3.0.0",
+                "https-browserify": "^1.0.0",
+                "os-browserify": "^0.3.0",
+                "path-browserify": "0.0.1",
+                "process": "^0.11.10",
+                "punycode": "^1.2.4",
+                "querystring-es3": "^0.2.0",
+                "readable-stream": "^2.3.3",
+                "stream-browserify": "^2.0.1",
+                "stream-http": "^2.7.2",
+                "string_decoder": "^1.0.0",
+                "timers-browserify": "^2.0.4",
+                "tty-browserify": "0.0.0",
+                "url": "^0.11.0",
+                "util": "^0.11.0",
+                "vm-browserify": "^1.0.1"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                }
+            }
+        },
+        "node-releases": {
+            "version": "1.1.63",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/node-releases/-/node-releases-1.1.63.tgz",
+            "integrity": "sha1-2227OIVEwx6IghYwTo/RcO/uP/U=",
+            "dev": true
+        },
+        "normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+            "dev": true
+        },
+        "normalize-range": {
+            "version": "0.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/normalize-range/-/normalize-range-0.1.2.tgz",
+            "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
+            "dev": true
+        },
+        "normalize-url": {
+            "version": "1.9.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/normalize-url/-/normalize-url-1.9.1.tgz",
+            "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.0.1",
+                "prepend-http": "^1.0.0",
+                "query-string": "^4.1.0",
+                "sort-keys": "^1.0.0"
+            }
+        },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true,
+            "requires": {
+                "path-key": "^2.0.0"
+            }
+        },
+        "num2fraction": {
+            "version": "1.2.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/num2fraction/-/num2fraction-1.2.2.tgz",
+            "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
+            "dev": true
+        },
+        "oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
+            "dev": true,
+            "optional": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "object-copy": {
+            "version": "0.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/object-copy/-/object-copy-0.1.0.tgz",
+            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "dev": true,
+            "requires": {
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "object-inspect": {
+            "version": "1.8.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/object-inspect/-/object-inspect-1.8.0.tgz",
+            "integrity": "sha1-34B+Xs9TpgnMa/6T6sPMe+WzqdA=",
+            "dev": true
+        },
+        "object-is": {
+            "version": "1.1.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/object-is/-/object-is-1.1.3.tgz",
+            "integrity": "sha1-LjueZVYBN0Ve471irsTZCi6hzIE=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.18.0-next.1"
+            }
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
+            "dev": true
+        },
+        "object-visit": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/object-visit/-/object-visit-1.0.1.tgz",
+            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.0"
+            }
+        },
+        "object.assign": {
+            "version": "4.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/object.assign/-/object.assign-4.1.1.tgz",
+            "integrity": "sha1-MDhnpmbN1Bk27N7fsfjz4ypHjN0=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.18.0-next.0",
+                "has-symbols": "^1.0.1",
+                "object-keys": "^1.1.1"
+            }
+        },
+        "object.pick": {
+            "version": "1.3.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/object.pick/-/object.pick-1.3.0.tgz",
+            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.1"
+            }
+        },
+        "obuf": {
+            "version": "1.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/obuf/-/obuf-1.1.2.tgz",
+            "integrity": "sha1-Cb6jND1BhZ69RGKS0RydTbYZCE4=",
+            "dev": true
+        },
+        "on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "dev": true,
+            "requires": {
+                "ee-first": "1.1.1"
+            }
+        },
+        "on-headers": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/on-headers/-/on-headers-1.0.2.tgz",
+            "integrity": "sha1-dysK5qqlJcOZ5Imt+tkMQD6zwo8=",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "open": {
+            "version": "6.4.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/open/-/open-6.4.0.tgz",
+            "integrity": "sha1-XBPpbQ3IlGhhZPGJZez+iJ7PyKk=",
+            "dev": true,
+            "requires": {
+                "is-wsl": "^1.1.0"
+            }
+        },
+        "opn": {
+            "version": "5.5.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/opn/-/opn-5.5.0.tgz",
+            "integrity": "sha1-/HFk+rVtI1kExRw7J9pnWMo7m/w=",
+            "dev": true,
+            "requires": {
+                "is-wsl": "^1.1.0"
+            }
+        },
+        "original": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/original/-/original-1.0.2.tgz",
+            "integrity": "sha1-5EKmHP/hxf0gpl8yYcJmY7MD8l8=",
+            "dev": true,
+            "requires": {
+                "url-parse": "^1.4.3"
+            }
+        },
+        "os-browserify": {
+            "version": "0.3.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/os-browserify/-/os-browserify-0.3.0.tgz",
+            "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+            "dev": true
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+            "dev": true,
+            "requires": {
+                "p-try": "^2.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+            "dev": true,
+            "requires": {
+                "p-limit": "^2.0.0"
+            }
+        },
+        "p-map": {
+            "version": "4.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-map/-/p-map-4.0.0.tgz",
+            "integrity": "sha1-uy+Vpe2i7BaOySdOBqdHw+KQTSs=",
+            "dev": true,
+            "requires": {
+                "aggregate-error": "^3.0.0"
+            }
+        },
+        "p-retry": {
+            "version": "3.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-retry/-/p-retry-3.0.1.tgz",
+            "integrity": "sha1-MWtMiJPiyNwc+okfQGxLQivr8yg=",
+            "dev": true,
+            "requires": {
+                "retry": "^0.12.0"
+            }
+        },
+        "p-try": {
+            "version": "2.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+            "dev": true
+        },
+        "pako": {
+            "version": "1.0.11",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
+            "dev": true
+        },
+        "parallel-transform": {
+            "version": "1.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/parallel-transform/-/parallel-transform-1.2.0.tgz",
+            "integrity": "sha1-kEnKN9bLIYLDsdLHIL6U0UpYFPw=",
+            "dev": true,
+            "requires": {
+                "cyclist": "^1.0.1",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.1.5"
+            }
+        },
+        "parse-asn1": {
+            "version": "5.1.6",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/parse-asn1/-/parse-asn1-5.1.6.tgz",
+            "integrity": "sha1-OFCAo+wTy2KmLTlAnLPoiETNrtQ=",
+            "dev": true,
+            "requires": {
+                "asn1.js": "^5.2.0",
+                "browserify-aes": "^1.0.0",
+                "evp_bytestokey": "^1.0.0",
+                "pbkdf2": "^3.0.3",
+                "safe-buffer": "^5.1.1"
+            }
+        },
+        "parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "dev": true,
+            "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+            }
+        },
+        "parse5": {
+            "version": "4.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/parse5/-/parse5-4.0.0.tgz",
+            "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
+            "dev": true
+        },
+        "parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ=",
+            "dev": true
+        },
+        "pascalcase": {
+            "version": "0.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pascalcase/-/pascalcase-0.1.1.tgz",
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+            "dev": true
+        },
+        "path-browserify": {
+            "version": "0.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/path-browserify/-/path-browserify-0.0.1.tgz",
+            "integrity": "sha1-5sTd1+06onxoogzE5Q4aTug7vEo=",
+            "dev": true
+        },
+        "path-dirname": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/path-dirname/-/path-dirname-1.0.2.tgz",
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+            "dev": true
+        },
+        "path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+            "dev": true
+        },
+        "path-to-regexp": {
+            "version": "0.1.7",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+            "dev": true
+        },
+        "path-type": {
+            "version": "4.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
+            "dev": true
+        },
+        "pbkdf2": {
+            "version": "3.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pbkdf2/-/pbkdf2-3.1.1.tgz",
+            "integrity": "sha1-y4cksPramEWWhW0abrr9NYRlS5Q=",
+            "dev": true,
+            "requires": {
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4",
+                "ripemd160": "^2.0.1",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
+            }
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true,
+            "optional": true
+        },
+        "picomatch": {
+            "version": "2.2.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/picomatch/-/picomatch-2.2.2.tgz",
+            "integrity": "sha1-IfMz6ba46v8CRo9RRupAbTRfTa0=",
+            "dev": true
+        },
+        "pify": {
+            "version": "4.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pify/-/pify-4.0.1.tgz",
+            "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
+            "requires": {
+                "pinkie": "^2.0.0"
+            }
+        },
+        "pkg-dir": {
+            "version": "4.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
+            "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
+            "dev": true,
+            "requires": {
+                "find-up": "^4.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+                    "dev": true
+                }
+            }
+        },
+        "pkg-up": {
+            "version": "3.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pkg-up/-/pkg-up-3.1.0.tgz",
+            "integrity": "sha1-EA7CNcwVDk/UJRlBJZaihRKg3vU=",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0"
+            }
+        },
+        "portfinder": {
+            "version": "1.0.28",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/portfinder/-/portfinder-1.0.28.tgz",
+            "integrity": "sha1-Z8RiKFK9U3TdHdkA93n1NGL6x3g=",
+            "dev": true,
+            "requires": {
+                "async": "^2.6.2",
+                "debug": "^3.1.1",
+                "mkdirp": "^0.5.5"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
+            }
+        },
+        "posix-character-classes": {
+            "version": "0.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+            "dev": true
+        },
+        "postcss": {
+            "version": "7.0.17",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/postcss/-/postcss-7.0.17.tgz",
+            "integrity": "sha1-TaG9/1Mi1KCsqrTYfz54JDa60x8=",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.2",
+                "source-map": "^0.6.1",
+                "supports-color": "^6.1.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "postcss-import": {
+            "version": "12.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/postcss-import/-/postcss-import-12.0.1.tgz",
+            "integrity": "sha1-z4x6sLXMq1ZJAkU25WX4QZKLcVM=",
+            "dev": true,
+            "requires": {
+                "postcss": "^7.0.1",
+                "postcss-value-parser": "^3.2.3",
+                "read-cache": "^1.0.0",
+                "resolve": "^1.1.7"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+                    "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-load-config": {
+            "version": "2.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/postcss-load-config/-/postcss-load-config-2.1.2.tgz",
+            "integrity": "sha1-xepQTyxK7zPHNZo03jVzdyrXUCo=",
+            "dev": true,
+            "requires": {
+                "cosmiconfig": "^5.0.0",
+                "import-cwd": "^2.0.0"
+            }
+        },
+        "postcss-loader": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/postcss-loader/-/postcss-loader-3.0.0.tgz",
+            "integrity": "sha1-a5eUPkfHLYRfqeA/Jzdz1OjdbC0=",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^1.1.0",
+                "postcss": "^7.0.0",
+                "postcss-load-config": "^2.0.0",
+                "schema-utils": "^1.0.0"
+            },
+            "dependencies": {
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                }
+            }
+        },
+        "postcss-value-parser": {
+            "version": "4.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+            "integrity": "sha1-RD9qIM7WSBor2k+oUypuVdeJoss=",
+            "dev": true
+        },
+        "prepend-http": {
+            "version": "1.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/prepend-http/-/prepend-http-1.0.4.tgz",
+            "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+            "dev": true
+        },
+        "process": {
+            "version": "0.11.10",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/process/-/process-0.11.10.tgz",
+            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
+            "dev": true
+        },
+        "promise": {
+            "version": "7.3.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/promise/-/promise-7.3.1.tgz",
+            "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "asap": "~2.0.3"
+            }
+        },
+        "promise-inflight": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/promise-inflight/-/promise-inflight-1.0.1.tgz",
+            "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+            "dev": true
+        },
+        "proxy-addr": {
+            "version": "2.0.6",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/proxy-addr/-/proxy-addr-2.0.6.tgz",
+            "integrity": "sha1-/cIzZQVEfT8vLGOO0nLK9hS7sr8=",
+            "dev": true,
+            "requires": {
+                "forwarded": "~0.1.2",
+                "ipaddr.js": "1.9.1"
+            }
+        },
+        "prr": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/prr/-/prr-1.0.1.tgz",
+            "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+            "dev": true
+        },
+        "psl": {
+            "version": "1.8.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/psl/-/psl-1.8.0.tgz",
+            "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ=",
+            "dev": true,
+            "optional": true
+        },
+        "public-encrypt": {
+            "version": "4.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/public-encrypt/-/public-encrypt-4.0.3.tgz",
+            "integrity": "sha1-T8ydd6B+SLp1J+fL4N4z0HATMeA=",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
+                    "dev": true
+                }
+            }
+        },
+        "pump": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pump/-/pump-3.0.0.tgz",
+            "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "pumpify": {
+            "version": "1.5.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pumpify/-/pumpify-1.5.1.tgz",
+            "integrity": "sha1-NlE74karJ1cLGjdKXOJ4v9dDcM4=",
+            "dev": true,
+            "requires": {
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
+            },
+            "dependencies": {
+                "pump": {
+                    "version": "2.0.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pump/-/pump-2.0.1.tgz",
+                    "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                }
+            }
+        },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/punycode/-/punycode-2.1.1.tgz",
+            "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.5.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
+            "dev": true,
+            "optional": true
+        },
+        "query-string": {
+            "version": "4.3.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/query-string/-/query-string-4.3.4.tgz",
+            "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
+            }
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "dev": true
+        },
+        "querystring-es3": {
+            "version": "0.2.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/querystring-es3/-/querystring-es3-0.2.1.tgz",
+            "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+            "dev": true
+        },
+        "querystringify": {
+            "version": "2.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/querystringify/-/querystringify-2.2.0.tgz",
+            "integrity": "sha1-M0WUG0FTy50ILY7uTNogFqmu9/Y=",
+            "dev": true
+        },
+        "randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha1-32+ENy8CcNxlzfYpE0mrekc9Tyo=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "randomfill": {
+            "version": "1.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/randomfill/-/randomfill-1.0.4.tgz",
+            "integrity": "sha1-ySGW/IarQr6YPxvzF3giSTHWFFg=",
+            "dev": true,
+            "requires": {
+                "randombytes": "^2.0.5",
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE=",
+            "dev": true
+        },
+        "raw-body": {
+            "version": "2.4.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/raw-body/-/raw-body-2.4.0.tgz",
+            "integrity": "sha1-oc5vucm8NWylLoklarWQWeE9AzI=",
+            "dev": true,
+            "requires": {
+                "bytes": "3.1.0",
+                "http-errors": "1.7.2",
+                "iconv-lite": "0.4.24",
+                "unpipe": "1.0.0"
+            },
+            "dependencies": {
+                "bytes": {
+                    "version": "3.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bytes/-/bytes-3.1.0.tgz",
+                    "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY=",
+                    "dev": true
+                }
+            }
+        },
+        "raw-loader": {
+            "version": "3.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/raw-loader/-/raw-loader-3.1.0.tgz",
+            "integrity": "sha1-Xp05mloiLMDeGPQsO8XklndTKz8=",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^1.1.0",
+                "schema-utils": "^2.0.1"
+            }
+        },
+        "read-cache": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/read-cache/-/read-cache-1.0.0.tgz",
+            "integrity": "sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=",
+            "dev": true,
+            "requires": {
+                "pify": "^2.3.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
+            "dev": true,
+            "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "readdirp": {
+            "version": "3.5.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readdirp/-/readdirp-3.5.0.tgz",
+            "integrity": "sha1-m6dMAZsV02UnjS6Ru4xI17TULJ4=",
+            "dev": true,
+            "requires": {
+                "picomatch": "^2.2.1"
+            }
+        },
+        "regenerate": {
+            "version": "1.4.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regenerate/-/regenerate-1.4.1.tgz",
+            "integrity": "sha1-ytkq2Oa1kXc0hfvgWkhcr09Ffm8=",
+            "dev": true
+        },
+        "regenerate-unicode-properties": {
+            "version": "8.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+            "integrity": "sha1-5d5xEdZV57pgwFfb6f83yH5lzew=",
+            "dev": true,
+            "requires": {
+                "regenerate": "^1.4.0"
+            }
+        },
+        "regenerator-runtime": {
+            "version": "0.13.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+            "integrity": "sha1-fPanfY9cb2Drc8X8GVWyzrAea/U=",
+            "dev": true
+        },
+        "regenerator-transform": {
+            "version": "0.14.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+            "integrity": "sha1-yY2hVGg2ccnE3LFuznNlF+G3/rQ=",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.8.4"
+            }
+        },
+        "regex-not": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "regexp.prototype.flags": {
+            "version": "1.3.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+            "integrity": "sha1-erqJs8E6ZFCdq888qNn7ub31y3U=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha1-pN5hsvZpifx0IWdsHLl4dXOs5Uw=",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "regexpu-core": {
+            "version": "4.7.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regexpu-core/-/regexpu-core-4.7.1.tgz",
+            "integrity": "sha1-LepamgcjMpj78NuR+pq8TG4PitY=",
+            "dev": true,
+            "requires": {
+                "regenerate": "^1.4.0",
+                "regenerate-unicode-properties": "^8.2.0",
+                "regjsgen": "^0.5.1",
+                "regjsparser": "^0.6.4",
+                "unicode-match-property-ecmascript": "^1.0.4",
+                "unicode-match-property-value-ecmascript": "^1.2.0"
+            }
+        },
+        "regjsgen": {
+            "version": "0.5.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regjsgen/-/regjsgen-0.5.2.tgz",
+            "integrity": "sha1-kv8pX7He7L9uzaslQ9IH6RqjNzM=",
+            "dev": true
+        },
+        "regjsparser": {
+            "version": "0.6.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regjsparser/-/regjsparser-0.6.4.tgz",
+            "integrity": "sha1-p2n4aEMIQBpm6bUp0kNv9NBmYnI=",
+            "dev": true,
+            "requires": {
+                "jsesc": "~0.5.0"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                    "dev": true
+                }
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
+        },
+        "repeat-element": {
+            "version": "1.1.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/repeat-element/-/repeat-element-1.1.3.tgz",
+            "integrity": "sha1-eC4NglwMWjuzlzH4Tv7mt0Lmsc4=",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
+        "request": {
+            "version": "2.88.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/request/-/request-2.88.2.tgz",
+            "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.5.0",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
+            "dev": true
+        },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.17.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/resolve/-/resolve-1.17.0.tgz",
+            "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
+            "dev": true,
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
+        },
+        "resolve-cwd": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+            "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+            "dev": true,
+            "requires": {
+                "resolve-from": "^3.0.0"
+            }
+        },
+        "resolve-from": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/resolve-from/-/resolve-from-3.0.0.tgz",
+            "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+            "dev": true
+        },
+        "resolve-url": {
+            "version": "0.2.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/resolve-url/-/resolve-url-0.2.1.tgz",
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+            "dev": true
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
+            "dev": true
+        },
+        "retry": {
+            "version": "0.12.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+            "dev": true
+        },
+        "reusify": {
+            "version": "1.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/reusify/-/reusify-1.0.4.tgz",
+            "integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=",
+            "dev": true
+        },
+        "rimraf": {
+            "version": "2.7.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/rimraf/-/rimraf-2.7.1.tgz",
+            "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
+        "ripemd160": {
+            "version": "2.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ripemd160/-/ripemd160-2.0.2.tgz",
+            "integrity": "sha1-ocGm9iR1FXe6XQeRTLyShQWFiQw=",
+            "dev": true,
+            "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
+            }
+        },
+        "run-parallel": {
+            "version": "1.1.9",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/run-parallel/-/run-parallel-1.1.9.tgz",
+            "integrity": "sha1-yd06fPn0ssS2JE4XOm7YZuYd1nk=",
+            "dev": true
+        },
+        "run-queue": {
+            "version": "1.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/run-queue/-/run-queue-1.0.3.tgz",
+            "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+            "dev": true,
+            "requires": {
+                "aproba": "^1.1.1"
+            }
+        },
+        "rxjs": {
+            "version": "6.4.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/rxjs/-/rxjs-6.4.0.tgz",
+            "integrity": "sha1-87sP572n+2nerAwW8XtQsLh5BQQ=",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.9.0"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+            "dev": true
+        },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "dev": true,
+            "requires": {
+                "ret": "~0.1.10"
+            }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+            "dev": true
+        },
+        "sass": {
+            "version": "1.22.9",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sass/-/sass-1.22.9.tgz",
+            "integrity": "sha1-QaLtYDgCf1i+K9UEEpNFKinCy4Q=",
+            "dev": true,
+            "requires": {
+                "chokidar": ">=2.0.0 <4.0.0"
+            }
+        },
+        "sass-loader": {
+            "version": "7.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sass-loader/-/sass-loader-7.2.0.tgz",
+            "integrity": "sha1-40EVI5MJ0VslJ8titd/vtiqW/38=",
+            "dev": true,
+            "requires": {
+                "clone-deep": "^4.0.1",
+                "loader-utils": "^1.0.1",
+                "neo-async": "^2.5.0",
+                "pify": "^4.0.1",
+                "semver": "^5.5.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+                    "dev": true
+                }
+            }
+        },
+        "sax": {
+            "version": "0.5.8",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sax/-/sax-0.5.8.tgz",
+            "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=",
+            "dev": true
+        },
+        "schema-utils": {
+            "version": "2.7.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-2.7.1.tgz",
+            "integrity": "sha1-HKTzLRskxZDCA7jnpQvw6kzTlNc=",
+            "dev": true,
+            "requires": {
+                "@types/json-schema": "^7.0.5",
+                "ajv": "^6.12.4",
+                "ajv-keywords": "^3.5.2"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                }
+            }
+        },
+        "select-hose": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/select-hose/-/select-hose-2.0.0.tgz",
+            "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+            "dev": true
+        },
+        "selfsigned": {
+            "version": "1.10.8",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/selfsigned/-/selfsigned-1.10.8.tgz",
+            "integrity": "sha1-DRcgi30Swz+OrIXEGDXyf8PYGjA=",
+            "dev": true,
+            "requires": {
+                "node-forge": "^0.10.0"
+            }
+        },
+        "semver": {
+            "version": "6.3.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+            "dev": true
+        },
+        "send": {
+            "version": "0.17.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/send/-/send-0.17.1.tgz",
+            "integrity": "sha1-wdiwWfeQD3Rm3Uk4vcROEd2zdsg=",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "~1.7.2",
+                "mime": "1.6.0",
+                "ms": "2.1.1",
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.1",
+                "statuses": "~1.5.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                            "dev": true
+                        }
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
+                    "dev": true
+                }
+            }
+        },
+        "serialize-javascript": {
+            "version": "4.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+            "integrity": "sha1-tSXhI4SJpez8Qq+sw/6Z5mb0sao=",
+            "dev": true,
+            "requires": {
+                "randombytes": "^2.1.0"
+            }
+        },
+        "serve-index": {
+            "version": "1.9.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/serve-index/-/serve-index-1.9.1.tgz",
+            "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+            "dev": true,
+            "requires": {
+                "accepts": "~1.3.4",
+                "batch": "0.6.1",
+                "debug": "2.6.9",
+                "escape-html": "~1.0.3",
+                "http-errors": "~1.6.2",
+                "mime-types": "~2.1.17",
+                "parseurl": "~1.3.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "http-errors": {
+                    "version": "1.6.3",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/http-errors/-/http-errors-1.6.3.tgz",
+                    "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+                    "dev": true,
+                    "requires": {
+                        "depd": "~1.1.2",
+                        "inherits": "2.0.3",
+                        "setprototypeof": "1.1.0",
+                        "statuses": ">= 1.4.0 < 2"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "setprototypeof": {
+                    "version": "1.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/setprototypeof/-/setprototypeof-1.1.0.tgz",
+                    "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY=",
+                    "dev": true
+                }
+            }
+        },
+        "serve-static": {
+            "version": "1.14.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/serve-static/-/serve-static-1.14.1.tgz",
+            "integrity": "sha1-Zm5jbcTwEPfvKZcKiKZ0MgiYsvk=",
+            "dev": true,
+            "requires": {
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.3",
+                "send": "0.17.1"
+            }
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "set-value": {
+            "version": "2.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/set-value/-/set-value-2.0.1.tgz",
+            "integrity": "sha1-oY1AUw5vB95CKMfe/kInr4ytAFs=",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+            "dev": true
+        },
+        "setprototypeof": {
+            "version": "1.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/setprototypeof/-/setprototypeof-1.1.1.tgz",
+            "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM=",
+            "dev": true
+        },
+        "sha.js": {
+            "version": "2.4.11",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sha.js/-/sha.js-2.4.11.tgz",
+            "integrity": "sha1-N6XPC4HsvGlD3hCbopYNGyZYSuc=",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "shallow-clone": {
+            "version": "3.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/shallow-clone/-/shallow-clone-3.0.1.tgz",
+            "integrity": "sha1-jymBrZJTH1UDWwH7IwdppA4C76M=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^6.0.2"
+            }
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/signal-exit/-/signal-exit-3.0.3.tgz",
+            "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw=",
+            "dev": true
+        },
+        "slash": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/slash/-/slash-3.0.0.tgz",
+            "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
+            "dev": true
+        },
+        "snapdragon": {
+            "version": "0.8.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
+            "dev": true,
+            "requires": {
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "snapdragon-node": {
+            "version": "2.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+            "dev": true,
+            "requires": {
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "snapdragon-util": {
+            "version": "3.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.2.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "sockjs": {
+            "version": "0.3.20",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sockjs/-/sockjs-0.3.20.tgz",
+            "integrity": "sha1-smooPsVi74smh7RAM6Tuzqx12FU=",
+            "dev": true,
+            "requires": {
+                "faye-websocket": "^0.10.0",
+                "uuid": "^3.4.0",
+                "websocket-driver": "0.6.5"
+            }
+        },
+        "sockjs-client": {
+            "version": "1.4.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sockjs-client/-/sockjs-client-1.4.0.tgz",
+            "integrity": "sha1-yfJWjhnI/YFztJl+o0IOC7MGx9U=",
+            "dev": true,
+            "requires": {
+                "debug": "^3.2.5",
+                "eventsource": "^1.0.7",
+                "faye-websocket": "~0.11.1",
+                "inherits": "^2.0.3",
+                "json3": "^3.3.2",
+                "url-parse": "^1.4.3"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "faye-websocket": {
+                    "version": "0.11.3",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/faye-websocket/-/faye-websocket-0.11.3.tgz",
+                    "integrity": "sha1-XA6aiWjokSwoZjn96XeosgnyUI4=",
+                    "dev": true,
+                    "requires": {
+                        "websocket-driver": ">=0.5.1"
+                    }
+                }
+            }
+        },
+        "sort-keys": {
+            "version": "1.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sort-keys/-/sort-keys-1.1.2.tgz",
+            "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+            "dev": true,
+            "requires": {
+                "is-plain-obj": "^1.0.0"
+            }
+        },
+        "source-list-map": {
+            "version": "2.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-list-map/-/source-list-map-2.0.1.tgz",
+            "integrity": "sha1-OZO9hzv8SEecyp6jpUeDXHwVSzQ="
+        },
+        "source-map": {
+            "version": "0.6.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        },
+        "source-map-loader": {
+            "version": "0.2.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map-loader/-/source-map-loader-0.2.4.tgz",
+            "integrity": "sha1-wYsNxuI79m9nkkN1V8VpoR4HInE=",
+            "dev": true,
+            "requires": {
+                "async": "^2.5.0",
+                "loader-utils": "^1.1.0"
+            }
+        },
+        "source-map-resolve": {
+            "version": "0.5.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+            "integrity": "sha1-GQhmvs51U+H48mei7oLGBrVQmho=",
+            "dev": true,
+            "requires": {
+                "atob": "^2.1.2",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
+            }
+        },
+        "source-map-support": {
+            "version": "0.5.13",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map-support/-/source-map-support-0.5.13.tgz",
+            "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "source-map-url": {
+            "version": "0.4.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map-url/-/source-map-url-0.4.0.tgz",
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+            "dev": true
+        },
+        "sourcemap-codec": {
+            "version": "1.4.8",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+            "integrity": "sha1-6oBL2UhXQC5pktBaOO8a41qatMQ=",
+            "dev": true
+        },
+        "spdy": {
+            "version": "4.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/spdy/-/spdy-4.0.2.tgz",
+            "integrity": "sha1-t09GYgOj7aRSwCSSuR+56EonZ3s=",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.0",
+                "handle-thing": "^2.0.0",
+                "http-deceiver": "^1.2.7",
+                "select-hose": "^2.0.0",
+                "spdy-transport": "^3.0.0"
+            }
+        },
+        "spdy-transport": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/spdy-transport/-/spdy-transport-3.0.0.tgz",
+            "integrity": "sha1-ANSGOmQArXXfkzYaFghgXl3NzzE=",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.0",
+                "detect-node": "^2.0.4",
+                "hpack.js": "^2.1.6",
+                "obuf": "^1.1.2",
+                "readable-stream": "^3.0.6",
+                "wbuf": "^1.7.3"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "speed-measure-webpack-plugin": {
+            "version": "1.3.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.3.1.tgz",
+            "integrity": "sha1-aYQKXNwItGOGl9rH2wN/WV1/NqA=",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.1"
+            }
+        },
+        "split-string": {
+            "version": "3.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/split-string/-/split-string-3.1.0.tgz",
+            "integrity": "sha1-fLCd2jqGWFcFxks5pkZgOGguj+I=",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^3.0.0"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "sshpk": {
+            "version": "1.16.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            }
+        },
+        "ssri": {
+            "version": "6.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ssri/-/ssri-6.0.1.tgz",
+            "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
+            "dev": true,
+            "requires": {
+                "figgy-pudding": "^3.5.1"
+            }
+        },
+        "static-extend": {
+            "version": "0.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/static-extend/-/static-extend-0.1.2.tgz",
+            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "dev": true,
+            "requires": {
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "statuses": {
+            "version": "1.5.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+            "dev": true
+        },
+        "stream-browserify": {
+            "version": "2.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/stream-browserify/-/stream-browserify-2.0.2.tgz",
+            "integrity": "sha1-h1IdOKRKp+6RzhzSpH3wy0ndZgs=",
+            "dev": true,
+            "requires": {
+                "inherits": "~2.0.1",
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "stream-each": {
+            "version": "1.2.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/stream-each/-/stream-each-1.2.3.tgz",
+            "integrity": "sha1-6+J6DDibBPvMIzZClS4Qcxr6m64=",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "stream-shift": "^1.0.0"
+            }
+        },
+        "stream-http": {
+            "version": "2.8.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/stream-http/-/stream-http-2.8.3.tgz",
+            "integrity": "sha1-stJCRpKIpaJ+xP6JM6z2I95lFPw=",
+            "dev": true,
+            "requires": {
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.3.6",
+                "to-arraybuffer": "^1.0.0",
+                "xtend": "^4.0.0"
+            }
+        },
+        "stream-shift": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/stream-shift/-/stream-shift-1.0.1.tgz",
+            "integrity": "sha1-1wiCgVWasneEJCebCHfaPDktWj0=",
+            "dev": true
+        },
+        "strict-uri-encode": {
+            "version": "1.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+            "dev": true
+        },
+        "string-width": {
+            "version": "3.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
+            "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+            "dev": true,
+            "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "string.prototype.trimend": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+            "integrity": "sha1-hYEqa4R6wAInD1gIFGBkyZX7aRM=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha1-pN5hsvZpifx0IWdsHLl4dXOs5Uw=",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "string.prototype.trimstart": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+            "integrity": "sha1-FK9tnzSwU/fPyJty+PLuFLkDmlQ=",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.17.7",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/es-abstract/-/es-abstract-1.17.7.tgz",
+                    "integrity": "sha1-pN5hsvZpifx0IWdsHLl4dXOs5Uw=",
+                    "dev": true,
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
+        },
+        "style-loader": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/style-loader/-/style-loader-1.0.0.tgz",
+            "integrity": "sha1-HVKW+RZejiyF0k7uC3yvnsjKH4I=",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^1.2.3",
+                "schema-utils": "^2.0.1"
+            }
+        },
+        "stylus": {
+            "version": "0.54.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/stylus/-/stylus-0.54.5.tgz",
+            "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
+            "dev": true,
+            "requires": {
+                "css-parse": "1.7.x",
+                "debug": "*",
+                "glob": "7.0.x",
+                "mkdirp": "0.5.x",
+                "sax": "0.5.x",
+                "source-map": "0.1.x"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.0.6",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/glob/-/glob-7.0.6.tgz",
+                    "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.1.43",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.1.43.tgz",
+                    "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+                    "dev": true,
+                    "requires": {
+                        "amdefine": ">=0.0.4"
+                    }
+                }
+            }
+        },
+        "stylus-loader": {
+            "version": "3.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/stylus-loader/-/stylus-loader-3.0.2.tgz",
+            "integrity": "sha1-J6cGQgsFo44DjnyssVNXjUUFE8Y=",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^1.0.2",
+                "lodash.clonedeep": "^4.5.0",
+                "when": "~3.6.x"
+            }
+        },
+        "supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+            "dev": true,
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
+        },
+        "tapable": {
+            "version": "1.1.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tapable/-/tapable-1.1.3.tgz",
+            "integrity": "sha1-ofzMBrWNth/XpF2i2kT186Pme6I=",
+            "dev": true
+        },
+        "tar": {
+            "version": "6.0.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tar/-/tar-6.0.5.tgz",
+            "integrity": "sha1-vegVCG4Qs58dzSmOidWW4VNeIA8=",
+            "dev": true,
+            "requires": {
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^3.0.0",
+                "minizlib": "^2.1.1",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
+            },
+            "dependencies": {
+                "chownr": {
+                    "version": "2.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/chownr/-/chownr-2.0.0.tgz",
+                    "integrity": "sha1-Fb++U9LqtM9w8YqM1o6+Wzyx3s4=",
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
+                    "dev": true
+                }
+            }
+        },
+        "terser": {
+            "version": "4.6.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/terser/-/terser-4.6.3.tgz",
+            "integrity": "sha1-4zqkJGHO1SONNS0t8qZ/IZIfjYc=",
+            "dev": true,
+            "requires": {
+                "commander": "^2.20.0",
+                "source-map": "~0.6.1",
+                "source-map-support": "~0.5.12"
+            }
+        },
+        "terser-webpack-plugin": {
+            "version": "3.0.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/terser-webpack-plugin/-/terser-webpack-plugin-3.0.3.tgz",
+            "integrity": "sha1-I72iaHsZf4eKdDNzuUEdkXrcLkU=",
+            "dev": true,
+            "requires": {
+                "cacache": "^15.0.4",
+                "find-cache-dir": "^3.3.1",
+                "jest-worker": "^26.0.0",
+                "p-limit": "^2.3.0",
+                "schema-utils": "^2.6.6",
+                "serialize-javascript": "^3.1.0",
+                "source-map": "^0.6.1",
+                "terser": "^4.6.13",
+                "webpack-sources": "^1.4.3"
+            },
+            "dependencies": {
+                "cacache": {
+                    "version": "15.0.5",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cacache/-/cacache-15.0.5.tgz",
+                    "integrity": "sha1-aRYoM9opFw1nMjNGQ8YOAF9fF9A=",
+                    "dev": true,
+                    "requires": {
+                        "@npmcli/move-file": "^1.0.1",
+                        "chownr": "^2.0.0",
+                        "fs-minipass": "^2.0.0",
+                        "glob": "^7.1.4",
+                        "infer-owner": "^1.0.4",
+                        "lru-cache": "^6.0.0",
+                        "minipass": "^3.1.1",
+                        "minipass-collect": "^1.0.2",
+                        "minipass-flush": "^1.0.5",
+                        "minipass-pipeline": "^1.2.2",
+                        "mkdirp": "^1.0.3",
+                        "p-map": "^4.0.0",
+                        "promise-inflight": "^1.0.1",
+                        "rimraf": "^3.0.2",
+                        "ssri": "^8.0.0",
+                        "tar": "^6.0.2",
+                        "unique-filename": "^1.1.1"
+                    }
+                },
+                "chownr": {
+                    "version": "2.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/chownr/-/chownr-2.0.0.tgz",
+                    "integrity": "sha1-Fb++U9LqtM9w8YqM1o6+Wzyx3s4=",
+                    "dev": true
+                },
+                "find-cache-dir": {
+                    "version": "3.3.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+                    "integrity": "sha1-ibM/rUpGcNqpT4Vff74x1thP6IA=",
+                    "dev": true,
+                    "requires": {
+                        "commondir": "^1.0.1",
+                        "make-dir": "^3.0.2",
+                        "pkg-dir": "^4.1.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+                    "dev": true
+                },
+                "jest-worker": {
+                    "version": "26.5.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/jest-worker/-/jest-worker-26.5.0.tgz",
+                    "integrity": "sha1-h97uhtu8X5jZkZ4NrfLEDjFS+jA=",
+                    "dev": true,
+                    "requires": {
+                        "@types/node": "*",
+                        "merge-stream": "^2.0.0",
+                        "supports-color": "^7.0.0"
+                    }
+                },
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+                    "dev": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha1-PrXtYmInVteaXw4qIh3+utdcL34=",
+                    "dev": true
+                },
+                "rimraf": {
+                    "version": "3.0.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/rimraf/-/rimraf-3.0.2.tgz",
+                    "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                },
+                "serialize-javascript": {
+                    "version": "3.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+                    "integrity": "sha1-i/OpFwcSZk7yVhtEtpHq/jmSFOo=",
+                    "dev": true,
+                    "requires": {
+                        "randombytes": "^2.1.0"
+                    }
+                },
+                "ssri": {
+                    "version": "8.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ssri/-/ssri-8.0.0.tgz",
+                    "integrity": "sha1-ecp04h+M6u3fy0uQFDxFi42YiAg=",
+                    "dev": true,
+                    "requires": {
+                        "minipass": "^3.1.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "terser": {
+                    "version": "4.8.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/terser/-/terser-4.8.0.tgz",
+                    "integrity": "sha1-YwVjQ9fHC7KfOvZlhlpG/gOg3xc=",
+                    "dev": true,
+                    "requires": {
+                        "commander": "^2.20.0",
+                        "source-map": "~0.6.1",
+                        "source-map-support": "~0.5.12"
+                    }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
+                    "dev": true
+                }
+            }
+        },
+        "through2": {
+            "version": "2.0.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha1-AcHjnrMdB8t9A6lqcIIyYLIxMs0=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+            }
+        },
+        "thunky": {
+            "version": "1.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/thunky/-/thunky-1.1.0.tgz",
+            "integrity": "sha1-Wrr3FKlAXbBQRzK7zNLO3Z75U30=",
+            "dev": true
+        },
+        "timers-browserify": {
+            "version": "2.0.11",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/timers-browserify/-/timers-browserify-2.0.11.tgz",
+            "integrity": "sha1-gAsfPu4nLlvFPuRloE0OgEwxIR8=",
+            "dev": true,
+            "requires": {
+                "setimmediate": "^1.0.4"
+            }
+        },
+        "to-arraybuffer": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+            "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+            "dev": true
+        },
+        "to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+            "dev": true
+        },
+        "to-object-path": {
+            "version": "0.3.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/to-object-path/-/to-object-path-0.3.0.tgz",
+            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "to-regex": {
+            "version": "3.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+            "dev": true,
+            "requires": {
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+            "dev": true,
+            "requires": {
+                "is-number": "^7.0.0"
+            }
+        },
+        "toidentifier": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/toidentifier/-/toidentifier-1.0.0.tgz",
+            "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM=",
+            "dev": true
+        },
+        "tough-cookie": {
+            "version": "2.5.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "psl": "^1.1.28",
+                "punycode": "^2.1.1"
+            }
+        },
+        "tree-kill": {
+            "version": "1.2.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tree-kill/-/tree-kill-1.2.2.tgz",
+            "integrity": "sha1-TKCakJLIi3OnzcXooBtQeweQoMw=",
+            "dev": true
+        },
+        "tslib": {
+            "version": "1.14.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tslib/-/tslib-1.14.1.tgz",
+            "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
+            "dev": true
+        },
+        "tty-browserify": {
+            "version": "0.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tty-browserify/-/tty-browserify-0.0.0.tgz",
+            "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+            "dev": true
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true
+        },
+        "type-is": {
+            "version": "1.6.18",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/type-is/-/type-is-1.6.18.tgz",
+            "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
+            "dev": true,
+            "requires": {
+                "media-typer": "0.3.0",
+                "mime-types": "~2.1.24"
+            }
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
+        "typescript": {
+            "version": "3.5.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/typescript/-/typescript-3.5.3.tgz",
+            "integrity": "sha1-yDD2V/k/HqhGgZ6SkJL1/lmD6Xc=",
+            "dev": true
+        },
+        "unicode-canonical-property-names-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+            "integrity": "sha1-JhmADEyCWADv3YNDr33Zkzy+KBg=",
+            "dev": true
+        },
+        "unicode-match-property-ecmascript": {
+            "version": "1.0.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+            "integrity": "sha1-jtKjJWmWG86SJ9Cc0/+7j+1fAgw=",
+            "dev": true,
+            "requires": {
+                "unicode-canonical-property-names-ecmascript": "^1.0.4",
+                "unicode-property-aliases-ecmascript": "^1.0.4"
+            }
+        },
+        "unicode-match-property-value-ecmascript": {
+            "version": "1.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+            "integrity": "sha1-DZH2AO7rMJaqlisdb8iIduZOpTE=",
+            "dev": true
+        },
+        "unicode-property-aliases-ecmascript": {
+            "version": "1.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+            "integrity": "sha1-3Vepn2IHvt/0Yoq++5TFDblByPQ=",
+            "dev": true
+        },
+        "union-value": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/union-value/-/union-value-1.0.1.tgz",
+            "integrity": "sha1-C2/nuDWuzaYcbqTU8CwUIh4QmEc=",
+            "dev": true,
+            "requires": {
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^2.0.1"
+            }
+        },
+        "unique-filename": {
+            "version": "1.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/unique-filename/-/unique-filename-1.1.1.tgz",
+            "integrity": "sha1-HWl2k2mtoFgxA6HmrodoG1ZXMjA=",
+            "dev": true,
+            "requires": {
+                "unique-slug": "^2.0.0"
+            }
+        },
+        "unique-slug": {
+            "version": "2.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/unique-slug/-/unique-slug-2.0.2.tgz",
+            "integrity": "sha1-uqvOkQg/xk6UWw861hPiZPfNTmw=",
+            "dev": true,
+            "requires": {
+                "imurmurhash": "^0.1.4"
+            }
+        },
+        "unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true
+        },
+        "unset-value": {
+            "version": "1.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/unset-value/-/unset-value-1.0.0.tgz",
+            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "dev": true,
+            "requires": {
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
+            },
+            "dependencies": {
+                "has-value": {
+                    "version": "0.3.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/has-value/-/has-value-0.3.1.tgz",
+                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "dev": true,
+                    "requires": {
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "dev": true,
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+                    "dev": true
+                }
+            }
+        },
+        "upath": {
+            "version": "1.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/upath/-/upath-1.2.0.tgz",
+            "integrity": "sha1-j2bbzVWog6za5ECK+LA1pQRMGJQ=",
+            "dev": true
+        },
+        "uri-js": {
+            "version": "4.4.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/uri-js/-/uri-js-4.4.0.tgz",
+            "integrity": "sha1-qnFCYd55PoqCNHp7zJznTobyhgI=",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "urix": {
+            "version": "0.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/urix/-/urix-0.1.0.tgz",
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+            "dev": true
+        },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/url/-/url-0.11.0.tgz",
+            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "dev": true,
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+                    "dev": true
+                }
+            }
+        },
+        "url-parse": {
+            "version": "1.4.7",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/url-parse/-/url-parse-1.4.7.tgz",
+            "integrity": "sha1-qKg1NejACjFuQDpdtKwbm4U64ng=",
+            "dev": true,
+            "requires": {
+                "querystringify": "^2.1.1",
+                "requires-port": "^1.0.0"
+            }
+        },
+        "use": {
+            "version": "3.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/use/-/use-3.1.1.tgz",
+            "integrity": "sha1-1QyMrHmhn7wg8pEfVuuXP04QBw8=",
+            "dev": true
+        },
+        "util": {
+            "version": "0.11.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/util/-/util-0.11.1.tgz",
+            "integrity": "sha1-MjZzNyDsZLsn9uJvQhqqLhtYjWE=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                }
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "utils-merge": {
+            "version": "1.0.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/utils-merge/-/utils-merge-1.0.1.tgz",
+            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "3.4.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/uuid/-/uuid-3.4.0.tgz",
+            "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+            "dev": true
+        },
+        "vary": {
+            "version": "1.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/vary/-/vary-1.1.2.tgz",
+            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+            "dev": true
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
+        },
+        "vm-browserify": {
+            "version": "1.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/vm-browserify/-/vm-browserify-1.1.2.tgz",
+            "integrity": "sha1-eGQcSIuObKkadfUR56OzKobl3aA=",
+            "dev": true
+        },
+        "watchpack": {
+            "version": "1.7.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/watchpack/-/watchpack-1.7.4.tgz",
+            "integrity": "sha1-bp2lOzyAuy1lCBiPWyAEEIZs0ws=",
+            "dev": true,
+            "requires": {
+                "chokidar": "^3.4.1",
+                "graceful-fs": "^4.1.2",
+                "neo-async": "^2.5.0",
+                "watchpack-chokidar2": "^2.0.0"
+            }
+        },
+        "watchpack-chokidar2": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
+            "integrity": "sha1-mUihhmy71suCTeoTp+1pH2yN3/A=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "chokidar": "^2.1.8"
+            },
+            "dependencies": {
+                "anymatch": {
+                    "version": "2.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/anymatch/-/anymatch-2.0.0.tgz",
+                    "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
+                    },
+                    "dependencies": {
+                        "normalize-path": {
+                            "version": "2.1.1",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/normalize-path/-/normalize-path-2.1.1.tgz",
+                            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "remove-trailing-separator": "^1.0.1"
+                            }
+                        }
+                    }
+                },
+                "binary-extensions": {
+                    "version": "1.13.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/binary-extensions/-/binary-extensions-1.13.1.tgz",
+                    "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
+                    "dev": true,
+                    "optional": true
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "chokidar": {
+                    "version": "2.1.8",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/chokidar/-/chokidar-2.1.8.tgz",
+                    "integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.1",
+                        "braces": "^2.3.2",
+                        "fsevents": "^1.2.7",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.3",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^3.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.2.1",
+                        "upath": "^1.1.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "fsevents": {
+                    "version": "1.2.13",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fsevents/-/fsevents-1.2.13.tgz",
+                    "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "bindings": "^1.5.0",
+                        "nan": "^2.12.1"
+                    }
+                },
+                "glob-parent": {
+                    "version": "3.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/glob-parent/-/glob-parent-3.1.0.tgz",
+                    "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "is-glob": {
+                            "version": "3.1.0",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-glob/-/is-glob-3.1.0.tgz",
+                            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "is-extglob": "^2.1.0"
+                            }
+                        }
+                    }
+                },
+                "is-binary-path": {
+                    "version": "1.0.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                    "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "binary-extensions": "^1.0.0"
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "readdirp": {
+                    "version": "2.2.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readdirp/-/readdirp-2.2.1.tgz",
+                    "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "micromatch": "^3.1.10",
+                        "readable-stream": "^2.0.2"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "2.1.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
+                    }
+                }
+            }
+        },
+        "wbuf": {
+            "version": "1.7.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/wbuf/-/wbuf-1.7.3.tgz",
+            "integrity": "sha1-wdjRSTFtPqhShIiVy2oL/oh7h98=",
+            "dev": true,
+            "requires": {
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "webpack": {
+            "version": "4.39.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack/-/webpack-4.39.2.tgz",
+            "integrity": "sha1-yapcF3bXwwnRs5EXZPAojIwoFqo=",
+            "dev": true,
+            "requires": {
+                "@webassemblyjs/ast": "1.8.5",
+                "@webassemblyjs/helper-module-context": "1.8.5",
+                "@webassemblyjs/wasm-edit": "1.8.5",
+                "@webassemblyjs/wasm-parser": "1.8.5",
+                "acorn": "^6.2.1",
+                "ajv": "^6.10.2",
+                "ajv-keywords": "^3.4.1",
+                "chrome-trace-event": "^1.0.2",
+                "enhanced-resolve": "^4.1.0",
+                "eslint-scope": "^4.0.3",
+                "json-parse-better-errors": "^1.0.2",
+                "loader-runner": "^2.4.0",
+                "loader-utils": "^1.2.3",
+                "memory-fs": "^0.4.1",
+                "micromatch": "^3.1.10",
+                "mkdirp": "^0.5.1",
+                "neo-async": "^2.6.1",
+                "node-libs-browser": "^2.2.1",
+                "schema-utils": "^1.0.0",
+                "tapable": "^1.1.3",
+                "terser-webpack-plugin": "^1.4.1",
+                "watchpack": "^1.6.0",
+                "webpack-sources": "^1.4.1"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "find-cache-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+                    "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+                    "dev": true,
+                    "requires": {
+                        "commondir": "^1.0.1",
+                        "make-dir": "^2.0.0",
+                        "pkg-dir": "^3.0.0"
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "pkg-dir": {
+                    "version": "3.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pkg-dir/-/pkg-dir-3.0.0.tgz",
+                    "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^3.0.0"
+                    }
+                },
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+                    "dev": true
+                },
+                "terser-webpack-plugin": {
+                    "version": "1.4.5",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+                    "integrity": "sha1-oheu+uozDnNP+sthIOwfoxLWBAs=",
+                    "dev": true,
+                    "requires": {
+                        "cacache": "^12.0.2",
+                        "find-cache-dir": "^2.1.0",
+                        "is-wsl": "^1.1.0",
+                        "schema-utils": "^1.0.0",
+                        "serialize-javascript": "^4.0.0",
+                        "source-map": "^0.6.1",
+                        "terser": "^4.1.2",
+                        "webpack-sources": "^1.4.0",
+                        "worker-farm": "^1.7.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "2.1.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
+                    }
+                }
+            }
+        },
+        "webpack-core": {
+            "version": "0.6.9",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack-core/-/webpack-core-0.6.9.tgz",
+            "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
+            "dev": true,
+            "requires": {
+                "source-list-map": "~0.1.7",
+                "source-map": "~0.4.1"
+            },
+            "dependencies": {
+                "source-list-map": {
+                    "version": "0.1.8",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-list-map/-/source-list-map-0.1.8.tgz",
+                    "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.4.4",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.4.4.tgz",
+                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                    "dev": true,
+                    "requires": {
+                        "amdefine": ">=0.0.4"
+                    }
+                }
+            }
+        },
+        "webpack-dev-middleware": {
+            "version": "3.7.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz",
+            "integrity": "sha1-ABnD23FuP6XOy/ZPKriKdLqzMfM=",
+            "dev": true,
+            "requires": {
+                "memory-fs": "^0.4.1",
+                "mime": "^2.4.4",
+                "mkdirp": "^0.5.1",
+                "range-parser": "^1.2.1",
+                "webpack-log": "^2.0.0"
+            },
+            "dependencies": {
+                "mime": {
+                    "version": "2.4.6",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mime/-/mime-2.4.6.tgz",
+                    "integrity": "sha1-5bQHyQ20QvK+tbFiNz0Htpr/pNE=",
+                    "dev": true
+                }
+            }
+        },
+        "webpack-dev-server": {
+            "version": "3.11.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz",
+            "integrity": "sha1-jxVKO84bz9HMYY705wMniFXn/4w=",
+            "dev": true,
+            "requires": {
+                "ansi-html": "0.0.7",
+                "bonjour": "^3.5.0",
+                "chokidar": "^2.1.8",
+                "compression": "^1.7.4",
+                "connect-history-api-fallback": "^1.6.0",
+                "debug": "^4.1.1",
+                "del": "^4.1.1",
+                "express": "^4.17.1",
+                "html-entities": "^1.3.1",
+                "http-proxy-middleware": "0.19.1",
+                "import-local": "^2.0.0",
+                "internal-ip": "^4.3.0",
+                "ip": "^1.1.5",
+                "is-absolute-url": "^3.0.3",
+                "killable": "^1.0.1",
+                "loglevel": "^1.6.8",
+                "opn": "^5.5.0",
+                "p-retry": "^3.0.1",
+                "portfinder": "^1.0.26",
+                "schema-utils": "^1.0.0",
+                "selfsigned": "^1.10.7",
+                "semver": "^6.3.0",
+                "serve-index": "^1.9.1",
+                "sockjs": "0.3.20",
+                "sockjs-client": "1.4.0",
+                "spdy": "^4.0.2",
+                "strip-ansi": "^3.0.1",
+                "supports-color": "^6.1.0",
+                "url": "^0.11.0",
+                "webpack-dev-middleware": "^3.7.2",
+                "webpack-log": "^2.0.0",
+                "ws": "^6.2.1",
+                "yargs": "^13.3.2"
+            },
+            "dependencies": {
+                "anymatch": {
+                    "version": "2.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/anymatch/-/anymatch-2.0.0.tgz",
+                    "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+                    "dev": true,
+                    "requires": {
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
+                    },
+                    "dependencies": {
+                        "normalize-path": {
+                            "version": "2.1.1",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/normalize-path/-/normalize-path-2.1.1.tgz",
+                            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                            "dev": true,
+                            "requires": {
+                                "remove-trailing-separator": "^1.0.1"
+                            }
+                        }
+                    }
+                },
+                "binary-extensions": {
+                    "version": "1.13.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/binary-extensions/-/binary-extensions-1.13.1.tgz",
+                    "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "chokidar": {
+                    "version": "2.1.8",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/chokidar/-/chokidar-2.1.8.tgz",
+                    "integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
+                    "dev": true,
+                    "requires": {
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.1",
+                        "braces": "^2.3.2",
+                        "fsevents": "^1.2.7",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.3",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^3.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.2.1",
+                        "upath": "^1.1.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "fsevents": {
+                    "version": "1.2.13",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fsevents/-/fsevents-1.2.13.tgz",
+                    "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "bindings": "^1.5.0",
+                        "nan": "^2.12.1"
+                    }
+                },
+                "glob-parent": {
+                    "version": "3.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/glob-parent/-/glob-parent-3.1.0.tgz",
+                    "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "is-glob": {
+                            "version": "3.1.0",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-glob/-/is-glob-3.1.0.tgz",
+                            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                            "dev": true,
+                            "requires": {
+                                "is-extglob": "^2.1.0"
+                            }
+                        }
+                    }
+                },
+                "is-binary-path": {
+                    "version": "1.0.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                    "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+                    "dev": true,
+                    "requires": {
+                        "binary-extensions": "^1.0.0"
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "readdirp": {
+                    "version": "2.2.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readdirp/-/readdirp-2.2.1.tgz",
+                    "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "micromatch": "^3.1.10",
+                        "readable-stream": "^2.0.2"
+                    }
+                },
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "2.1.1",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
+                    }
+                }
+            }
+        },
+        "webpack-log": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack-log/-/webpack-log-2.0.0.tgz",
+            "integrity": "sha1-W3ko4GN1k/EZ0y9iJ8HgrDHhtH8=",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "^3.0.0",
+                "uuid": "^3.3.2"
+            }
+        },
+        "webpack-merge": {
+            "version": "4.2.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack-merge/-/webpack-merge-4.2.1.tgz",
+            "integrity": "sha1-XpI8+ALqKs5P1a8dMkc2imM0ibQ=",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.5"
+            }
+        },
+        "webpack-sources": {
+            "version": "1.4.3",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack-sources/-/webpack-sources-1.4.3.tgz",
+            "integrity": "sha1-7t2OwLko+/HL/plOItLYkPMwqTM=",
+            "requires": {
+                "source-list-map": "^2.0.0",
+                "source-map": "~0.6.1"
+            }
+        },
+        "webpack-subresource-integrity": {
+            "version": "1.1.0-rc.6",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack-subresource-integrity/-/webpack-subresource-integrity-1.1.0-rc.6.tgz",
+            "integrity": "sha1-N/bxJk4es3jkFGWpjagPrXariIY=",
+            "dev": true,
+            "requires": {
+                "webpack-core": "^0.6.8"
+            }
+        },
+        "websocket-driver": {
+            "version": "0.6.5",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/websocket-driver/-/websocket-driver-0.6.5.tgz",
+            "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
+            "dev": true,
+            "requires": {
+                "websocket-extensions": ">=0.1.1"
+            }
+        },
+        "websocket-extensions": {
+            "version": "0.1.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+            "integrity": "sha1-f4RzvIOd/YdgituV1+sHUhFXikI=",
+            "dev": true
+        },
+        "when": {
+            "version": "3.6.4",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/when/-/when-3.6.4.tgz",
+            "integrity": "sha1-RztRfsFZ4rhQBUl6E5g/CVQS404=",
+            "dev": true
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/which/-/which-1.3.1.tgz",
+            "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/which-module/-/which-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
+        "worker-farm": {
+            "version": "1.7.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/worker-farm/-/worker-farm-1.7.0.tgz",
+            "integrity": "sha1-JqlMU5G7ypJhUgAvabhKS/dy5ag=",
+            "dev": true,
+            "requires": {
+                "errno": "~0.1.7"
+            }
+        },
+        "worker-plugin": {
+            "version": "3.2.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/worker-plugin/-/worker-plugin-3.2.0.tgz",
+            "integrity": "sha1-3a6fFht2/Lqs+PVOzQN4RFhOQ+c=",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^1.1.0"
+            }
+        },
+        "wrap-ansi": {
+            "version": "5.1.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+            "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.0",
+                "string-width": "^3.0.0",
+                "strip-ansi": "^5.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "ws": {
+            "version": "6.2.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ws/-/ws-6.2.1.tgz",
+            "integrity": "sha1-RC/fCkftZPWbal2P8TD0dI7VJPs=",
+            "dev": true,
+            "requires": {
+                "async-limiter": "~1.0.0"
+            }
+        },
+        "xtend": {
+            "version": "4.0.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
+            "dev": true
+        },
+        "y18n": {
+            "version": "4.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/y18n/-/y18n-4.0.0.tgz",
+            "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
+            "dev": true
+        },
+        "yallist": {
+            "version": "3.1.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yallist/-/yallist-3.1.1.tgz",
+            "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
+            "dev": true
+        },
+        "yargs": {
+            "version": "13.3.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yargs/-/yargs-13.3.2.tgz",
+            "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
+            "dev": true,
+            "requires": {
+                "cliui": "^5.0.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^3.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^13.1.2"
+            }
+        },
+        "yargs-parser": {
+            "version": "13.1.2",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yargs-parser/-/yargs-parser-13.1.2.tgz",
+            "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            }
+        },
+        "yazl": {
+            "version": "2.5.1",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yazl/-/yazl-2.5.1.tgz",
+            "integrity": "sha1-o9ZdPdZZpbCTeFDoYJ8i//orXDU=",
+            "requires": {
+                "buffer-crc32": "~0.2.3"
+            }
+        },
+        "zip-webpack-plugin": {
+            "version": "3.0.0",
+            "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/zip-webpack-plugin/-/zip-webpack-plugin-3.0.0.tgz",
+            "integrity": "sha1-Y7PBc/GoegBpFc1zKKPEC0TcjjI=",
+            "requires": {
+                "webpack-sources": "^1.1.0",
+                "yazl": "^2.4.3"
+            }
+        }
+    }
+}

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/new/package.json
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/new/package.json
@@ -1,0 +1,8 @@
+{
+    "dependencies": {
+        "zip-webpack-plugin": "3.0.0"
+    },
+    "devDependencies": {
+        "@angular-devkit/build-angular": "0.803.29"
+    }
+}

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/new/schema.json
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/new/schema.json
@@ -1,10 +1,29 @@
 {
     "type": "object",
     "properties": {
+        "enableRuntimeDependecyManagement": {
+            "type": "boolean",
+            "description": "Based on the this some features will be turned on or off.",
+            "default": ""
+        },
         "modulePath": {
             "type": "string",
             "description": "Path to module like loadChildren",
             "default": ""
+        },
+        "externalLibs": {
+            "type": "array",
+            "description": "The list of the libraries which will be provided by the vCloud Director Core UI. The list of strings will be converted to Regular Expression, defined by the JS. (The input supports strings only)",
+            "default": []
+        },
+        "librariesConfig": {
+            "type": "object",
+            "description": "In this section you can define your libs name, version and scope (provided - Provided by the UI, runtime - If the library is bootstrapped already from somebody else use it, else request and bootstrap your library and also make it avaiable for other plugins, self - Use your specific version no matter what)."
+        },
+        "ignoreDefaultExternals": {
+            "type": "boolean",
+            "description": "By setting this value to 'true' you will disable the default list of external libraries, and you have to provide your own in 'externalLibs' list.",
+            "default": false
         }
     }
 }

--- a/packages/angular/projects/vcd/plugin-builders/tsconfig.json
+++ b/packages/angular/projects/vcd/plugin-builders/tsconfig.json
@@ -8,7 +8,8 @@
       "target": "es6",
       "skipLibCheck": true
     },
-    "files": [
-      "./src/lib/base/index.ts"
+    "include": [
+      "./src/lib/base/**/*.ts",
+      "./src/lib/new/**/*.ts"
     ]
 }

--- a/packages/angular/projects/vcd/plugin-builders/tslint.json
+++ b/packages/angular/projects/vcd/plugin-builders/tslint.json
@@ -12,6 +12,13 @@
       "element",
       "lib",
       "kebab-case"
-    ]
+    ],
+    "ordered-imports": [
+      true,
+      {
+        "import-sources-order": "case-insensitive",
+        "named-imports-order": "case-insensitive"
+      }
+    ],
   }
 }

--- a/packages/angular/projects/vcd/sdk/src/new/package-lock.json
+++ b/packages/angular/projects/vcd/sdk/src/new/package-lock.json
@@ -1,117 +1,189 @@
 {
-  "name": "@vcd/plugin-builders",
-  "version": "0.12.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@angular-devkit/architect": {
-      "version": "0.8.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@angular-devkit/architect/-/architect-0.8.0.tgz",
-      "integrity": "sha1-wY51grHW6WRsatAYbJqaRDqYbZg=",
+      "version": "0.803.23",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@angular-devkit/architect/-/architect-0.803.23.tgz",
+      "integrity": "sha1-pzri7e3lOfN/v7CeQIWsJOw3gck=",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "0.8.0",
-        "rxjs": "~6.2.0"
+        "@angular-devkit/core": "8.3.23",
+        "rxjs": "6.4.0"
       }
     },
     "@angular-devkit/build-angular": {
-      "version": "0.8.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@angular-devkit/build-angular/-/build-angular-0.8.0.tgz",
-      "integrity": "sha1-I4KTTpXhEwuvKvMrqYPKQwHN2dE=",
+      "version": "0.803.23",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@angular-devkit/build-angular/-/build-angular-0.803.23.tgz",
+      "integrity": "sha1-1gaYyhrjQmwtOFgqilmuEOIkmA4=",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.8.0",
-        "@angular-devkit/build-optimizer": "0.8.0",
-        "@angular-devkit/build-webpack": "0.8.0",
-        "@angular-devkit/core": "0.8.0",
-        "@ngtools/webpack": "6.2.0",
-        "ajv": "~6.4.0",
-        "autoprefixer": "^8.4.1",
-        "circular-dependency-plugin": "^5.0.2",
-        "clean-css": "^4.1.11",
-        "copy-webpack-plugin": "^4.5.2",
-        "file-loader": "^1.1.11",
-        "glob": "^7.0.3",
-        "html-webpack-plugin": "^3.0.6",
-        "istanbul": "^0.4.5",
-        "istanbul-instrumenter-loader": "^3.0.1",
-        "karma-source-map-support": "^1.2.0",
-        "less": "^3.7.1",
-        "less-loader": "^4.1.0",
-        "license-webpack-plugin": "^1.3.1",
-        "loader-utils": "^1.1.0",
-        "mini-css-extract-plugin": "~0.4.0",
-        "minimatch": "^3.0.4",
-        "node-sass": "^4.9.3",
-        "opn": "^5.1.0",
-        "parse5": "^4.0.0",
-        "portfinder": "^1.0.13",
-        "postcss": "^6.0.22",
-        "postcss-import": "^11.1.0",
-        "postcss-loader": "^2.1.5",
-        "postcss-url": "^7.3.2",
-        "raw-loader": "^0.5.1",
-        "rxjs": "~6.2.0",
-        "sass-loader": "^7.1.0",
-        "semver": "^5.5.0",
-        "source-map-loader": "^0.2.3",
-        "source-map-support": "^0.5.0",
-        "stats-webpack-plugin": "^0.6.2",
-        "style-loader": "^0.21.0",
-        "stylus": "^0.54.5",
-        "stylus-loader": "^3.0.2",
-        "tree-kill": "^1.2.0",
-        "uglifyjs-webpack-plugin": "^1.2.5",
-        "url-loader": "^1.0.1",
-        "webpack": "^4.15.1",
-        "webpack-dev-middleware": "^3.1.3",
-        "webpack-dev-server": "^3.1.4",
-        "webpack-merge": "^4.1.2",
-        "webpack-sources": "^1.1.0",
-        "webpack-subresource-integrity": "^1.1.0-rc.4"
+        "@angular-devkit/architect": "0.803.23",
+        "@angular-devkit/build-optimizer": "0.803.23",
+        "@angular-devkit/build-webpack": "0.803.23",
+        "@angular-devkit/core": "8.3.23",
+        "@babel/core": "7.7.5",
+        "@babel/preset-env": "7.7.6",
+        "@ngtools/webpack": "8.3.23",
+        "ajv": "6.10.2",
+        "autoprefixer": "9.6.1",
+        "browserslist": "4.8.3",
+        "cacache": "12.0.2",
+        "caniuse-lite": "1.0.30001019",
+        "circular-dependency-plugin": "5.2.0",
+        "clean-css": "4.2.1",
+        "copy-webpack-plugin": "5.1.1",
+        "core-js": "3.2.1",
+        "coverage-istanbul-loader": "2.0.3",
+        "file-loader": "4.2.0",
+        "find-cache-dir": "3.0.0",
+        "glob": "7.1.4",
+        "jest-worker": "24.9.0",
+        "karma-source-map-support": "1.4.0",
+        "less": "3.9.0",
+        "less-loader": "5.0.0",
+        "license-webpack-plugin": "2.1.2",
+        "loader-utils": "1.2.3",
+        "mini-css-extract-plugin": "0.8.0",
+        "minimatch": "3.0.4",
+        "open": "6.4.0",
+        "parse5": "4.0.0",
+        "postcss": "7.0.17",
+        "postcss-import": "12.0.1",
+        "postcss-loader": "3.0.0",
+        "raw-loader": "3.1.0",
+        "regenerator-runtime": "0.13.3",
+        "rxjs": "6.4.0",
+        "sass": "1.22.9",
+        "sass-loader": "7.2.0",
+        "semver": "6.3.0",
+        "source-map": "0.7.3",
+        "source-map-loader": "0.2.4",
+        "source-map-support": "0.5.13",
+        "speed-measure-webpack-plugin": "1.3.1",
+        "style-loader": "1.0.0",
+        "stylus": "0.54.5",
+        "stylus-loader": "3.0.2",
+        "terser": "4.3.9",
+        "terser-webpack-plugin": "1.4.3",
+        "tree-kill": "1.2.2",
+        "webpack": "4.39.2",
+        "webpack-dev-middleware": "3.7.2",
+        "webpack-dev-server": "3.9.0",
+        "webpack-merge": "4.2.1",
+        "webpack-sources": "1.4.3",
+        "webpack-subresource-integrity": "1.1.0-rc.6",
+        "worker-plugin": "3.2.0"
       }
     },
     "@angular-devkit/build-optimizer": {
-      "version": "0.8.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@angular-devkit/build-optimizer/-/build-optimizer-0.8.0.tgz",
-      "integrity": "sha1-1+mN2VeUH3dHWn/o9jtnwLN5oyw=",
+      "version": "0.803.23",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@angular-devkit/build-optimizer/-/build-optimizer-0.803.23.tgz",
+      "integrity": "sha1-VzE4y3ICrhy2DKgy6l35ikZnT70=",
       "dev": true,
       "requires": {
-        "loader-utils": "^1.1.0",
-        "source-map": "^0.5.6",
-        "typescript": "~2.9.2",
-        "webpack-sources": "^1.1.0"
+        "loader-utils": "1.2.3",
+        "source-map": "0.7.3",
+        "tslib": "1.10.0",
+        "typescript": "3.5.3",
+        "webpack-sources": "1.4.3"
       },
       "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+        "tslib": {
+          "version": "1.10.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tslib/-/tslib-1.10.0.tgz",
+          "integrity": "sha1-w8GflZc/sKYpc/sJ2Q2WHuQ+XIo=",
           "dev": true
         }
       }
     },
     "@angular-devkit/build-webpack": {
-      "version": "0.8.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@angular-devkit/build-webpack/-/build-webpack-0.8.0.tgz",
-      "integrity": "sha1-UN9n5nzF6lf4J2bp4a6esXKSSEA=",
+      "version": "0.803.23",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@angular-devkit/build-webpack/-/build-webpack-0.803.23.tgz",
+      "integrity": "sha1-Q/JEmDX54CCJTklCCjSsmDGQ88Y=",
       "dev": true,
       "requires": {
-        "@angular-devkit/architect": "0.8.0",
-        "@angular-devkit/core": "0.8.0",
-        "rxjs": "~6.2.0"
+        "@angular-devkit/architect": "0.803.23",
+        "@angular-devkit/core": "8.3.23",
+        "rxjs": "6.4.0"
       }
     },
     "@angular-devkit/core": {
-      "version": "0.8.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@angular-devkit/core/-/core-0.8.0.tgz",
-      "integrity": "sha1-0xwmZ399UwLieZRoI5M7vJUEnlY=",
+      "version": "8.3.23",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@angular-devkit/core/-/core-8.3.23.tgz",
+      "integrity": "sha1-YSv4p2sczeQM1qXoWgLcCDu2ZsY=",
       "dev": true,
       "requires": {
-        "ajv": "~6.4.0",
-        "chokidar": "^2.0.3",
-        "rxjs": "~6.2.0",
-        "source-map": "^0.5.6"
+        "ajv": "6.10.2",
+        "fast-json-stable-stringify": "2.0.0",
+        "magic-string": "0.25.3",
+        "rxjs": "6.4.0",
+        "source-map": "0.7.3"
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha1-Fo2ho26Q2miujUnA8bSMfGJJITo=",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/core": {
+      "version": "7.7.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/core/-/core-7.7.5.tgz",
+      "integrity": "sha1-rhMjzQNbUWApMwf1BkfoP4umL34=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.7.4",
+        "@babel/helpers": "^7.7.4",
+        "@babel/parser": "^7.7.5",
+        "@babel/template": "^7.7.4",
+        "@babel/traverse": "^7.7.4",
+        "@babel/types": "^7.7.4",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "2.1.3",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/json5/-/json5-2.1.3.tgz",
+          "integrity": "sha1-ybD3+pIzv+WAf+ZvzzpWF+1ZfUM=",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.11.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/generator/-/generator-7.11.0.tgz",
+      "integrity": "sha1-S5DHjYwSglAkVoy+g+5smvGTWFw=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.11.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
       },
       "dependencies": {
         "source-map": {
@@ -122,34 +194,821 @@
         }
       }
     },
-    "@ngtools/webpack": {
-      "version": "6.2.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@ngtools/webpack/-/webpack-6.2.0.tgz",
-      "integrity": "sha1-vp4l/zTZvaTMDKDKtnTwokJh5sA=",
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
+      "integrity": "sha1-W/DUlaP3V6w72ki1vzs7ownHK6M=",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "0.8.0",
-        "rxjs": "~6.2.0",
-        "tree-kill": "^1.0.0",
-        "webpack-sources": "^1.1.0"
+        "@babel/types": "^7.10.4"
       }
     },
-    "@types/events": {
-      "version": "3.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc=",
-      "dev": true
-    },
-    "@types/glob": {
-      "version": "7.1.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@types/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha1-qlmhxuP7xCHgfM0xqUTDDrpSFXU=",
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+      "integrity": "sha1-uwt18xv5jL+f8UPBrleLhydK4aM=",
       "dev": true,
       "requires": {
-        "@types/events": "*",
+        "@babel/helper-explode-assignable-expression": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-create-regexp-features-plugin": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.10.4.tgz",
+      "integrity": "sha1-/dYNiFJGWaC2lZwFeZJeQlcU87g=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-regex": "^7.10.4",
+        "regexpu-core": "^4.7.0"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.10.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz",
+      "integrity": "sha1-tTwQ23imQIABUmkrEzkxR6y5uzA=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/types": "^7.10.5",
+        "lodash": "^4.17.19"
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.10.4.tgz",
+      "integrity": "sha1-QKHNkXv/Eoj2malKdbN6Gi29jHw=",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+      "integrity": "sha1-0tOyDFmtjEcRL6fSqUvAnV74Lxo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+      "integrity": "sha1-mMHL6g4jMvM/mkZhuM4VBbLBm6I=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz",
+      "integrity": "sha1-1JsAHR1aaMpeZgTdoBpil/fJOB4=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.11.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
+      "integrity": "sha1-rmnIPYTugvS0L5bioJQQk1qPJt8=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.11.0"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+      "integrity": "sha1-TFxUvgS9MWcKc4J5fXW5+i5bViA=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.11.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
+      "integrity": "sha1-sW8lAinkchGr3YSzS2RzfCqy01k=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4",
+        "@babel/helper-simple-access": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.11.0",
+        "lodash": "^4.17.19"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.4.tgz",
+      "integrity": "sha1-UNyWQT1ZT5lad5BZBbBYk813lnM=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
+      "integrity": "sha1-L3WoMSadT2d95JmG3/WZJ1M883U=",
+      "dev": true
+    },
+    "@babel/helper-regex": {
+      "version": "7.10.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
+      "integrity": "sha1-Mt+7eYmQc8QVVXBToZvQVarlCuA=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.19"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.10.4.tgz",
+      "integrity": "sha1-/Oi+pOlpC76SMFbe0h5UtOi2jtU=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-wrap-function": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
+      "integrity": "sha1-1YXNk4jqBuYDHkzUS2cTy+rZ5s8=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.10.4",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
+      "integrity": "sha1-D1zNopRSd6KnotOoIeFTle3PNGE=",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.11.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.11.0.tgz",
+      "integrity": "sha1-7sFi8RLC9Y068K8SXju1dmUUZyk=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.11.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.11.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+      "integrity": "sha1-+KSRJErPamdhWKxCBykRuoOtCZ8=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.11.0"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha1-p4x6clHgH2FlEtMbEK3PUq2l4NI=",
+      "dev": true
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-wrap-function/-/helper-wrap-function-7.10.4.tgz",
+      "integrity": "sha1-im9wHqsP8592W1oc/vQJmQ5iS4c=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helpers/-/helpers-7.10.4.tgz",
+      "integrity": "sha1-Kr6w1yGv98Cpc3a54fb2XXpHUEQ=",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha1-fRvf1ldTU4+r5sOFls23bZrGAUM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@babel/parser": {
+      "version": "7.11.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/parser/-/parser-7.11.0.tgz",
+      "integrity": "sha1-qdfhGurSXTtCLReyxlAsjd3val0=",
+      "dev": true
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.10.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.10.5.tgz",
+      "integrity": "sha1-NJHKvy98F5q4IGBs7Cf+0V4OhVg=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-remap-async-to-generator": "^7.10.4",
+        "@babel/plugin-syntax-async-generators": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.10.4.tgz",
+      "integrity": "sha1-uleibLmLN3QenVvKG4sN34KR8X4=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.10.4.tgz",
+      "integrity": "sha1-WT5ZxjUoFgIzvTIbGuvgggwjQds=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.11.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz",
+      "integrity": "sha1-vYH5Wh90Z2DqQ7bC09YrEXkK0K8=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-transform-parameters": "^7.10.4"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.10.4.tgz",
+      "integrity": "sha1-Mck4MJ0kp4pJ1o/av/qoY3WFVN0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.10.4.tgz",
+      "integrity": "sha1-RIPNpTBBzjQTt/4vAAImZd36p10=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha1-qYP7Gusuw/btBCohD2QOkOeG/g0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha1-Yr+Ysto80h1iYVT8lu5bPLaOrLM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha1-AcohtmjNghjJ5kDLbdiMVBKyyWo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha1-YRGiZbz7Ag6579D9/X0mQCue1sE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz",
+      "integrity": "sha1-S764kXtU/PdoNk4KgfVg4zo+9X0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz",
+      "integrity": "sha1-4ilg135pfHT0HFAdRNc9v4pqZM0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.10.4.tgz",
+      "integrity": "sha1-QaUBfknrbzzak5KlHu8pQFskWjc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-remap-async-to-generator": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz",
+      "integrity": "sha1-GvpZV0T3XkOpGvc7DZmOz+Trwug=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.10.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.10.5.tgz",
+      "integrity": "sha1-uBuKr++/5o8PZffvOXuezmimA30=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz",
+      "integrity": "sha1-QFE2rys+IYvEoZJiKLyRerGgrcc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-define-map": "^7.10.4",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.10.4",
+        "globals": "^11.1.0"
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz",
+      "integrity": "sha1-ne2DqBboLe0o1S1LTsvdgQzfwOs=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz",
+      "integrity": "sha1-cN3Ss9G+qD0BUJ6bsl3bOnT8heU=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.10.4.tgz",
+      "integrity": "sha1-RpwgYhBcHragQOr0+sS0iAeDle4=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.10.4.tgz",
+      "integrity": "sha1-aX5Qyf7hQ4D+hD0fMGspVhdDHkc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.10.4.tgz",
+      "integrity": "sha1-WuM4xX+M9AAb2zVgeuZrktZlry4=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz",
+      "integrity": "sha1-wIiS6IGdOl2ykDGxFa9RHbv+uuk=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz",
+      "integrity": "sha1-akZ4gOD8ljhRS6NpERgR3b4mRLc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz",
+      "integrity": "sha1-n0K6CEEQChNfInEtDjkcRi9XHzw=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz",
+      "integrity": "sha1-sexE/PGVr8uNssYs2OVRyIG6+Lc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.10.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.10.5.tgz",
+      "integrity": "sha1-G5zdrwXZ6Is6rTOcs+RFxPAgqbE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.10.5",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz",
+      "integrity": "sha1-ZmZ8Pu2h6/eJbUHx8WsXEFovvKA=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-simple-access": "^7.10.4",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.10.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.10.5.tgz",
+      "integrity": "sha1-YnAJnIVAZmgbrp4F+H4bnK2+jIU=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.10.4",
+        "@babel/helper-module-transforms": "^7.10.5",
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "babel-plugin-dynamic-import-node": "^2.3.3"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.10.4.tgz",
+      "integrity": "sha1-moSB/oG4JGVLOgtl2j34nz0hg54=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.10.4.tgz",
+      "integrity": "sha1-eLTZeIELbzvPA/njGPL8DtQa7LY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.10.4.tgz",
+      "integrity": "sha1-kJfXU8t7Aky3OBo7LlLpUTqcaIg=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz",
+      "integrity": "sha1-1xRsTROUM+emUm+IjGZ+MUoJOJQ=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-replace-supers": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.10.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz",
+      "integrity": "sha1-WdM51Y0LGVBDX0BD504lEABeLEo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz",
+      "integrity": "sha1-9v5UtlkDUimHhbg+3YFdIUxC48A=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.10.4.tgz",
+      "integrity": "sha1-IBXlnYOQdOdoON4hWdtCGWb9i2M=",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.14.2"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.10.4.tgz",
+      "integrity": "sha1-jyaCvNzvntMn4bCGFYXXAT+KVN0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz",
+      "integrity": "sha1-n9Jexc3VVbt/Rz5ebuHJce7eTdY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.11.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.11.0.tgz",
+      "integrity": "sha1-+oTTAPXk9XdS/kGm0bPFVPE/F8w=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.10.4.tgz",
+      "integrity": "sha1-jziJ7oZXWBEwop2cyR18c7fEoo0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4",
+        "@babel/helper-regex": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.10.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz",
+      "integrity": "sha1-eLxdYmpmQtszEtnQ8AH152Of3ow=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.10.4.tgz",
+      "integrity": "sha1-lQnxp+7DHE7b/+E3wWzDP/C8W/w=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.10.4.tgz",
+      "integrity": "sha1-5W1x+SgvrG2wnIJ0IFVXbV5tgKg=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.10.4",
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.7.6",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/preset-env/-/preset-env-7.7.6.tgz",
+      "integrity": "sha1-OaxgBCe7uU7sayeVPx36HWTUV7I=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.7.4",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-async-generator-functions": "^7.7.4",
+        "@babel/plugin-proposal-dynamic-import": "^7.7.4",
+        "@babel/plugin-proposal-json-strings": "^7.7.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.7.4",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.7.4",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.7.4",
+        "@babel/plugin-syntax-async-generators": "^7.7.4",
+        "@babel/plugin-syntax-dynamic-import": "^7.7.4",
+        "@babel/plugin-syntax-json-strings": "^7.7.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.7.4",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.7.4",
+        "@babel/plugin-syntax-top-level-await": "^7.7.4",
+        "@babel/plugin-transform-arrow-functions": "^7.7.4",
+        "@babel/plugin-transform-async-to-generator": "^7.7.4",
+        "@babel/plugin-transform-block-scoped-functions": "^7.7.4",
+        "@babel/plugin-transform-block-scoping": "^7.7.4",
+        "@babel/plugin-transform-classes": "^7.7.4",
+        "@babel/plugin-transform-computed-properties": "^7.7.4",
+        "@babel/plugin-transform-destructuring": "^7.7.4",
+        "@babel/plugin-transform-dotall-regex": "^7.7.4",
+        "@babel/plugin-transform-duplicate-keys": "^7.7.4",
+        "@babel/plugin-transform-exponentiation-operator": "^7.7.4",
+        "@babel/plugin-transform-for-of": "^7.7.4",
+        "@babel/plugin-transform-function-name": "^7.7.4",
+        "@babel/plugin-transform-literals": "^7.7.4",
+        "@babel/plugin-transform-member-expression-literals": "^7.7.4",
+        "@babel/plugin-transform-modules-amd": "^7.7.5",
+        "@babel/plugin-transform-modules-commonjs": "^7.7.5",
+        "@babel/plugin-transform-modules-systemjs": "^7.7.4",
+        "@babel/plugin-transform-modules-umd": "^7.7.4",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
+        "@babel/plugin-transform-new-target": "^7.7.4",
+        "@babel/plugin-transform-object-super": "^7.7.4",
+        "@babel/plugin-transform-parameters": "^7.7.4",
+        "@babel/plugin-transform-property-literals": "^7.7.4",
+        "@babel/plugin-transform-regenerator": "^7.7.5",
+        "@babel/plugin-transform-reserved-words": "^7.7.4",
+        "@babel/plugin-transform-shorthand-properties": "^7.7.4",
+        "@babel/plugin-transform-spread": "^7.7.4",
+        "@babel/plugin-transform-sticky-regex": "^7.7.4",
+        "@babel/plugin-transform-template-literals": "^7.7.4",
+        "@babel/plugin-transform-typeof-symbol": "^7.7.4",
+        "@babel/plugin-transform-unicode-regex": "^7.7.4",
+        "@babel/types": "^7.7.4",
+        "browserslist": "^4.6.0",
+        "core-js-compat": "^3.4.7",
+        "invariant": "^2.2.2",
+        "js-levenshtein": "^1.1.3",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.11.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/runtime/-/runtime-7.11.0.tgz",
+      "integrity": "sha1-8QJFh3BCqBXgf35pP6/wrp06Kqw=",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.7",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+          "integrity": "sha1-ysLazIoepnX+qrrriugziYrkb1U=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/template": {
+      "version": "7.10.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/template/-/template-7.10.4.tgz",
+      "integrity": "sha1-MlGZbEIA68cdGo/EBfupQPNrong=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.11.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/traverse/-/traverse-7.11.0.tgz",
+      "integrity": "sha1-m5ls4bmPU/fD5BdRFWBdVu0H3SQ=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.11.0",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/parser": "^7.11.0",
+        "@babel/types": "^7.11.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.19"
+      }
+    },
+    "@babel/types": {
+      "version": "7.11.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@babel/types/-/types-7.11.0.tgz",
+      "integrity": "sha1-Kua/G6mujDxDgk5YYSaYcbIG6Q0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "lodash": "^4.17.19",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@istanbuljs/schema/-/schema-0.1.2.tgz",
+      "integrity": "sha1-JlIL8Jq+SlZEzVQU43ElqJVCQd0=",
+      "dev": true
+    },
+    "@ngtools/webpack": {
+      "version": "8.3.23",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@ngtools/webpack/-/webpack-8.3.23.tgz",
+      "integrity": "sha1-KWHUjRhg6Tx6/LbskQQKdT9kY6g=",
+      "dev": true,
+      "requires": {
+        "@angular-devkit/core": "8.3.23",
+        "enhanced-resolve": "4.1.0",
+        "rxjs": "6.4.0",
+        "tree-kill": "1.2.2",
+        "webpack-sources": "1.4.3"
+      }
+    },
+    "@types/glob": {
+      "version": "7.1.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha1-5rqA82t9qtLGhazZJmOC5omFwYM=",
+      "dev": true,
+      "requires": {
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "@types/json-schema": {
+      "version": "7.0.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@types/json-schema/-/json-schema-7.0.5.tgz",
+      "integrity": "sha1-3M5EMOZLRDuolF8CkPtWStW6xt0=",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -158,183 +1017,209 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.13.5",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@types/node/-/node-13.13.5.tgz",
-      "integrity": "sha1-luw7Cvr9ZKTM6pEHt1v4SJ8OV2U=",
+      "version": "14.0.27",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@types/node/-/node-14.0.27.tgz",
+      "integrity": "sha1-oVGHOvWl6FG1GzsGXJ5jOQqeDrE=",
       "dev": true
     },
-    "@webassemblyjs/ast": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/ast/-/ast-1.9.0.tgz",
-      "integrity": "sha1-vYUGBLQEJFmlpBzX0zjL7Wle2WQ=",
+    "@types/source-list-map": {
+      "version": "0.1.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@types/source-list-map/-/source-list-map-0.1.2.tgz",
+      "integrity": "sha1-AHiDYGP/rxdBI0m7o2QIfgrALsk=",
+      "dev": true
+    },
+    "@types/webpack-sources": {
+      "version": "0.1.8",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@types/webpack-sources/-/webpack-sources-0.1.8.tgz",
+      "integrity": "sha1-B411QQQ1mT7IoKKFXohwbz91H4E=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/helper-module-context": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/wast-parser": "1.9.0"
+        "@types/node": "*",
+        "@types/source-list-map": "*",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "@webassemblyjs/ast": {
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/ast/-/ast-1.8.5.tgz",
+      "integrity": "sha1-UbHF/mV2o0lTv0slPfnw1JDZ41k=",
+      "dev": true,
+      "requires": {
+        "@webassemblyjs/helper-module-context": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/wast-parser": "1.8.5"
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
-      "integrity": "sha1-PD07Jxvd/ITesA9xNEQ4MR1S/7Q=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
+      "integrity": "sha1-G6kmopI2E+3OSW/VsC6M6KX0lyE=",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
-      "integrity": "sha1-ID9nbjM7lsnaLuqzzO8zxFkotqI=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
+      "integrity": "sha1-xJ2tIvZFInxe22EL25aX8aq3Ifc=",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
-      "integrity": "sha1-oUQtJpxf6yP8vJ73WdrDVH8p3gA=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
+      "integrity": "sha1-/qk+Qphj3V5DOFVfQikjhaZT8gQ=",
       "dev": true
     },
     "@webassemblyjs/helper-code-frame": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
-      "integrity": "sha1-ZH+Iks0gQ6gqwMjF51w28dkVnyc=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
+      "integrity": "sha1-mnQP9I4/qjAisd/1RCPfmqKTwl4=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/wast-printer": "1.9.0"
+        "@webassemblyjs/wast-printer": "1.8.5"
       }
     },
     "@webassemblyjs/helper-fsm": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
-      "integrity": "sha1-wFJWtxJEIUZx9LCOwQitY7cO3bg=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
+      "integrity": "sha1-ugt9Oz9+RzPaYFnJMyJ12GBwJFI=",
       "dev": true
     },
     "@webassemblyjs/helper-module-context": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
-      "integrity": "sha1-JdiIS3aDmHGgimxvgGw5ee9xLwc=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
+      "integrity": "sha1-3vS5knsBAdyMu9jR7bW3ucguskU=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0"
+        "@webassemblyjs/ast": "1.8.5",
+        "mamacro": "^0.0.3"
       }
     },
     "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
-      "integrity": "sha1-T+2L6sm4wU+MWLcNEk1UndH+V5A=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
+      "integrity": "sha1-U3p1Dt31weky83RCBlUckcG5PmE=",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
-      "integrity": "sha1-WkE41aYpK6GLBMWuSXF+QWeWU0Y=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
+      "integrity": "sha1-dMpqa8vhnlCjtrRihH5pUD5r/L8=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5"
       }
     },
     "@webassemblyjs/ieee754": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
-      "integrity": "sha1-Fceg+6roP7JhQ7us9tbfFwKtOeQ=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
+      "integrity": "sha1-cSMp2+8kDza/V70ve4+5v0FUQh4=",
       "dev": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
-      "integrity": "sha1-8Zygt2ptxVYjoJz/p2noOPoeHJU=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
+      "integrity": "sha1-BE7es06mefPgTNT9mCTV41dnrhA=",
       "dev": true,
       "requires": {
         "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/utf8": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
-      "integrity": "sha1-BNM7Y2945qaBMifoJAL3Y3tiKas=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
+      "integrity": "sha1-qL87XY/+mGx8Hjc8y9wqCRXwztw=",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
-      "integrity": "sha1-P+bXnT8PkiGDqoYALELdJWz+6c8=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
+      "integrity": "sha1-li2hKqWswcExyBxCMpkcgs5W4Bo=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/helper-wasm-section": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0",
-        "@webassemblyjs/wasm-opt": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0",
-        "@webassemblyjs/wast-printer": "1.9.0"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/helper-wasm-section": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5",
+        "@webassemblyjs/wasm-opt": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5",
+        "@webassemblyjs/wast-printer": "1.8.5"
       }
     },
     "@webassemblyjs/wasm-gen": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
-      "integrity": "sha1-ULxw7Gje2OJ2OwGhQYv0NJGnpJw=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
+      "integrity": "sha1-VIQHZsLBAC62TtGr5yCt7XFPmLw=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/ieee754": "1.9.0",
-        "@webassemblyjs/leb128": "1.9.0",
-        "@webassemblyjs/utf8": "1.9.0"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/ieee754": "1.8.5",
+        "@webassemblyjs/leb128": "1.8.5",
+        "@webassemblyjs/utf8": "1.8.5"
       }
     },
     "@webassemblyjs/wasm-opt": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
-      "integrity": "sha1-IhEYHlsxMmRDzIES658LkChyGmE=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
+      "integrity": "sha1-sk2fa6UDlK8TSfUQr6j/y4pj0mQ=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-buffer": "1.9.0",
-        "@webassemblyjs/wasm-gen": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-buffer": "1.8.5",
+        "@webassemblyjs/wasm-gen": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5"
       }
     },
     "@webassemblyjs/wasm-parser": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
-      "integrity": "sha1-nUjkSCbfSmWYKUqmyHRp1kL/9l4=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
+      "integrity": "sha1-IVdvDsiLkUJzV7hTY4NmjvfGa40=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-api-error": "1.9.0",
-        "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
-        "@webassemblyjs/ieee754": "1.9.0",
-        "@webassemblyjs/leb128": "1.9.0",
-        "@webassemblyjs/utf8": "1.9.0"
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-api-error": "1.8.5",
+        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
+        "@webassemblyjs/ieee754": "1.8.5",
+        "@webassemblyjs/leb128": "1.8.5",
+        "@webassemblyjs/utf8": "1.8.5"
       }
     },
     "@webassemblyjs/wast-parser": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
-      "integrity": "sha1-MDERXXmsW9JhVWzsw/qQo+9FGRQ=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
+      "integrity": "sha1-4Q7s1ULQ5705T2gnxJ899tTu+4w=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/floating-point-hex-parser": "1.9.0",
-        "@webassemblyjs/helper-api-error": "1.9.0",
-        "@webassemblyjs/helper-code-frame": "1.9.0",
-        "@webassemblyjs/helper-fsm": "1.9.0",
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/floating-point-hex-parser": "1.8.5",
+        "@webassemblyjs/helper-api-error": "1.8.5",
+        "@webassemblyjs/helper-code-frame": "1.8.5",
+        "@webassemblyjs/helper-fsm": "1.8.5",
         "@xtuc/long": "4.2.2"
       }
     },
     "@webassemblyjs/wast-printer": {
-      "version": "1.9.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
-      "integrity": "sha1-STXVTIX+9jewDOn1I3dFHQDUeJk=",
+      "version": "1.8.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
+      "integrity": "sha1-EUu8SB/RDKDiOzVg+oEnSLC65bw=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/wast-parser": "1.9.0",
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/wast-parser": "1.8.5",
         "@xtuc/long": "4.2.2"
       }
     },
@@ -348,12 +1233,6 @@
       "version": "4.2.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha1-0pHGpOl5ibXGHZrPOWrk/hM6cY0=",
-      "dev": true
-    },
-    "abbrev": {
-      "version": "1.0.9",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/abbrev/-/abbrev-1.0.9.tgz",
-      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
       "dev": true
     },
     "accepts": {
@@ -373,15 +1252,15 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.4.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv/-/ajv-6.4.0.tgz",
-      "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+      "version": "6.10.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^1.0.0",
+        "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0",
-        "uri-js": "^3.0.2"
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ajv-errors": {
@@ -391,17 +1270,16 @@
       "dev": true
     },
     "ajv-keywords": {
-      "version": "3.4.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
-      "integrity": "sha1-75FuJxxkrBIXH9g4TqrmsjRYVNo=",
+      "version": "3.5.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha1-MfKdpatuANHC0yms97WSlhTVAU0=",
       "dev": true
     },
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "ansi-colors": {
       "version": "3.2.4",
@@ -431,24 +1309,13 @@
       }
     },
     "anymatch": {
-      "version": "2.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/anymatch/-/anymatch-2.0.0.tgz",
-      "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+      "version": "3.1.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha1-xV7PAhheJGklk5kxDBc84xIzsUI=",
       "dev": true,
       "requires": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
-      },
-      "dependencies": {
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        }
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "aproba": {
@@ -456,16 +1323,6 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
       "dev": true
-    },
-    "are-we-there-yet": {
-      "version": "1.1.5",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
-      "dev": true,
-      "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
-      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -493,13 +1350,6 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
-    },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true,
-      "optional": true
     },
     "array-flatten": {
       "version": "2.1.2",
@@ -540,6 +1390,7 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "dev": true,
+      "optional": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -556,9 +1407,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+          "version": "4.11.9",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
           "dev": true
         }
       }
@@ -603,23 +1454,19 @@
       "dev": true
     },
     "async": {
-      "version": "1.5.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-      "dev": true
+      "version": "2.6.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/async/-/async-2.6.3.tgz",
+      "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
     },
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha1-tyfb+H12UWAvBvTUrDh/R9kbDL8=",
       "dev": true
-    },
-    "async-foreach": {
-      "version": "0.1.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/async-foreach/-/async-foreach-0.1.3.tgz",
-      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
-      "dev": true,
-      "optional": true
     },
     "async-limiter": {
       "version": "1.0.1",
@@ -631,7 +1478,8 @@
       "version": "0.4.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "atob": {
       "version": "2.1.2",
@@ -640,159 +1488,42 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "8.6.5",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/autoprefixer/-/autoprefixer-8.6.5.tgz",
-      "integrity": "sha1-ND89GT7VaLMgjgARehuW62kdTuk=",
+      "version": "9.6.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/autoprefixer/-/autoprefixer-9.6.1.tgz",
+      "integrity": "sha1-UZZ6AtLSMAuwGGbBYR7INI01Wkc=",
       "dev": true,
       "requires": {
-        "browserslist": "^3.2.8",
-        "caniuse-lite": "^1.0.30000864",
+        "browserslist": "^4.6.3",
+        "caniuse-lite": "^1.0.30000980",
+        "chalk": "^2.4.2",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^6.0.23",
-        "postcss-value-parser": "^3.2.3"
+        "postcss": "^7.0.17",
+        "postcss-value-parser": "^4.0.0"
       }
     },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "aws4": {
-      "version": "1.9.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/aws4/-/aws4-1.9.1.tgz",
-      "integrity": "sha1-fjPY99RJs/ZzzXLeuavcVS2+Uo4=",
-      "dev": true
+      "version": "1.10.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/aws4/-/aws4-1.10.0.tgz",
+      "integrity": "sha1-oXs6jqgRBg501H0wYSJACtRJeuI=",
+      "dev": true,
+      "optional": true
     },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+      "integrity": "sha1-hP2hnJduxcbe/vV/lCez3vZuF6M=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
+        "object.assign": "^4.1.0"
       }
-    },
-    "babel-generator": {
-      "version": "6.26.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/babel-generator/-/babel-generator-6.26.1.tgz",
-      "integrity": "sha1-GERAjTuPDTWkBOp6wYDwh6YBvZA=",
-      "dev": true,
-      "requires": {
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "detect-indent": "^4.0.0",
-        "jsesc": "^1.3.0",
-        "lodash": "^4.17.4",
-        "source-map": "^0.5.7",
-        "trim-right": "^1.0.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
-      }
-    },
-    "babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "babel-template": {
-      "version": "6.26.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      }
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
-      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -872,6 +1603,7 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -883,9 +1615,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "1.13.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/binary-extensions/-/binary-extensions-1.13.1.tgz",
-      "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
+      "version": "2.1.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha1-MPpAyef+B9vIlWeM0ocCTeokHdk=",
       "dev": true
     },
     "bindings": {
@@ -898,16 +1630,6 @@
         "file-uri-to-path": "1.0.0"
       }
     },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "inherits": "~2.0.0"
-      }
-    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bluebird/-/bluebird-3.7.2.tgz",
@@ -915,9 +1637,9 @@
       "dev": true
     },
     "bn.js": {
-      "version": "5.1.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-5.1.1.tgz",
-      "integrity": "sha1-SO/EAxqcQEG5yZxpQdkDRjq2LrU=",
+      "version": "5.1.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-5.1.2.tgz",
+      "integrity": "sha1-yWhpAtPJoncp9DqxD515wgBNp7A=",
       "dev": true
     },
     "body-parser": {
@@ -944,6 +1666,21 @@
           "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY=",
           "dev": true
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
         "qs": {
           "version": "6.7.0",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/qs/-/qs-6.7.0.tgz",
@@ -966,12 +1703,6 @@
         "multicast-dns-service-types": "^1.1.0"
       }
     },
-    "boolbase": {
-      "version": "1.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -983,32 +1714,12 @@
       }
     },
     "braces": {
-      "version": "2.3.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/braces/-/braces-2.3.2.tgz",
-      "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+      "version": "3.0.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
       "dev": true,
       "requires": {
-        "arr-flatten": "^1.1.0",
-        "array-unique": "^0.3.2",
-        "extend-shallow": "^2.0.1",
-        "fill-range": "^4.0.0",
-        "isobject": "^3.0.1",
-        "repeat-element": "^1.1.2",
-        "snapdragon": "^0.8.1",
-        "snapdragon-node": "^2.0.1",
-        "split-string": "^3.0.2",
-        "to-regex": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "fill-range": "^7.0.1"
       }
     },
     "brorand": {
@@ -1065,17 +1776,17 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+          "version": "4.11.9",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
           "dev": true
         }
       }
     },
     "browserify-sign": {
-      "version": "4.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/browserify-sign/-/browserify-sign-4.1.0.tgz",
-      "integrity": "sha1-T+lxs3mlrrSSXgZ3n5+h9B0knXA=",
+      "version": "4.2.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/browserify-sign/-/browserify-sign-4.2.0.tgz",
+      "integrity": "sha1-VF0LGwfmssmSEQgr8bEsznoLDhE=",
       "dev": true,
       "requires": {
         "bn.js": "^5.1.1",
@@ -1085,7 +1796,8 @@
         "elliptic": "^6.5.2",
         "inherits": "^2.0.4",
         "parse-asn1": "^5.1.5",
-        "readable-stream": "^3.6.0"
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
       },
       "dependencies": {
         "readable-stream": {
@@ -1098,6 +1810,12 @@
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
           }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
+          "dev": true
         }
       }
     },
@@ -1111,13 +1829,14 @@
       }
     },
     "browserslist": {
-      "version": "3.2.8",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/browserslist/-/browserslist-3.2.8.tgz",
-      "integrity": "sha1-sABTYdZHHw9ZUnl6dvyYXx+Xj8Y=",
+      "version": "4.8.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/browserslist/-/browserslist-4.8.3.tgz",
+      "integrity": "sha1-ZYAvzXcXfIeOAV8OMYnyxPYnukQ=",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000844",
-        "electron-to-chromium": "^1.3.47"
+        "caniuse-lite": "^1.0.30001017",
+        "electron-to-chromium": "^1.3.322",
+        "node-releases": "^1.1.44"
       }
     },
     "buffer": {
@@ -1130,11 +1849,6 @@
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
       }
-    },
-    "buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1167,23 +1881,25 @@
       "dev": true
     },
     "cacache": {
-      "version": "10.0.4",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cacache/-/cacache-10.0.4.tgz",
-      "integrity": "sha1-ZFI2eZnv+dQYiu/ZoU6dfGomNGA=",
+      "version": "12.0.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cacache/-/cacache-12.0.2.tgz",
+      "integrity": "sha1-jbAyBeNgiaPfaVTGbOklQUQaxGw=",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.1",
-        "chownr": "^1.0.1",
-        "glob": "^7.1.2",
-        "graceful-fs": "^4.1.11",
-        "lru-cache": "^4.1.1",
-        "mississippi": "^2.0.0",
+        "bluebird": "^3.5.5",
+        "chownr": "^1.1.1",
+        "figgy-pudding": "^3.5.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.1.15",
+        "infer-owner": "^1.0.3",
+        "lru-cache": "^5.1.1",
+        "mississippi": "^3.0.0",
         "mkdirp": "^0.5.1",
         "move-concurrently": "^1.0.1",
         "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.2",
-        "ssri": "^5.2.4",
-        "unique-filename": "^1.1.0",
+        "rimraf": "^2.6.3",
+        "ssri": "^6.0.1",
+        "unique-filename": "^1.1.1",
         "y18n": "^4.0.0"
       }
     },
@@ -1228,45 +1944,24 @@
       "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
       "dev": true
     },
-    "camel-case": {
-      "version": "3.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/camel-case/-/camel-case-3.0.0.tgz",
-      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-      "dev": true,
-      "requires": {
-        "no-case": "^2.2.0",
-        "upper-case": "^1.1.1"
-      }
-    },
     "camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-      "dev": true,
-      "optional": true
-    },
-    "camelcase-keys": {
-      "version": "2.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
-      }
+      "version": "5.3.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+      "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001053",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30001053.tgz",
-      "integrity": "sha1-t64CdWfOJmW5ZbBDfkUSspbM0g0=",
+      "version": "1.0.30001019",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30001019.tgz",
+      "integrity": "sha1-hX4/zKrSsv6z8fbYqPYtdH6mSOE=",
       "dev": true
     },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "chalk": {
       "version": "2.4.2",
@@ -1280,23 +1975,30 @@
       }
     },
     "chokidar": {
-      "version": "2.1.8",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/chokidar/-/chokidar-2.1.8.tgz",
-      "integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
+      "version": "3.4.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/chokidar/-/chokidar-3.4.1.tgz",
+      "integrity": "sha1-6QW97PEOqgoLHbDGZEgcxMvCK6E=",
       "dev": true,
       "requires": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.1"
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.4.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha1-tsHvQXxOVmPqSY8cRa+saRa7wik=",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
       }
     },
     "chownr": {
@@ -1354,58 +2056,46 @@
       }
     },
     "clean-css": {
-      "version": "4.2.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/clean-css/-/clean-css-4.2.3.tgz",
-      "integrity": "sha1-UHtd59l7SO5T2ErbAWD/YhY4D3g=",
+      "version": "4.2.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/clean-css/-/clean-css-4.2.1.tgz",
+      "integrity": "sha1-LUEe92uFabbQyEBo2r6FsKpeXBc=",
       "dev": true,
       "requires": {
         "source-map": "~0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
       }
     },
     "cliui": {
-      "version": "5.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
+      "version": "4.1.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "version": "3.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
         "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "version": "4.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -1426,12 +2116,6 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       }
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -1474,9 +2158,9 @@
       }
     },
     "commander": {
-      "version": "2.17.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/commander/-/commander-2.17.1.tgz",
-      "integrity": "sha1-vXerfebelCBc6sxy8XFtKfIKd78=",
+      "version": "2.20.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
       "dev": true
     },
     "commondir": {
@@ -1513,6 +2197,23 @@
         "on-headers": "~1.0.2",
         "safe-buffer": "5.1.2",
         "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "concat-map": {
@@ -1543,12 +2244,6 @@
       "version": "1.2.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/console-browserify/-/console-browserify-1.2.0.tgz",
       "integrity": "sha1-ZwY871fOts9Jk6KrOlWECujEkzY=",
-      "dev": true
-    },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
     "constants-browserify": {
@@ -1614,26 +2309,102 @@
       "dev": true
     },
     "copy-webpack-plugin": {
-      "version": "4.6.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/copy-webpack-plugin/-/copy-webpack-plugin-4.6.0.tgz",
-      "integrity": "sha1-5/QN2KaEd9QF3Rt6hUquMksVi64=",
+      "version": "5.1.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
+      "integrity": "sha1-VIGgPeoRI9iKmIxv+LeCRyFPC4g=",
       "dev": true,
       "requires": {
-        "cacache": "^10.0.4",
-        "find-cache-dir": "^1.0.0",
+        "cacache": "^12.0.3",
+        "find-cache-dir": "^2.1.0",
+        "glob-parent": "^3.1.0",
         "globby": "^7.1.1",
-        "is-glob": "^4.0.0",
-        "loader-utils": "^1.1.0",
+        "is-glob": "^4.0.1",
+        "loader-utils": "^1.2.3",
         "minimatch": "^3.0.4",
-        "p-limit": "^1.0.0",
-        "serialize-javascript": "^1.4.0"
+        "normalize-path": "^3.0.0",
+        "p-limit": "^2.2.1",
+        "schema-utils": "^1.0.0",
+        "serialize-javascript": "^2.1.2",
+        "webpack-log": "^2.0.0"
+      },
+      "dependencies": {
+        "cacache": {
+          "version": "12.0.4",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cacache/-/cacache-12.0.4.tgz",
+          "integrity": "sha1-ZovL0QWutfHZL+JVcOyVJcj6pAw=",
+          "dev": true,
+          "requires": {
+            "bluebird": "^3.5.5",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.4",
+            "graceful-fs": "^4.1.15",
+            "infer-owner": "^1.0.3",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.3",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
+            "y18n": "^4.0.0"
+          }
+        },
+        "find-cache-dir": {
+          "version": "2.1.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+          "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+          "dev": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^2.0.0",
+            "pkg-dir": "^3.0.0"
+          }
+        }
       }
     },
     "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha1-OIMUafmSK97Y7iHJ3EaYXgOZMIw=",
+      "version": "3.2.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/core-js/-/core-js-3.2.1.tgz",
+      "integrity": "sha1-zUHzhTTabMWffbBQ/mcwfemGiwk=",
       "dev": true
+    },
+    "core-js-compat": {
+      "version": "3.6.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/core-js-compat/-/core-js-compat-3.6.5.tgz",
+      "integrity": "sha1-KlHZpOJd/W5pAlGqgfmePAVIHxw=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.8.5",
+        "semver": "7.0.0"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.13.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/browserslist/-/browserslist-4.13.0.tgz",
+          "integrity": "sha1-QlVsugEeGwondbYRy6ao7KGOlA0=",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001093",
+            "electron-to-chromium": "^1.3.488",
+            "escalade": "^3.0.1",
+            "node-releases": "^1.1.58"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001109",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30001109.tgz",
+          "integrity": "sha1-qfPyagw3U7Bj16y7SN+5wORvKxk=",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha1-XzyjV2HkfgWyBsba/yz4FPAxa44=",
+          "dev": true
+        }
+      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1651,16 +2422,48 @@
         "is-directory": "^0.3.1",
         "js-yaml": "^3.13.1",
         "parse-json": "^4.0.0"
+      }
+    },
+    "coverage-istanbul-loader": {
+      "version": "2.0.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/coverage-istanbul-loader/-/coverage-istanbul-loader-2.0.3.tgz",
+      "integrity": "sha1-h9QvA/oP0/qHQ+x2lF2dZ/EFcio=",
+      "dev": true,
+      "requires": {
+        "convert-source-map": "^1.7.0",
+        "istanbul-lib-instrument": "^4.0.0",
+        "loader-utils": "^1.2.3",
+        "merge-source-map": "^1.1.0",
+        "schema-utils": "^2.6.1"
       },
       "dependencies": {
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+        "ajv": {
+          "version": "6.12.3",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha1-GMWvOKER3etPJpe9eNaKvByr1wY=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha1-FxUfdtjq5n+793lgwzxnatn078c=",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
           }
         }
       }
@@ -1676,9 +2479,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+          "version": "4.11.9",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
           "dev": true
         }
       }
@@ -1711,14 +2514,24 @@
       }
     },
     "cross-spawn": {
-      "version": "3.0.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cross-spawn/-/cross-spawn-3.0.1.tgz",
-      "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+      "version": "6.0.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "lru-cache": "^4.0.1",
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
       }
     },
     "crypto-browserify": {
@@ -1740,60 +2553,11 @@
         "randomfill": "^1.0.3"
       }
     },
-    "css": {
-      "version": "2.2.4",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/css/-/css-2.2.4.tgz",
-      "integrity": "sha1-xkZ1XHOXHyu6amAeLPL9cbEpiSk=",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.5.2",
-        "urix": "^0.1.0"
-      }
-    },
     "css-parse": {
-      "version": "2.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/css-parse/-/css-parse-2.0.0.tgz",
-      "integrity": "sha1-pGjuZnwW2BzPBcWMONKpfHgNv9Q=",
-      "dev": true,
-      "requires": {
-        "css": "^2.0.0"
-      }
-    },
-    "css-select": {
-      "version": "1.2.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/css-select/-/css-select-1.2.0.tgz",
-      "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "dev": true,
-      "requires": {
-        "boolbase": "~1.0.0",
-        "css-what": "2.1",
-        "domutils": "1.5.1",
-        "nth-check": "~1.0.1"
-      }
-    },
-    "css-what": {
-      "version": "2.1.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/css-what/-/css-what-2.1.3.tgz",
-      "integrity": "sha1-ptdgRXM2X+dGhsPzEcVlE9iChfI=",
+      "version": "1.7.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/css-parse/-/css-parse-1.7.0.tgz",
+      "integrity": "sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs=",
       "dev": true
-    },
-    "cuint": {
-      "version": "0.2.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cuint/-/cuint-0.2.2.tgz",
-      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
-      "dev": true
-    },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "array-find-index": "^1.0.1"
-      }
     },
     "cyclist": {
       "version": "1.0.1",
@@ -1806,17 +2570,18 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
     },
     "debug": {
-      "version": "2.6.9",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "version": "4.1.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
       }
     },
     "decamelize": {
@@ -1844,12 +2609,6 @@
         "object-keys": "^1.1.1",
         "regexp.prototype.flags": "^1.2.0"
       }
-    },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -1946,12 +2705,6 @@
               "dev": true
             }
           }
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
-          "dev": true
         }
       }
     },
@@ -1959,12 +2712,6 @@
       "version": "1.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
     },
     "depd": {
@@ -1989,15 +2736,6 @@
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
       "dev": true
     },
-    "detect-indent": {
-      "version": "4.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/detect-indent/-/detect-indent-4.0.0.tgz",
-      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
-      "requires": {
-        "repeating": "^2.0.0"
-      }
-    },
     "detect-node": {
       "version": "2.0.4",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/detect-node/-/detect-node-2.0.4.tgz",
@@ -2016,9 +2754,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+          "version": "4.11.9",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
           "dev": true
         }
       }
@@ -2057,63 +2795,11 @@
         "buffer-indexof": "^1.0.0"
       }
     },
-    "dom-converter": {
-      "version": "0.2.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/dom-converter/-/dom-converter-0.2.0.tgz",
-      "integrity": "sha1-ZyGp2u4uKTaClVtq/kFncWJ7t2g=",
-      "dev": true,
-      "requires": {
-        "utila": "~0.4"
-      }
-    },
-    "dom-serializer": {
-      "version": "0.2.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/dom-serializer/-/dom-serializer-0.2.2.tgz",
-      "integrity": "sha1-GvuB9TNxcXXUeGVd68XjMtn5u1E=",
-      "dev": true,
-      "requires": {
-        "domelementtype": "^2.0.1",
-        "entities": "^2.0.0"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "2.0.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha1-H4vf6R9aeAYydOgDtL3O326U+U0=",
-          "dev": true
-        }
-      }
-    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/domain-browser/-/domain-browser-1.2.0.tgz",
       "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
       "dev": true
-    },
-    "domelementtype": {
-      "version": "1.3.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/domelementtype/-/domelementtype-1.3.1.tgz",
-      "integrity": "sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8=",
-      "dev": true
-    },
-    "domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=",
-      "dev": true,
-      "requires": {
-        "domelementtype": "1"
-      }
-    },
-    "domutils": {
-      "version": "1.5.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/domutils/-/domutils-1.5.1.tgz",
-      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
-      "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      }
     },
     "duplexify": {
       "version": "3.7.1",
@@ -2132,6 +2818,7 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -2143,22 +2830,16 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
       "dev": true
     },
-    "ejs": {
-      "version": "2.7.4",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha1-SGYSh1c9zFPjZsehrlLDoSDuybo=",
-      "dev": true
-    },
     "electron-to-chromium": {
-      "version": "1.3.430",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/electron-to-chromium/-/electron-to-chromium-1.3.430.tgz",
-      "integrity": "sha1-M5FPfC23cb3PMJd71P1iWO6KLzc=",
+      "version": "1.3.516",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/electron-to-chromium/-/electron-to-chromium-1.3.516.tgz",
+      "integrity": "sha1-A+wHGwYeRit4a/fnziJv16t88fY=",
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha1-BcVnjXFzwEnYykM1UiJKSV0ON2I=",
+      "version": "6.5.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha1-y1nrLv2vc6C9eMzXAVpirW4Pk9Y=",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -2171,23 +2852,17 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+          "version": "4.11.9",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
           "dev": true
         }
       }
     },
-    "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
-      "dev": true
-    },
     "emojis-list": {
-      "version": "3.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha1-VXBmIEatKeLpFucariYKvf9Pang=",
+      "version": "2.1.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
     },
     "encodeurl": {
@@ -2206,33 +2881,15 @@
       }
     },
     "enhanced-resolve": {
-      "version": "4.1.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
-      "integrity": "sha1-KTfiuAZs0P584JkKmPDXGjUYn2Y=",
+      "version": "4.1.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
+      "integrity": "sha1-Qcfgv9/nSsH/4eV61qXGyfN0Kn8=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.5.0",
+        "memory-fs": "^0.4.0",
         "tapable": "^1.0.0"
-      },
-      "dependencies": {
-        "memory-fs": {
-          "version": "0.5.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/memory-fs/-/memory-fs-0.5.0.tgz",
-          "integrity": "sha1-MkwBKIuIZSlm0WHbd4OHIIRajjw=",
-          "dev": true,
-          "requires": {
-            "errno": "^0.1.3",
-            "readable-stream": "^2.0.1"
-          }
-        }
       }
-    },
-    "entities": {
-      "version": "2.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/entities/-/entities-2.0.0.tgz",
-      "integrity": "sha1-aNYITKsbB5dnVA2A5Wo5tCPkq/Q=",
-      "dev": true
     },
     "errno": {
       "version": "0.1.7",
@@ -2253,22 +2910,22 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.5",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/es-abstract/-/es-abstract-1.17.5.tgz",
-      "integrity": "sha1-2MnR1myJgfuSAOIlHXme7pJ3Suk=",
+      "version": "1.17.6",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha1-kUIHFweFeyysx7iey2cDFsPi1So=",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -2282,6 +2939,12 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "escalade": {
+      "version": "3.0.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/escalade/-/escalade-3.0.2.tgz",
+      "integrity": "sha1-algNcO24eIDyK0yR0NVgeN9pYsQ=",
+      "dev": true
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/escape-html/-/escape-html-1.0.3.tgz",
@@ -2294,31 +2957,6 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "escodegen": {
-      "version": "1.8.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/escodegen/-/escodegen-1.8.1.tgz",
-      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-      "dev": true,
-      "requires": {
-        "esprima": "^2.7.1",
-        "estraverse": "^1.9.1",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.2.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.2.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.2.0.tgz",
-          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
-      }
-    },
     "eslint-scope": {
       "version": "4.0.3",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -2327,20 +2965,12 @@
       "requires": {
         "esrecurse": "^4.1.0",
         "estraverse": "^4.1.1"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
-          "dev": true
-        }
       }
     },
     "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+      "version": "4.0.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true
     },
     "esrecurse": {
@@ -2350,26 +2980,12 @@
       "dev": true,
       "requires": {
         "estraverse": "^4.1.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
-          "dev": true
-        }
       }
     },
     "estraverse": {
-      "version": "1.9.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/estraverse/-/estraverse-1.9.3.tgz",
-      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
-      "dev": true
-    },
-    "esutils": {
-      "version": "2.0.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
+      "version": "4.3.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
       "dev": true
     },
     "etag": {
@@ -2379,15 +2995,15 @@
       "dev": true
     },
     "eventemitter3": {
-      "version": "4.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/eventemitter3/-/eventemitter3-4.0.0.tgz",
-      "integrity": "sha1-1lF2FjiH7lnzhtZMgmELaWpKdOs=",
+      "version": "4.0.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/eventemitter3/-/eventemitter3-4.0.4.tgz",
+      "integrity": "sha1-tUY6zmNaCD0Bi9x8kXtMXxCoU4Q=",
       "dev": true
     },
     "events": {
-      "version": "3.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/events/-/events-3.1.0.tgz",
-      "integrity": "sha1-hCea8bNMt1qoi/X/KR9tC9mzGlk=",
+      "version": "3.2.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/events/-/events-3.2.0.tgz",
+      "integrity": "sha1-k7h8GPjvzUICpGGuxN/AVWtjk3k=",
       "dev": true
     },
     "eventsource": {
@@ -2422,21 +3038,6 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
-          "dev": true,
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        }
       }
     },
     "expand-brackets": {
@@ -2454,6 +3055,15 @@
         "to-regex": "^3.0.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
@@ -2471,6 +3081,12 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -2518,6 +3134,21 @@
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
           "dev": true
         },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
         "qs": {
           "version": "6.7.0",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/qs/-/qs-6.7.0.tgz",
@@ -2530,7 +3161,8 @@
       "version": "3.0.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend/-/extend-3.0.2.tgz",
       "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2625,21 +3257,15 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "version": "2.0.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
-      "dev": true
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "version": "2.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "faye-websocket": {
@@ -2658,13 +3284,44 @@
       "dev": true
     },
     "file-loader": {
-      "version": "1.1.11",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/file-loader/-/file-loader-1.1.11.tgz",
-      "integrity": "sha1-b+iGRJsPKpNuQ8q6rAzb+zaVBvg=",
+      "version": "4.2.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/file-loader/-/file-loader-4.2.0.tgz",
+      "integrity": "sha1-X7Ek0jadcHXXCppavs0S5gqVIV4=",
       "dev": true,
       "requires": {
-        "loader-utils": "^1.0.2",
-        "schema-utils": "^0.4.5"
+        "loader-utils": "^1.2.3",
+        "schema-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.3",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha1-GMWvOKER3etPJpe9eNaKvByr1wY=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha1-FxUfdtjq5n+793lgwzxnatn078c=",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        }
       }
     },
     "file-uri-to-path": {
@@ -2675,26 +3332,12 @@
       "optional": true
     },
     "fill-range": {
-      "version": "4.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
-      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "version": "7.0.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1",
-        "to-regex-range": "^2.1.0"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        }
+        "to-regex-range": "^5.0.1"
       }
     },
     "finalhandler": {
@@ -2710,26 +3353,97 @@
         "parseurl": "~1.3.3",
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "find-cache-dir": {
-      "version": "1.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
-      "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+      "version": "3.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-cache-dir/-/find-cache-dir-3.0.0.tgz",
+      "integrity": "sha1-zUt92Xtxhbfhfb/i1uQRXuPuuPw=",
       "dev": true,
       "requires": {
         "commondir": "^1.0.1",
-        "make-dir": "^1.0.0",
-        "pkg-dir": "^2.0.0"
+        "make-dir": "^3.0.0",
+        "pkg-dir": "^4.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha1-l6/n1s3AvFkoWEt8jXsW6KmqXRk=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha1-Gvujlq/WdqbUJQTQpno6frn2KqA=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha1-o0KLtwiLOmApL2aRkni3wpetTwc=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha1-8JkTPfft5CLoHR2ESCcO6z5CYfM=",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        }
       }
     },
     "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "version": "3.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "dev": true,
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "^3.0.0"
       }
     },
     "flush-write-stream": {
@@ -2743,30 +3457,10 @@
       }
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha1-r6FPCLoSpSljFA/kMhJliJe8Dss=",
-      "dev": true,
-      "requires": {
-        "debug": "^3.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-          "dev": true
-        }
-      }
+      "version": "1.12.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/follow-redirects/-/follow-redirects-1.12.1.tgz",
+      "integrity": "sha1-3lSmIFMRuT1gOY68Ac9wFWgjErY=",
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -2778,13 +3472,15 @@
       "version": "0.6.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "dev": true,
+      "optional": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -2841,27 +3537,11 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.13",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fsevents/-/fsevents-1.2.13.tgz",
-      "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
+      "version": "2.1.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "bindings": "^1.5.0",
-        "nan": "^2.12.1"
-      }
-    },
-    "fstream": {
-      "version": "1.0.12",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha1-Touo7i1Ivk99DeUFRVVI6uWTIEU=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      }
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -2869,43 +3549,10 @@
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "dev": true,
-      "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "gaze": {
-      "version": "1.1.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/gaze/-/gaze-1.1.3.tgz",
-      "integrity": "sha1-xEFzPhO5J6yMD/C0w7Az8ogSkko=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "globule": "^1.0.0"
-      }
-    },
     "get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
-      "dev": true,
-      "optional": true
-    },
-    "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "version": "1.0.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
       "dev": true
     },
     "get-stream": {
@@ -2915,18 +3562,6 @@
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
       }
     },
     "get-value": {
@@ -2940,14 +3575,15 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
     },
     "glob": {
-      "version": "7.1.6",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+      "version": "7.1.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -2980,9 +3616,9 @@
       }
     },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+      "version": "11.12.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
       "dev": true
     },
     "globby": {
@@ -2997,18 +3633,14 @@
         "ignore": "^3.3.5",
         "pify": "^3.0.0",
         "slash": "^1.0.0"
-      }
-    },
-    "globule": {
-      "version": "1.3.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/globule/-/globule-1.3.1.tgz",
-      "integrity": "sha1-kKJTOPIrf761J87mPGKa6nVNM7k=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "glob": "~7.1.1",
-        "lodash": "~4.17.12",
-        "minimatch": "~3.0.2"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "graceful-fs": {
@@ -3023,40 +3655,30 @@
       "integrity": "sha1-hX95zjWVgMNA1DCBzGSJcNC7I04=",
       "dev": true
     },
-    "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha1-1MBcG6+Q6ZRfd6pop6IZqkp9904=",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
-        "wordwrap": "^1.0.0"
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/har-schema/-/har-schema-2.0.0.tgz",
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+      "version": "5.1.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha1-HwgDufjLIMD6E4It8ezds2veHv0=",
       "dev": true,
+      "optional": true,
       "requires": {
-        "ajv": "^6.5.5",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha1-xinF7O0XuvMUQ3kY0tqIyZ1ZWM0=",
+          "version": "6.12.3",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha1-GMWvOKER3etPJpe9eNaKvByr1wY=",
           "dev": true,
+          "optional": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -3065,25 +3687,11 @@
           }
         },
         "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha1-VFFFB3xQFJHjOxXsQIwpQ3bpSuQ=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
-          "dev": true
-        },
-        "uri-js": {
-          "version": "4.2.2",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/uri-js/-/uri-js-4.2.2.tgz",
-          "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+          "version": "3.1.3",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
           "dev": true,
-          "requires": {
-            "punycode": "^2.1.0"
-          }
+          "optional": true
         }
       }
     },
@@ -3096,15 +3704,6 @@
         "function-bind": "^1.1.1"
       }
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
@@ -3115,12 +3714,6 @@
       "version": "1.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=",
-      "dev": true
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
       "dev": true
     },
     "has-value": {
@@ -3144,6 +3737,26 @@
         "kind-of": "^4.0.0"
       },
       "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
         "kind-of": {
           "version": "4.0.0",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-4.0.0.tgz",
@@ -3178,9 +3791,9 @@
           }
         },
         "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha1-t02uxJsRSPiMZLaNSbHoFcHy9Rk=",
+          "version": "5.2.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha1-Hq+fqb2x/dTsdfWPnNtOa3gn7sY=",
           "dev": true
         }
       }
@@ -3195,12 +3808,6 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
-    "he": {
-      "version": "1.2.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/he/-/he-1.2.0.tgz",
-      "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
-      "dev": true
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -3211,12 +3818,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha1-dTm9S8Hg4KiVgVouAmJCCxKFhIg=",
-      "dev": true
     },
     "hpack.js": {
       "version": "2.1.6",
@@ -3235,101 +3836,6 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/html-entities/-/html-entities-1.3.1.tgz",
       "integrity": "sha1-+5oaS1sUxdq6gtPjTGrk/nAaDkQ=",
       "dev": true
-    },
-    "html-minifier": {
-      "version": "3.5.21",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/html-minifier/-/html-minifier-3.5.21.tgz",
-      "integrity": "sha1-0AQOBUcw41TbAIRjWTGUAVIS0gw=",
-      "dev": true,
-      "requires": {
-        "camel-case": "3.0.x",
-        "clean-css": "4.2.x",
-        "commander": "2.17.x",
-        "he": "1.2.x",
-        "param-case": "2.1.x",
-        "relateurl": "0.2.x",
-        "uglify-js": "3.4.x"
-      }
-    },
-    "html-webpack-plugin": {
-      "version": "3.2.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
-      "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
-      "dev": true,
-      "requires": {
-        "html-minifier": "^3.2.3",
-        "loader-utils": "^0.2.16",
-        "lodash": "^4.17.3",
-        "pretty-error": "^2.0.2",
-        "tapable": "^1.0.0",
-        "toposort": "^1.0.0",
-        "util.promisify": "1.0.0"
-      },
-      "dependencies": {
-        "big.js": {
-          "version": "3.2.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/big.js/-/big.js-3.2.0.tgz",
-          "integrity": "sha1-pfwpi4G54Nyi5FiCR4S2XFK6WI4=",
-          "dev": true
-        },
-        "emojis-list": {
-          "version": "2.1.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/emojis-list/-/emojis-list-2.1.0.tgz",
-          "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-          "dev": true
-        },
-        "json5": {
-          "version": "0.5.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/json5/-/json5-0.5.1.tgz",
-          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-          "dev": true
-        },
-        "loader-utils": {
-          "version": "0.2.17",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/loader-utils/-/loader-utils-0.2.17.tgz",
-          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-          "dev": true,
-          "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0",
-            "object-assign": "^4.0.1"
-          }
-        }
-      }
-    },
-    "htmlparser2": {
-      "version": "3.10.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=",
-      "dev": true,
-      "requires": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "entities": {
-          "version": "1.1.2",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha1-vfpzUplmTfr9NFKe1PhSKidf6lY=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha1-M3u9o63AcGvT4CRCaihtS0sskZg=",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
     },
     "http-deceiver": {
       "version": "1.2.7",
@@ -3359,15 +3865,15 @@
       }
     },
     "http-parser-js": {
-      "version": "0.4.10",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/http-parser-js/-/http-parser-js-0.4.10.tgz",
-      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
+      "version": "0.5.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/http-parser-js/-/http-parser-js-0.5.2.tgz",
+      "integrity": "sha1-2i4x0jezk6rnKs5DiC3X4nCo/3c=",
       "dev": true
     },
     "http-proxy": {
-      "version": "1.18.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/http-proxy/-/http-proxy-1.18.0.tgz",
-      "integrity": "sha1-2+VfY+daNH2389mZdPJpKjFKajo=",
+      "version": "1.18.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha1-QBVB8FNIhLv5UmAzTnL4juOXZUk=",
       "dev": true,
       "requires": {
         "eventemitter3": "^4.0.0",
@@ -3392,6 +3898,7 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -3474,60 +3981,6 @@
       "requires": {
         "pkg-dir": "^3.0.0",
         "resolve-cwd": "^2.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pkg-dir/-/pkg-dir-3.0.0.tgz",
-          "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
-          "dev": true,
-          "requires": {
-            "find-up": "^3.0.0"
-          }
-        }
       }
     },
     "imurmurhash": {
@@ -3535,23 +3988,6 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
-    },
-    "in-publish": {
-      "version": "2.0.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/in-publish/-/in-publish-2.0.1.tgz",
-      "integrity": "sha1-lIsaU1yAMFYc6lIvc/ePS+NX4Aw=",
-      "dev": true,
-      "optional": true
-    },
-    "indent-string": {
-      "version": "2.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/indent-string/-/indent-string-2.1.0.tgz",
-      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "repeating": "^2.0.0"
-      }
     },
     "infer-owner": {
       "version": "1.0.4",
@@ -3657,12 +4093,12 @@
       "dev": true
     },
     "is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "version": "2.1.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
       "dev": true,
       "requires": {
-        "binary-extensions": "^1.0.0"
+        "binary-extensions": "^2.0.0"
       }
     },
     "is-buffer": {
@@ -3672,9 +4108,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.5",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-callable/-/is-callable-1.1.5.tgz",
-      "integrity": "sha1-9+RrWWiQRW23Tn9ul2yzJz0G+qs=",
+      "version": "1.2.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-callable/-/is-callable-1.2.0.tgz",
+      "integrity": "sha1-gzNlYLVKOONeOi33r9BFTWkUaLs=",
       "dev": true
     },
     "is-data-descriptor": {
@@ -3740,20 +4176,11 @@
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
-    "is-finite": {
-      "version": "1.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha1-kEE1x3+0LAZB1qobzbxNqo2ggvM=",
-      "dev": true
-    },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
     },
     "is-glob": {
       "version": "4.0.1",
@@ -3765,24 +4192,10 @@
       }
     },
     "is-number": {
-      "version": "3.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
-      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-      "dev": true,
-      "requires": {
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
+      "version": "7.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+      "dev": true
     },
     "is-path-cwd": {
       "version": "2.2.0",
@@ -3808,6 +4221,12 @@
         "path-is-inside": "^1.0.2"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -3818,12 +4237,12 @@
       }
     },
     "is-regex": {
-      "version": "1.0.5",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-regex/-/is-regex-1.0.5.tgz",
-      "integrity": "sha1-OdWJo1i/GJZ/cmlnEguPwa7XTq4=",
+      "version": "1.1.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-regex/-/is-regex-1.1.0.tgz",
+      "integrity": "sha1-7OOOOJ5JDfDcIcrqK9WW+Yf3Z/8=",
       "dev": true,
       "requires": {
-        "has": "^1.0.3"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-stream": {
@@ -3845,12 +4264,6 @@
       "version": "1.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
-    },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true,
       "optional": true
     },
@@ -3888,145 +4301,68 @@
       "version": "0.1.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
-    },
-    "istanbul": {
-      "version": "0.4.5",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/istanbul/-/istanbul-0.4.5.tgz",
-      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1.0.x",
-        "async": "1.x",
-        "escodegen": "1.8.x",
-        "esprima": "2.7.x",
-        "glob": "^5.0.15",
-        "handlebars": "^4.0.1",
-        "js-yaml": "3.x",
-        "mkdirp": "0.5.x",
-        "nopt": "3.x",
-        "once": "1.x",
-        "resolve": "1.1.x",
-        "supports-color": "^3.1.0",
-        "which": "^1.1.1",
-        "wordwrap": "^1.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        }
-      }
-    },
-    "istanbul-instrumenter-loader": {
-      "version": "3.0.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/istanbul-instrumenter-loader/-/istanbul-instrumenter-loader-3.0.1.tgz",
-      "integrity": "sha1-mVe9WSUrNz+uXFK3tRiOb94qCUk=",
-      "dev": true,
-      "requires": {
-        "convert-source-map": "^1.5.0",
-        "istanbul-lib-instrument": "^1.7.3",
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^0.3.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "dev": true,
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
-        "schema-utils": {
-          "version": "0.3.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-0.3.0.tgz",
-          "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
-          "dev": true,
-          "requires": {
-            "ajv": "^5.0.0"
-          }
-        }
-      }
-    },
-    "istanbul-lib-coverage": {
-      "version": "1.2.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.1.tgz",
-      "integrity": "sha1-zPftzQoLubj3Kf7rCTBHD5r2ZPA=",
-      "dev": true
-    },
-    "istanbul-lib-instrument": {
-      "version": "1.10.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.2.tgz",
-      "integrity": "sha1-H1XtEKw8R/K93dUweTUSZ1TQqco=",
-      "dev": true,
-      "requires": {
-        "babel-generator": "^6.18.0",
-        "babel-template": "^6.16.0",
-        "babel-traverse": "^6.18.0",
-        "babel-types": "^6.18.0",
-        "babylon": "^6.18.0",
-        "istanbul-lib-coverage": "^1.2.1",
-        "semver": "^5.3.0"
-      }
-    },
-    "js-base64": {
-      "version": "2.5.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/js-base64/-/js-base64-2.5.2.tgz",
-      "integrity": "sha1-MTtidN2nGPcU0AszMLuubjjpAgk=",
       "dev": true,
       "optional": true
     },
+    "istanbul-lib-coverage": {
+      "version": "3.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+      "integrity": "sha1-9ZRKN8cLVQsCp4pcOyBVsoDOyOw=",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "4.0.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha1-hzxv/4l0UBGCIndGlqPyiQLXfB0=",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.7.5",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
+      }
+    },
+    "jest-worker": {
+      "version": "24.9.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/jest-worker/-/jest-worker-24.9.0.tgz",
+      "integrity": "sha1-Xb/bWy0yLphWeJgjipaXvM5ns+U=",
+      "dev": true,
+      "requires": {
+        "merge-stream": "^2.0.0",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "js-levenshtein": {
+      "version": "1.1.6",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/js-levenshtein/-/js-levenshtein-1.1.6.tgz",
+      "integrity": "sha1-xs7ljrNVA3LfjeuF+tXOZs4B1Z0=",
+      "dev": true
+    },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "version": "4.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+      "version": "3.14.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha1-p6NBcPJqIbsWJCTYray0ETpp5II=",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
-          "dev": true
-        }
       }
     },
     "jsbn": {
@@ -4036,9 +4372,9 @@
       "dev": true
     },
     "jsesc": {
-      "version": "1.3.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "version": "2.5.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
       "dev": true
     },
     "json-parse-better-errors": {
@@ -4051,19 +4387,21 @@
       "version": "0.2.3",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "version": "0.4.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "json3": {
       "version": "3.3.3",
@@ -4085,6 +4423,7 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
       "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -4123,9 +4462,9 @@
       }
     },
     "less": {
-      "version": "3.11.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/less/-/less-3.11.1.tgz",
-      "integrity": "sha1-xr8I454CQE/mswej3/+v3FW9NuI=",
+      "version": "3.9.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/less/-/less-3.9.0.tgz",
+      "integrity": "sha1-t1EcQ/N89X3Iff/ZiD7BISibFHQ=",
       "dev": true,
       "requires": {
         "clone": "^2.1.2",
@@ -4136,61 +4475,37 @@
         "mkdirp": "^0.5.0",
         "promise": "^7.1.1",
         "request": "^2.83.0",
-        "source-map": "~0.6.0",
-        "tslib": "^1.10.0"
+        "source-map": "~0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "less-loader": {
-      "version": "4.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/less-loader/-/less-loader-4.1.0.tgz",
-      "integrity": "sha1-LBNSxbCaT4QQFJAnT9UWdN5BNj4=",
+      "version": "5.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/less-loader/-/less-loader-5.0.0.tgz",
+      "integrity": "sha1-SY3eOmxsT4h0WO6e0/CGoSrRtGY=",
       "dev": true,
       "requires": {
         "clone": "^2.1.1",
         "loader-utils": "^1.1.0",
-        "pify": "^3.0.0"
-      }
-    },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "pify": "^4.0.1"
       }
     },
     "license-webpack-plugin": {
-      "version": "1.5.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/license-webpack-plugin/-/license-webpack-plugin-1.5.0.tgz",
-      "integrity": "sha1-IsoPEqiEruNbth39jqtF/jagRSM=",
+      "version": "2.1.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/license-webpack-plugin/-/license-webpack-plugin-2.1.2.tgz",
+      "integrity": "sha1-Y/fFcVN6RQ7EfcmPXV/9vKezsU8=",
       "dev": true,
       "requires": {
-        "ejs": "^2.5.7"
-      }
-    },
-    "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true,
-          "optional": true
-        }
+        "@types/webpack-sources": "^0.1.5",
+        "webpack-sources": "^1.2.0"
       }
     },
     "loader-runner": {
@@ -4200,30 +4515,30 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha1-xXm140yzSxp07cbB+za/o3HVphM=",
+      "version": "1.2.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/loader-utils/-/loader-utils-1.2.3.tgz",
+      "integrity": "sha1-H/XcaRHJ8KBiUxpMBLYJQGEIwsc=",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
+        "emojis-list": "^2.0.0",
         "json5": "^1.0.1"
       }
     },
     "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "version": "3.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
+        "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
+      "version": "4.17.19",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha1-5I3e2+MLMyF4PFtDAfvTU7weSks=",
       "dev": true
     },
     "lodash.clonedeep": {
@@ -4247,41 +4562,47 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "yallist": "^3.0.2"
       }
     },
-    "lower-case": {
-      "version": "1.1.4",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/lower-case/-/lower-case-1.1.4.tgz",
-      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
-      "dev": true
-    },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+    "magic-string": {
+      "version": "0.25.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/magic-string/-/magic-string-0.25.3.tgz",
+      "integrity": "sha1-NLjSosf+ydm9+ZKaP9gdJx7zW+k=",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "make-dir": {
-      "version": "1.3.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
+      "version": "2.1.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
       }
+    },
+    "mamacro": {
+      "version": "0.0.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mamacro/-/mamacro-0.0.3.tgz",
+      "integrity": "sha1-rSyVdhl8nxq/MI0Hh4Zb2XWj8+Q=",
+      "dev": true
     },
     "map-age-cleaner": {
       "version": "0.1.3",
@@ -4296,12 +4617,6 @@
       "version": "0.2.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-      "dev": true
-    },
-    "map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
     },
     "map-visit": {
@@ -4351,29 +4666,33 @@
         "readable-stream": "^2.0.1"
       }
     },
-    "meow": {
-      "version": "3.7.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/meow/-/meow-3.7.0.tgz",
-      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
-      }
-    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "merge-source-map": {
+      "version": "1.1.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/merge-source-map/-/merge-source-map-1.1.0.tgz",
+      "integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
       "dev": true
     },
     "methods": {
@@ -4401,6 +4720,90 @@
         "regex-not": "^1.0.0",
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.2"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
       }
     },
     "miller-rabin": {
@@ -4414,9 +4817,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+          "version": "4.11.9",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
           "dev": true
         }
       }
@@ -4449,27 +4852,15 @@
       "dev": true
     },
     "mini-css-extract-plugin": {
-      "version": "0.4.5",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.5.tgz",
-      "integrity": "sha1-yZ6eeNVPP6d1YzruWTOuqk6AcZo=",
+      "version": "0.8.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.0.tgz",
+      "integrity": "sha1-gdQexP5YxxOpatfHI82y0L1NcOE=",
       "dev": true,
       "requires": {
         "loader-utils": "^1.1.0",
+        "normalize-url": "1.9.1",
         "schema-utils": "^1.0.0",
         "webpack-sources": "^1.1.0"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        }
       }
     },
     "minimalistic-assert": {
@@ -4500,9 +4891,9 @@
       "dev": true
     },
     "mississippi": {
-      "version": "2.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mississippi/-/mississippi-2.0.0.tgz",
-      "integrity": "sha1-NEKlCPr8KFAEhv7qmUCWduTuWm8=",
+      "version": "3.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mississippi/-/mississippi-3.0.0.tgz",
+      "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
       "dev": true,
       "requires": {
         "concat-stream": "^1.5.0",
@@ -4511,7 +4902,7 @@
         "flush-write-stream": "^1.0.0",
         "from2": "^2.1.0",
         "parallel-transform": "^1.1.0",
-        "pump": "^2.0.1",
+        "pump": "^3.0.0",
         "pumpify": "^1.3.3",
         "stream-each": "^1.1.0",
         "through2": "^2.0.0"
@@ -4562,9 +4953,9 @@
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
       "dev": true
     },
     "multicast-dns": {
@@ -4616,9 +5007,9 @@
       "dev": true
     },
     "neo-async": {
-      "version": "2.6.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
+      "version": "2.6.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha1-tKr7k+OustgXTKU88WOrfXMIMF8=",
       "dev": true
     },
     "nice-try": {
@@ -4627,50 +5018,11 @@
       "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
       "dev": true
     },
-    "no-case": {
-      "version": "2.3.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/no-case/-/no-case-2.3.2.tgz",
-      "integrity": "sha1-YLgTOWvjmz8SiKTB7V0efSi0ZKw=",
-      "dev": true,
-      "requires": {
-        "lower-case": "^1.1.1"
-      }
-    },
     "node-forge": {
       "version": "0.9.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/node-forge/-/node-forge-0.9.0.tgz",
       "integrity": "sha1-1iQFDtu0SHStyhK7mlLsY8t4JXk=",
       "dev": true
-    },
-    "node-gyp": {
-      "version": "3.8.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/node-gyp/-/node-gyp-3.8.0.tgz",
-      "integrity": "sha1-VAMEJhwzDoDQ1e3OJTpoyzlkIYw=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "fstream": "^1.0.0",
-        "glob": "^7.0.3",
-        "graceful-fs": "^4.1.2",
-        "mkdirp": "^0.5.0",
-        "nopt": "2 || 3",
-        "npmlog": "0 || 1 || 2 || 3 || 4",
-        "osenv": "0",
-        "request": "^2.87.0",
-        "rimraf": "2",
-        "semver": "~5.3.0",
-        "tar": "^2.0.0",
-        "which": "1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.3.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true,
-          "optional": true
-        }
-      }
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -4711,93 +5063,11 @@
         }
       }
     },
-    "node-sass": {
-      "version": "4.14.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/node-sass/-/node-sass-4.14.1.tgz",
-      "integrity": "sha1-mch+wu+3BH7WOPtMnbfzpC4iF7U=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "async-foreach": "^0.1.3",
-        "chalk": "^1.1.1",
-        "cross-spawn": "^3.0.0",
-        "gaze": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "glob": "^7.0.3",
-        "in-publish": "^2.0.0",
-        "lodash": "^4.17.15",
-        "meow": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "nan": "^2.13.2",
-        "node-gyp": "^3.8.0",
-        "npmlog": "^4.0.0",
-        "request": "^2.88.0",
-        "sass-graph": "2.2.5",
-        "stdout-stream": "^1.4.0",
-        "true-case-path": "^1.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true,
-          "optional": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
-    "nopt": {
-      "version": "3.0.6",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true,
-      "requires": {
-        "abbrev": "1"
-      }
-    },
-    "normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        }
-      }
+    "node-releases": {
+      "version": "1.1.60",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/node-releases/-/node-releases-1.1.60.tgz",
+      "integrity": "sha1-aUi9/OgobwtdDlqI6DhOlU3+cIQ=",
+      "dev": true
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -4811,6 +5081,18 @@
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
       "dev": true
     },
+    "normalize-url": {
+      "version": "1.9.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/normalize-url/-/normalize-url-1.9.1.tgz",
+      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.0.1",
+        "prepend-http": "^1.0.0",
+        "query-string": "^4.1.0",
+        "sort-keys": "^1.0.0"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -4818,27 +5100,6 @@
       "dev": true,
       "requires": {
         "path-key": "^2.0.0"
-      }
-    },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
-      "dev": true,
-      "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
-      }
-    },
-    "nth-check": {
-      "version": "1.0.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/nth-check/-/nth-check-1.0.2.tgz",
-      "integrity": "sha1-sr0pXDfj3VijvwcAN2Zjuk2c8Fw=",
-      "dev": true,
-      "requires": {
-        "boolbase": "~1.0.0"
       }
     },
     "num2fraction": {
@@ -4857,7 +5118,8 @@
       "version": "0.9.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -4897,9 +5159,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc=",
+      "version": "1.8.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha1-34B+Xs9TpgnMa/6T6sPMe+WzqdA=",
       "dev": true
     },
     "object-is": {
@@ -4937,16 +5199,6 @@
         "function-bind": "^1.1.1",
         "has-symbols": "^1.0.0",
         "object-keys": "^1.0.11"
-      }
-    },
-    "object.getownpropertydescriptors": {
-      "version": "2.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-      "integrity": "sha1-Npvx+VktiridcS3O1cuBx8U1Jkk=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
       }
     },
     "object.pick": {
@@ -4988,6 +5240,15 @@
         "wrappy": "1"
       }
     },
+    "open": {
+      "version": "6.4.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/open/-/open-6.4.0.tgz",
+      "integrity": "sha1-XBPpbQ3IlGhhZPGJZez+iJ7PyKk=",
+      "dev": true,
+      "requires": {
+        "is-wsl": "^1.1.0"
+      }
+    },
     "opn": {
       "version": "5.5.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/opn/-/opn-5.5.0.tgz",
@@ -4995,20 +5256,6 @@
       "dev": true,
       "requires": {
         "is-wsl": "^1.1.0"
-      }
-    },
-    "optionator": {
-      "version": "0.8.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
-      "dev": true,
-      "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
       }
     },
     "original": {
@@ -5026,13 +5273,6 @@
       "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
       "dev": true
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true,
-      "optional": true
-    },
     "os-locale": {
       "version": "3.1.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/os-locale/-/os-locale-3.1.0.tgz",
@@ -5042,24 +5282,6 @@
         "execa": "^1.0.0",
         "lcid": "^2.0.0",
         "mem": "^4.0.0"
-      }
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true,
-      "optional": true
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "os-homedir": "^1.0.0",
-        "os-tmpdir": "^1.0.0"
       }
     },
     "p-defer": {
@@ -5081,21 +5303,21 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+      "version": "2.3.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "version": "3.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "^2.0.0"
       }
     },
     "p-map": {
@@ -5114,9 +5336,9 @@
       }
     },
     "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "version": "2.2.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true
     },
     "pako": {
@@ -5136,15 +5358,6 @@
         "readable-stream": "^2.1.5"
       }
     },
-    "param-case": {
-      "version": "2.1.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/param-case/-/param-case-2.1.1.tgz",
-      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "dev": true,
-      "requires": {
-        "no-case": "^2.2.0"
-      }
-    },
     "parse-asn1": {
       "version": "5.1.5",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/parse-asn1/-/parse-asn1-5.1.5.tgz",
@@ -5160,13 +5373,13 @@
       }
     },
     "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "version": "4.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
       }
     },
     "parse5": {
@@ -5242,12 +5455,20 @@
       "dev": true,
       "requires": {
         "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "pbkdf2": {
-      "version": "3.0.17",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha1-l2wgZTBhexTrsyEUI597CTNuk6Y=",
+      "version": "3.1.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pbkdf2/-/pbkdf2-3.1.1.tgz",
+      "integrity": "sha1-y4cksPramEWWhW0abrr9NYRlS5Q=",
       "dev": true,
       "requires": {
         "create-hash": "^1.1.2",
@@ -5261,12 +5482,19 @@
       "version": "2.1.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true,
+      "optional": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha1-IfMz6ba46v8CRo9RRupAbTRfTa0=",
       "dev": true
     },
     "pify": {
-      "version": "3.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "version": "4.0.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
       "dev": true
     },
     "pinkie": {
@@ -5285,34 +5513,25 @@
       }
     },
     "pkg-dir": {
-      "version": "2.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pkg-dir/-/pkg-dir-2.0.0.tgz",
-      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "version": "3.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
       "dev": true,
       "requires": {
-        "find-up": "^2.1.0"
+        "find-up": "^3.0.0"
       }
     },
     "portfinder": {
-      "version": "1.0.26",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/portfinder/-/portfinder-1.0.26.tgz",
-      "integrity": "sha1-R1ZY1WyjC+1yrH8TeO01C9G2TnA=",
+      "version": "1.0.28",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/portfinder/-/portfinder-1.0.28.tgz",
+      "integrity": "sha1-Z8RiKFK9U3TdHdkA93n1NGL6x3g=",
       "dev": true,
       "requires": {
         "async": "^2.6.2",
         "debug": "^3.1.1",
-        "mkdirp": "^0.5.1"
+        "mkdirp": "^0.5.5"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/async/-/async-2.6.3.tgz",
-          "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-3.2.6.tgz",
@@ -5321,12 +5540,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-          "dev": true
         }
       }
     },
@@ -5337,26 +5550,51 @@
       "dev": true
     },
     "postcss": {
-      "version": "6.0.23",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/postcss/-/postcss-6.0.23.tgz",
-      "integrity": "sha1-YcgswyisYOZ3ZF+XkFTrmLwOMyQ=",
+      "version": "7.0.17",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/postcss/-/postcss-7.0.17.tgz",
+      "integrity": "sha1-TaG9/1Mi1KCsqrTYfz54JDa60x8=",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
+        "chalk": "^2.4.2",
         "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "postcss-import": {
-      "version": "11.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/postcss-import/-/postcss-import-11.1.0.tgz",
-      "integrity": "sha1-Vck2LJGSmU7GiGXSJEGd8dspgfA=",
+      "version": "12.0.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/postcss-import/-/postcss-import-12.0.1.tgz",
+      "integrity": "sha1-z4x6sLXMq1ZJAkU25WX4QZKLcVM=",
       "dev": true,
       "requires": {
-        "postcss": "^6.0.1",
+        "postcss": "^7.0.1",
         "postcss-value-parser": "^3.2.3",
         "read-cache": "^1.0.0",
         "resolve": "^1.1.7"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+          "dev": true
+        }
       }
     },
     "postcss-load-config": {
@@ -5370,51 +5608,28 @@
       }
     },
     "postcss-loader": {
-      "version": "2.1.6",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/postcss-loader/-/postcss-loader-2.1.6.tgz",
-      "integrity": "sha1-HX3XsXxrojS5vtWvE+C+pApC10A=",
+      "version": "3.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/postcss-loader/-/postcss-loader-3.0.0.tgz",
+      "integrity": "sha1-a5eUPkfHLYRfqeA/Jzdz1OjdbC0=",
       "dev": true,
       "requires": {
         "loader-utils": "^1.1.0",
-        "postcss": "^6.0.0",
+        "postcss": "^7.0.0",
         "postcss-load-config": "^2.0.0",
-        "schema-utils": "^0.4.0"
-      }
-    },
-    "postcss-url": {
-      "version": "7.3.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/postcss-url/-/postcss-url-7.3.2.tgz",
-      "integrity": "sha1-X+onOAf7hLOMRhw8mp6KvSNfcSA=",
-      "dev": true,
-      "requires": {
-        "mime": "^1.4.1",
-        "minimatch": "^3.0.4",
-        "mkdirp": "^0.5.0",
-        "postcss": "^6.0.1",
-        "xxhashjs": "^0.2.1"
+        "schema-utils": "^1.0.0"
       }
     },
     "postcss-value-parser": {
-      "version": "3.3.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-      "integrity": "sha1-n/giVH4okyE88cMO+lGsX9G6goE=",
+      "version": "4.1.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+      "integrity": "sha1-RD9qIM7WSBor2k+oUypuVdeJoss=",
       "dev": true
     },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
-    },
-    "pretty-error": {
-      "version": "2.1.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pretty-error/-/pretty-error-2.1.1.tgz",
-      "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
-      "dev": true,
-      "requires": {
-        "renderkid": "^2.0.1",
-        "utila": "~0.4"
-      }
     },
     "process": {
       "version": "0.11.10",
@@ -5460,17 +5675,12 @@
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
     },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/psl/-/psl-1.8.0.tgz",
       "integrity": "sha1-kyb4vPsBOtzABf3/BWrM4CDlHCQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -5487,17 +5697,17 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+          "version": "4.11.9",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha1-JtVWgpRY+dHoH8SJUkk9C6NQeCg=",
           "dev": true
         }
       }
     },
     "pump": {
-      "version": "2.0.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
+      "version": "3.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -5513,6 +5723,18 @@
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
         "pump": "^2.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
       }
     },
     "punycode": {
@@ -5525,7 +5747,18 @@
       "version": "6.5.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/qs/-/qs-6.5.2.tgz",
       "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
-      "dev": true
+      "dev": true,
+      "optional": true
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/query-string/-/query-string-4.3.4.tgz",
+      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -5591,10 +5824,45 @@
       }
     },
     "raw-loader": {
-      "version": "0.5.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/raw-loader/-/raw-loader-0.5.1.tgz",
-      "integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
-      "dev": true
+      "version": "3.1.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/raw-loader/-/raw-loader-3.1.0.tgz",
+      "integrity": "sha1-Xp05mloiLMDeGPQsO8XklndTKz8=",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^2.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.3",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha1-GMWvOKER3etPJpe9eNaKvByr1wY=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha1-FxUfdtjq5n+793lgwzxnatn078c=",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        }
+      }
     },
     "read-cache": {
       "version": "1.0.0",
@@ -5610,73 +5878,6 @@
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
-        }
-      }
-    },
-    "read-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
-      },
-      "dependencies": {
-        "path-type": {
-          "version": "1.1.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/path-type/-/path-type-1.1.0.tgz",
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "1.1.2",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-up/-/find-up-1.1.2.tgz",
-          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
         }
       }
     },
@@ -5696,32 +5897,43 @@
       }
     },
     "readdirp": {
-      "version": "2.2.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readdirp/-/readdirp-2.2.1.tgz",
-      "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
+      "version": "3.4.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readdirp/-/readdirp-3.4.0.tgz",
+      "integrity": "sha1-n9zN+ekVWAVEkiGsZF6DA6tbmto=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
+        "picomatch": "^2.2.1"
       }
     },
-    "redent": {
-      "version": "1.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/redent/-/redent-1.0.0.tgz",
-      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+    "regenerate": {
+      "version": "1.4.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regenerate/-/regenerate-1.4.1.tgz",
+      "integrity": "sha1-ytkq2Oa1kXc0hfvgWkhcr09Ffm8=",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "8.2.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+      "integrity": "sha1-5d5xEdZV57pgwFfb6f83yH5lzew=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
+        "regenerate": "^1.4.0"
       }
     },
     "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
+      "version": "0.13.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha1-fPanfY9cb2Drc8X8GVWyzrAea/U=",
       "dev": true
+    },
+    "regenerator-transform": {
+      "version": "0.14.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+      "integrity": "sha1-yY2hVGg2ccnE3LFuznNlF+G3/rQ=",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.8.4"
+      }
     },
     "regex-not": {
       "version": "1.0.2",
@@ -5743,30 +5955,48 @@
         "es-abstract": "^1.17.0-next.1"
       }
     },
-    "relateurl": {
-      "version": "0.2.7",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+    "regexpu-core": {
+      "version": "4.7.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regexpu-core/-/regexpu-core-4.7.0.tgz",
+      "integrity": "sha1-/L9FjFBDGwu3tF1pZ7gZLZHz2Tg=",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.2.0",
+        "regjsgen": "^0.5.1",
+        "regjsparser": "^0.6.4",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.2.0"
+      }
+    },
+    "regjsgen": {
+      "version": "0.5.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regjsgen/-/regjsgen-0.5.2.tgz",
+      "integrity": "sha1-kv8pX7He7L9uzaslQ9IH6RqjNzM=",
       "dev": true
+    },
+    "regjsparser": {
+      "version": "0.6.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/regjsparser/-/regjsparser-0.6.4.tgz",
+      "integrity": "sha1-p2n4aEMIQBpm6bUp0kNv9NBmYnI=",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
-    },
-    "renderkid": {
-      "version": "2.0.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/renderkid/-/renderkid-2.0.3.tgz",
-      "integrity": "sha1-OAF5wv9a4TZcUivy/Pz/AcW3QUk=",
-      "dev": true,
-      "requires": {
-        "css-select": "^1.1.0",
-        "dom-converter": "^0.2",
-        "htmlparser2": "^3.3.0",
-        "strip-ansi": "^3.0.0",
-        "utila": "^0.4.0"
-      }
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -5780,20 +6010,12 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
     },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "^1.0.0"
-      }
-    },
     "request": {
       "version": "2.88.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/request/-/request-2.88.2.tgz",
       "integrity": "sha1-1zyRhzHLWofaBH4gcjQUb2ZNErM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -5824,11 +6046,10 @@
       "dev": true
     },
     "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
-      "dev": true,
-      "optional": true
+      "version": "1.0.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+      "dev": true
     },
     "requires-port": {
       "version": "1.0.0",
@@ -5837,10 +6058,13 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.1.7",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-      "dev": true
+      "version": "1.17.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha1-sllBtUloIxzC0bt2p5y38sC/hEQ=",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
     },
     "resolve-cwd": {
       "version": "2.0.0",
@@ -5904,9 +6128,9 @@
       }
     },
     "rxjs": {
-      "version": "6.2.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/rxjs/-/rxjs-6.2.2.tgz",
-      "integrity": "sha1-63X6PBhv9SiZB9Bkg6d4hFhuHPk=",
+      "version": "6.4.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/rxjs/-/rxjs-6.4.0.tgz",
+      "integrity": "sha1-87sP572n+2nerAwW8XtQsLh5BQQ=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -5933,83 +6157,51 @@
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true
     },
-    "sass-graph": {
-      "version": "2.2.5",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sass-graph/-/sass-graph-2.2.5.tgz",
-      "integrity": "sha1-qYHIdEa4MZ2W3OBnHkh4eb0kwug=",
+    "sass": {
+      "version": "1.22.9",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sass/-/sass-1.22.9.tgz",
+      "integrity": "sha1-QaLtYDgCf1i+K9UEEpNFKinCy4Q=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "glob": "^7.0.0",
-        "lodash": "^4.0.0",
-        "scss-tokenizer": "^0.2.3",
-        "yargs": "^13.3.2"
+        "chokidar": ">=2.0.0 <4.0.0"
       }
     },
     "sass-loader": {
-      "version": "7.3.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sass-loader/-/sass-loader-7.3.1.tgz",
-      "integrity": "sha1-pb9ooEvOocE/+ELXRxUPerfQ0j8=",
+      "version": "7.2.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sass-loader/-/sass-loader-7.2.0.tgz",
+      "integrity": "sha1-40EVI5MJ0VslJ8titd/vtiqW/38=",
       "dev": true,
       "requires": {
         "clone-deep": "^4.0.1",
         "loader-utils": "^1.0.1",
         "neo-async": "^2.5.0",
         "pify": "^4.0.1",
-        "semver": "^6.3.0"
+        "semver": "^5.5.0"
       },
       "dependencies": {
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
-          "dev": true
-        },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "version": "5.7.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
           "dev": true
         }
       }
     },
     "sax": {
-      "version": "1.2.4",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "version": "0.5.8",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sax/-/sax-0.5.8.tgz",
+      "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=",
       "dev": true
     },
     "schema-utils": {
-      "version": "0.4.7",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-0.4.7.tgz",
-      "integrity": "sha1-unT1l9K+LqiAExdG7hfQoJPGgYc=",
+      "version": "1.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-1.0.0.tgz",
+      "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
       "dev": true,
       "requires": {
         "ajv": "^6.1.0",
+        "ajv-errors": "^1.0.0",
         "ajv-keywords": "^3.1.0"
-      }
-    },
-    "scss-tokenizer": {
-      "version": "0.2.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
-      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "js-base64": "^2.1.8",
-        "source-map": "^0.4.2"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
       }
     },
     "select-hose": {
@@ -6028,9 +6220,9 @@
       }
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+      "version": "6.3.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
       "dev": true
     },
     "send": {
@@ -6054,6 +6246,23 @@
         "statuses": "~1.5.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.1.1.tgz",
@@ -6063,9 +6272,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.9.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-      "integrity": "sha1-z8IArvd7YAxH2pu4FJyUPnmML9s=",
+      "version": "2.1.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha1-7OxTsOAxe9yV73arcHS3OEeF+mE=",
       "dev": true
     },
     "serve-index": {
@@ -6083,6 +6292,15 @@
         "parseurl": "~1.3.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "http-errors": {
           "version": "1.6.3",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/http-errors/-/http-errors-1.6.3.tgz",
@@ -6099,6 +6317,12 @@
           "version": "2.0.3",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         },
         "setprototypeof": {
@@ -6224,6 +6448,15 @@
         "use": "^3.1.0"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/define-property/-/define-property-0.2.5.tgz",
@@ -6241,6 +6474,12 @@
           "requires": {
             "is-extendable": "^0.1.0"
           }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "source-map": {
           "version": "0.5.7",
@@ -6362,24 +6601,29 @@
           "requires": {
             "websocket-driver": ">=0.5.1"
           }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-          "dev": true
         }
+      }
+    },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0"
       }
     },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-list-map/-/source-list-map-2.0.1.tgz",
-      "integrity": "sha1-OZO9hzv8SEecyp6jpUeDXHwVSzQ="
+      "integrity": "sha1-OZO9hzv8SEecyp6jpUeDXHwVSzQ=",
+      "dev": true
     },
     "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+      "version": "0.7.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.7.3.tgz",
+      "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
+      "dev": true
     },
     "source-map-loader": {
       "version": "0.2.4",
@@ -6389,17 +6633,6 @@
       "requires": {
         "async": "^2.5.0",
         "loader-utils": "^1.1.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/async/-/async-2.6.3.tgz",
-          "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        }
       }
     },
     "source-map-resolve": {
@@ -6416,13 +6649,21 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
+      "version": "0.5.13",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
       }
     },
     "source-map-url": {
@@ -6431,36 +6672,10 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
-    "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
-      "dev": true,
-      "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.3.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha1-PyjOGnegA3JoPq3kpDMYNSeiFj0=",
-      "dev": true
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
-      "dev": true,
-      "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha1-6oBL2UhXQC5pktBaOO8a41qatMQ=",
       "dev": true
     },
     "spdy": {
@@ -6474,23 +6689,6 @@
         "http-deceiver": "^1.2.7",
         "select-hose": "^2.0.0",
         "spdy-transport": "^3.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-          "dev": true
-        }
       }
     },
     "spdy-transport": {
@@ -6507,21 +6705,6 @@
         "wbuf": "^1.7.3"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-          "dev": true
-        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -6533,6 +6716,15 @@
             "util-deprecate": "^1.0.1"
           }
         }
+      }
+    },
+    "speed-measure-webpack-plugin": {
+      "version": "1.3.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.3.1.tgz",
+      "integrity": "sha1-aYQKXNwItGOGl9rH2wN/WV1/NqA=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
       }
     },
     "split-string": {
@@ -6555,6 +6747,7 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -6568,12 +6761,12 @@
       }
     },
     "ssri": {
-      "version": "5.3.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ssri/-/ssri-5.3.0.tgz",
-      "integrity": "sha1-ujhyycbTOgcEp9cf8EXl7EiZnQY=",
+      "version": "6.0.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ssri/-/ssri-6.0.1.tgz",
+      "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.1"
+        "figgy-pudding": "^3.5.1"
       }
     },
     "static-extend": {
@@ -6597,30 +6790,11 @@
         }
       }
     },
-    "stats-webpack-plugin": {
-      "version": "0.6.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/stats-webpack-plugin/-/stats-webpack-plugin-0.6.2.tgz",
-      "integrity": "sha1-LFlJtTHgf4eojm6k3PrFOqjHWis=",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.4"
-      }
-    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
       "dev": true
-    },
-    "stdout-stream": {
-      "version": "1.4.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/stdout-stream/-/stdout-stream-1.4.1.tgz",
-      "integrity": "sha1-WsF0zdXNcmEEqgwLK9g4FdjVNd4=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "readable-stream": "^2.0.1"
-      }
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -6661,15 +6835,37 @@
       "integrity": "sha1-1wiCgVWasneEJCebCHfaPDktWj0=",
       "dev": true
     },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
+    },
     "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "version": "2.1.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "dev": true,
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
     },
     "string.prototype.trimend": {
@@ -6680,28 +6876,6 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
-      }
-    },
-    "string.prototype.trimleft": {
-      "version": "2.1.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-      "integrity": "sha1-RAiqLl1t3QyagHObCH+8BnwDs8w=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimstart": "^1.0.0"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-      "integrity": "sha1-x28c7zDyG7rYr+uNsVEUls+w8qM=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimend": "^1.0.0"
       }
     },
     "string.prototype.trimstart": {
@@ -6732,78 +6906,89 @@
         "ansi-regex": "^2.0.0"
       }
     },
-    "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "is-utf8": "^0.2.0"
-      }
-    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
-    "strip-indent": {
-      "version": "1.0.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strip-indent/-/strip-indent-1.0.1.tgz",
-      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "get-stdin": "^4.0.1"
-      }
-    },
     "style-loader": {
-      "version": "0.21.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/style-loader/-/style-loader-0.21.0.tgz",
-      "integrity": "sha1-aMUuXrKvycqStidL4nfuWa6jqFI=",
+      "version": "1.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/style-loader/-/style-loader-1.0.0.tgz",
+      "integrity": "sha1-HVKW+RZejiyF0k7uC3yvnsjKH4I=",
       "dev": true,
       "requires": {
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^0.4.5"
+        "loader-utils": "^1.2.3",
+        "schema-utils": "^2.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.3",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha1-GMWvOKER3etPJpe9eNaKvByr1wY=",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha1-FxUfdtjq5n+793lgwzxnatn078c=",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        }
       }
     },
     "stylus": {
-      "version": "0.54.7",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/stylus/-/stylus-0.54.7.tgz",
-      "integrity": "sha1-xs5Hk5Ze5Ti86+UPMVN7/ATYjNI=",
+      "version": "0.54.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/stylus/-/stylus-0.54.5.tgz",
+      "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
       "dev": true,
       "requires": {
-        "css-parse": "~2.0.0",
-        "debug": "~3.1.0",
-        "glob": "^7.1.3",
-        "mkdirp": "~0.5.x",
-        "safer-buffer": "^2.1.2",
-        "sax": "~1.2.4",
-        "semver": "^6.0.0",
-        "source-map": "^0.7.3"
+        "css-parse": "1.7.x",
+        "debug": "*",
+        "glob": "7.0.x",
+        "mkdirp": "0.5.x",
+        "sax": "0.5.x",
+        "source-map": "0.1.x"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+        "glob": {
+          "version": "7.0.6",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/glob/-/glob-7.0.6.tgz",
+          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
-          "dev": true
-        },
         "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha1-UwL4FpAxc1ImVECS5kmB91F1A4M=",
-          "dev": true
+          "version": "0.1.43",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
         }
       }
     },
@@ -6833,22 +7018,10 @@
       "integrity": "sha1-ofzMBrWNth/XpF2i2kT186Pme6I=",
       "dev": true
     },
-    "tar": {
-      "version": "2.2.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tar/-/tar-2.2.2.tgz",
-      "integrity": "sha1-DKiEhWLHKZuLRG/2pNYM27I+3EA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.12",
-        "inherits": "2"
-      }
-    },
     "terser": {
-      "version": "4.6.13",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/terser/-/terser-4.6.13.tgz",
-      "integrity": "sha1-6HmnNkpeDbUrpIkezeAHQixWqRY=",
+      "version": "4.3.9",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/terser/-/terser-4.3.9.tgz",
+      "integrity": "sha1-5L43+AVT0CZFZocnd3aH2tJrvKg=",
       "dev": true,
       "requires": {
         "commander": "^2.20.0",
@@ -6856,10 +7029,10 @@
         "source-map-support": "~0.5.12"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -6881,29 +7054,6 @@
         "worker-farm": "^1.7.0"
       },
       "dependencies": {
-        "cacache": {
-          "version": "12.0.4",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cacache/-/cacache-12.0.4.tgz",
-          "integrity": "sha1-ZovL0QWutfHZL+JVcOyVJcj6pAw=",
-          "dev": true,
-          "requires": {
-            "bluebird": "^3.5.5",
-            "chownr": "^1.1.1",
-            "figgy-pudding": "^3.5.1",
-            "glob": "^7.1.4",
-            "graceful-fs": "^4.1.15",
-            "infer-owner": "^1.0.3",
-            "lru-cache": "^5.1.1",
-            "mississippi": "^3.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.3",
-            "ssri": "^6.0.1",
-            "unique-filename": "^1.1.1",
-            "y18n": "^4.0.0"
-          }
-        },
         "find-cache-dir": {
           "version": "2.1.0",
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
@@ -6915,141 +7065,10 @@
             "pkg-dir": "^3.0.0"
           }
         },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "5.1.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/lru-cache/-/lru-cache-5.1.1.tgz",
-          "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "make-dir": {
-          "version": "2.1.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
-          "dev": true,
-          "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "mississippi": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mississippi/-/mississippi-3.0.0.tgz",
-          "integrity": "sha1-6goykfl+C16HdrNj1fChLZTGcCI=",
-          "dev": true,
-          "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^3.0.0",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
-          "dev": true
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pkg-dir/-/pkg-dir-3.0.0.tgz",
-          "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
-          "dev": true,
-          "requires": {
-            "find-up": "^3.0.0"
-          }
-        },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        },
-        "serialize-javascript": {
-          "version": "2.1.2",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-          "integrity": "sha1-7OxTsOAxe9yV73arcHS3OEeF+mE=",
-          "dev": true
-        },
-        "ssri": {
-          "version": "6.0.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha1-KjxBso3UW2K2Nnbst0ABJlrp7dg=",
-          "dev": true,
-          "requires": {
-            "figgy-pudding": "^3.5.1"
-          }
-        },
-        "yallist": {
-          "version": "3.1.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
@@ -7086,9 +7105,9 @@
       "dev": true
     },
     "to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "version": "2.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-object-path": {
@@ -7124,13 +7143,12 @@
       }
     },
     "to-regex-range": {
-      "version": "2.1.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
-      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "version": "5.0.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "repeat-string": "^1.6.1"
+        "is-number": "^7.0.0"
       }
     },
     "toidentifier": {
@@ -7139,17 +7157,12 @@
       "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM=",
       "dev": true
     },
-    "toposort": {
-      "version": "1.0.7",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/toposort/-/toposort-1.0.7.tgz",
-      "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
-      "dev": true
-    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha1-zZ+yoKodWhK0c72fuW+j3P9lreI=",
       "dev": true,
+      "optional": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -7161,33 +7174,10 @@
       "integrity": "sha1-TKCakJLIi3OnzcXooBtQeweQoMw=",
       "dev": true
     },
-    "trim-newlines": {
-      "version": "1.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
-      "dev": true,
-      "optional": true
-    },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
-    },
-    "true-case-path": {
-      "version": "1.0.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/true-case-path/-/true-case-path-1.0.3.tgz",
-      "integrity": "sha1-+BO1qMhrQNpZYGcisUTjIleZ9H0=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "glob": "^7.1.2"
-      }
-    },
     "tslib": {
-      "version": "1.11.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tslib/-/tslib-1.11.2.tgz",
-      "integrity": "sha1-nHnYMnLJp6rxZvc5Fclmfs3ePMk=",
+      "version": "1.13.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha1-yIHhPMcBWJTtkUhi0nZDb6mkcEM=",
       "dev": true
     },
     "tty-browserify": {
@@ -7201,6 +7191,7 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -7210,15 +7201,6 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "~1.1.2"
-      }
     },
     "type-is": {
       "version": "1.6.18",
@@ -7237,62 +7219,38 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha1-HL9h0F1rliaSROtqO85L2RTg8Aw=",
+      "version": "3.5.3",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha1-yDD2V/k/HqhGgZ6SkJL1/lmD6Xc=",
       "dev": true
     },
-    "uglify-js": {
-      "version": "3.4.10",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/uglify-js/-/uglify-js-3.4.10.tgz",
-      "integrity": "sha1-mtlWPY6zrN+404WX0q8dgV9qdV8=",
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha1-JhmADEyCWADv3YNDr33Zkzy+KBg=",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha1-jtKjJWmWG86SJ9Cc0/+7j+1fAgw=",
       "dev": true,
       "requires": {
-        "commander": "~2.19.0",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.19.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/commander/-/commander-2.19.0.tgz",
-          "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So=",
-          "dev": true
-        }
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
       }
     },
-    "uglifyjs-webpack-plugin": {
-      "version": "1.3.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
-      "integrity": "sha1-dfVIFghYFjoIZD4IbV/v4YpdZ94=",
-      "dev": true,
-      "requires": {
-        "cacache": "^10.0.4",
-        "find-cache-dir": "^1.0.0",
-        "schema-utils": "^0.4.5",
-        "serialize-javascript": "^1.4.0",
-        "source-map": "^0.6.1",
-        "uglify-es": "^3.3.4",
-        "webpack-sources": "^1.1.0",
-        "worker-farm": "^1.5.2"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.13.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/commander/-/commander-2.13.0.tgz",
-          "integrity": "sha1-aWS8pnaF33wfFDDFhPB9dZeIW5w=",
-          "dev": true
-        },
-        "uglify-es": {
-          "version": "3.3.9",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/uglify-es/-/uglify-es-3.3.9.tgz",
-          "integrity": "sha1-DBxPBwC+2NvBJM2zBNJZLKID5nc=",
-          "dev": true,
-          "requires": {
-            "commander": "~2.13.0",
-            "source-map": "~0.6.1"
-          }
-        }
-      }
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.2.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+      "integrity": "sha1-DZH2AO7rMJaqlisdb8iIduZOpTE=",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.1.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+      "integrity": "sha1-3Vepn2IHvt/0Yoq++5TFDblByPQ=",
+      "dev": true
     },
     "union-value": {
       "version": "1.0.1",
@@ -7376,16 +7334,10 @@
       "integrity": "sha1-j2bbzVWog6za5ECK+LA1pQRMGJQ=",
       "dev": true
     },
-    "upper-case": {
-      "version": "1.1.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/upper-case/-/upper-case-1.1.3.tgz",
-      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
-      "dev": true
-    },
     "uri-js": {
-      "version": "3.0.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/uri-js/-/uri-js-3.0.2.tgz",
-      "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+      "version": "4.2.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -7412,36 +7364,6 @@
           "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/punycode/-/punycode-1.3.2.tgz",
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
-        }
-      }
-    },
-    "url-loader": {
-      "version": "1.1.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/url-loader/-/url-loader-1.1.2.tgz",
-      "integrity": "sha1-uXHRkbg69pPF4/6kBkvp4fLX+Ng=",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.1.0",
-        "mime": "^2.0.3",
-        "schema-utils": "^1.0.0"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "2.4.5",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mime/-/mime-2.4.5.tgz",
-          "integrity": "sha1-2N4uy5KYLe27ZUHJtoQdfyGOoAk=",
-          "dev": true
-        },
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
-          }
         }
       }
     },
@@ -7484,22 +7406,6 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
-    "util.promisify": {
-      "version": "1.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/util.promisify/-/util.promisify-1.0.0.tgz",
-      "integrity": "sha1-RA9xZaRZyaFtwUXrjnLzVocJcDA=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "object.getownpropertydescriptors": "^2.0.3"
-      }
-    },
-    "utila": {
-      "version": "0.4.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/utila/-/utila-0.4.0.tgz",
-      "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
-      "dev": true
-    },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -7512,16 +7418,6 @@
       "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
       "dev": true
     },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/vary/-/vary-1.1.2.tgz",
@@ -7533,6 +7429,7 @@
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -7546,14 +7443,181 @@
       "dev": true
     },
     "watchpack": {
-      "version": "1.6.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/watchpack/-/watchpack-1.6.1.tgz",
-      "integrity": "sha1-KA2gqHGFkhdAEMB4x1hadM2M0OI=",
+      "version": "1.7.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/watchpack/-/watchpack-1.7.4.tgz",
+      "integrity": "sha1-bp2lOzyAuy1lCBiPWyAEEIZs0ws=",
       "dev": true,
       "requires": {
-        "chokidar": "^2.1.8",
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.0"
+      }
+    },
+    "watchpack-chokidar2": {
+      "version": "2.0.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
+      "integrity": "sha1-mUihhmy71suCTeoTp+1pH2yN3/A=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chokidar": "^2.1.8"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
+          "dev": true,
+          "optional": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
       }
     },
     "wbuf": {
@@ -7566,16 +7630,16 @@
       }
     },
     "webpack": {
-      "version": "4.43.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack/-/webpack-4.43.0.tgz",
-      "integrity": "sha1-xIVHsR1WMiTFYdrRFyyKoLimeOY=",
+      "version": "4.39.2",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack/-/webpack-4.39.2.tgz",
+      "integrity": "sha1-yapcF3bXwwnRs5EXZPAojIwoFqo=",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.9.0",
-        "@webassemblyjs/helper-module-context": "1.9.0",
-        "@webassemblyjs/wasm-edit": "1.9.0",
-        "@webassemblyjs/wasm-parser": "1.9.0",
-        "acorn": "^6.4.1",
+        "@webassemblyjs/ast": "1.8.5",
+        "@webassemblyjs/helper-module-context": "1.8.5",
+        "@webassemblyjs/wasm-edit": "1.8.5",
+        "@webassemblyjs/wasm-parser": "1.8.5",
+        "acorn": "^6.2.1",
         "ajv": "^6.10.2",
         "ajv-keywords": "^3.4.1",
         "chrome-trace-event": "^1.0.2",
@@ -7586,58 +7650,39 @@
         "loader-utils": "^1.2.3",
         "memory-fs": "^0.4.1",
         "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.3",
+        "mkdirp": "^0.5.1",
         "neo-async": "^2.6.1",
         "node-libs-browser": "^2.2.1",
         "schema-utils": "^1.0.0",
         "tapable": "^1.1.3",
-        "terser-webpack-plugin": "^1.4.3",
-        "watchpack": "^1.6.1",
+        "terser-webpack-plugin": "^1.4.1",
+        "watchpack": "^1.6.0",
         "webpack-sources": "^1.4.1"
+      }
+    },
+    "webpack-core": {
+      "version": "0.6.9",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack-core/-/webpack-core-0.6.9.tgz",
+      "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
+      "dev": true,
+      "requires": {
+        "source-list-map": "~0.1.7",
+        "source-map": "~0.4.1"
       },
       "dependencies": {
-        "ajv": {
-          "version": "6.12.2",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ajv/-/ajv-6.12.2.tgz",
-          "integrity": "sha1-xinF7O0XuvMUQ3kY0tqIyZ1ZWM0=",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha1-VFFFB3xQFJHjOxXsQIwpQ3bpSuQ=",
+        "source-list-map": {
+          "version": "0.1.8",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-list-map/-/source-list-map-0.1.8.tgz",
+          "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
           "dev": true
         },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
-          "dev": true
-        },
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        },
-        "uri-js": {
-          "version": "4.2.2",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/uri-js/-/uri-js-4.2.2.tgz",
-          "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
-          "dev": true,
-          "requires": {
-            "punycode": "^2.1.0"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -7656,17 +7701,17 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.4.5",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mime/-/mime-2.4.5.tgz",
-          "integrity": "sha1-2N4uy5KYLe27ZUHJtoQdfyGOoAk=",
+          "version": "2.4.6",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/mime/-/mime-2.4.6.tgz",
+          "integrity": "sha1-5bQHyQ20QvK+tbFiNz0Htpr/pNE=",
           "dev": true
         }
       }
     },
     "webpack-dev-server": {
-      "version": "3.10.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack-dev-server/-/webpack-dev-server-3.10.3.tgz",
-      "integrity": "sha1-81lFA2gT5X71gsJCDve0cOFNOvA=",
+      "version": "3.9.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack-dev-server/-/webpack-dev-server-3.9.0.tgz",
+      "integrity": "sha1-J8O10Pa2Z3xDBEZayBdiPIsnuJw=",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
@@ -7684,7 +7729,7 @@
         "ip": "^1.1.5",
         "is-absolute-url": "^3.0.3",
         "killable": "^1.0.1",
-        "loglevel": "^1.6.6",
+        "loglevel": "^1.6.4",
         "opn": "^5.5.0",
         "p-retry": "^3.0.1",
         "portfinder": "^1.0.25",
@@ -7704,152 +7749,139 @@
         "yargs": "12.0.5"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "4.1.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
-          "dev": true,
-          "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "get-caller-file": {
-          "version": "1.0.3",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/get-caller-file/-/get-caller-file-1.0.3.tgz",
-          "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
+        "anymatch": {
           "version": "2.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha1-vLJLTzeTTZqnrBe0ra+J58du8us=",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-          "dev": true
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
-          "dev": true
-        },
-        "schema-utils": {
-          "version": "1.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/schema-utils/-/schema-utils-1.0.0.tgz",
-          "integrity": "sha1-C3mpMgTXtgDUsoUNH2bCo0lRx3A=",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-errors": "^1.0.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
           },
           "dependencies": {
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "normalize-path": {
+              "version": "2.1.1",
+              "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/normalize-path/-/normalize-path-2.1.1.tgz",
+              "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "remove-trailing-separator": "^1.0.1"
               }
             }
+          }
+        },
+        "binary-extensions": {
+          "version": "1.13.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/binary-extensions/-/binary-extensions-1.13.1.tgz",
+          "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "2.1.8",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/chokidar/-/chokidar-2.1.8.tgz",
+          "integrity": "sha1-gEs6e2qZNYw8XGHnHYco8EHP+Rc=",
+          "dev": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "fsevents": "^1.2.7",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.1"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.13",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/fsevents/-/fsevents-1.2.13.tgz",
+          "integrity": "sha1-8yXLBFVZJCi88Rs4M3DvcOO/zDg=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-binary-path/-/is-binary-path-1.0.1.tgz",
+          "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+          "dev": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/readdirp/-/readdirp-2.2.1.tgz",
+          "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
           }
         },
         "supports-color": {
@@ -7861,66 +7893,14 @@
             "has-flag": "^3.0.0"
           }
         },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
-          }
-        },
-        "yargs": {
-          "version": "12.0.5",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yargs/-/yargs-12.0.5.tgz",
-          "integrity": "sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=",
-          "dev": true,
-          "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^3.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^11.1.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "11.1.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yargs-parser/-/yargs-parser-11.1.1.tgz",
-          "integrity": "sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
           }
         }
       }
@@ -7936,47 +7916,56 @@
       }
     },
     "webpack-merge": {
-      "version": "4.2.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack-merge/-/webpack-merge-4.2.2.tgz",
-      "integrity": "sha1-onxS6ng9E5iv0gh/VH17nS9DY00=",
+      "version": "4.2.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack-merge/-/webpack-merge-4.2.1.tgz",
+      "integrity": "sha1-XpI8+ALqKs5P1a8dMkc2imM0ibQ=",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.5"
       }
     },
     "webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack-sources/-/webpack-sources-1.4.3.tgz",
       "integrity": "sha1-7t2OwLko+/HL/plOItLYkPMwqTM=",
+      "dev": true,
       "requires": {
         "source-list-map": "^2.0.0",
         "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
       }
     },
     "webpack-subresource-integrity": {
-      "version": "1.4.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack-subresource-integrity/-/webpack-subresource-integrity-1.4.1.tgz",
-      "integrity": "sha1-6L+Ri0RCd99GpmzYRULLzcWmJy0=",
+      "version": "1.1.0-rc.6",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/webpack-subresource-integrity/-/webpack-subresource-integrity-1.1.0-rc.6.tgz",
+      "integrity": "sha1-N/bxJk4es3jkFGWpjagPrXariIY=",
       "dev": true,
       "requires": {
-        "webpack-sources": "^1.3.0"
+        "webpack-core": "^0.6.8"
       }
     },
     "websocket-driver": {
-      "version": "0.7.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/websocket-driver/-/websocket-driver-0.7.3.tgz",
-      "integrity": "sha1-otTg1PTxFvHmKX66WLBdQwEA6fk=",
+      "version": "0.7.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha1-ia1Slbv2S0gKvLox5JU6ynBvV2A=",
       "dev": true,
       "requires": {
-        "http-parser-js": ">=0.4.0 <0.4.11",
+        "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",
         "websocket-extensions": ">=0.1.1"
       }
     },
     "websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha1-XS/yKXcAPsaHpLhwc9+7rBRszyk=",
+      "version": "0.1.4",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha1-f4RzvIOd/YdgituV1+sHUhFXikI=",
       "dev": true
     },
     "when": {
@@ -8000,27 +7989,6 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
-    "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
-    },
     "worker-farm": {
       "version": "1.7.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/worker-farm/-/worker-farm-1.7.0.tgz",
@@ -8030,50 +7998,43 @@
         "errno": "~0.1.7"
       }
     },
-    "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
+    "worker-plugin": {
+      "version": "3.2.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/worker-plugin/-/worker-plugin-3.2.0.tgz",
+      "integrity": "sha1-3a6fFht2/Lqs+PVOzQN4RFhOQ+c=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
+        "loader-utils": "^1.1.0"
+      }
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
-          "dev": true
-        },
         "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "version": "1.0.0",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
-          "dev": true,
-          "optional": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "number-is-nan": "^1.0.0"
           }
         },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         }
       }
@@ -8099,15 +8060,6 @@
       "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
       "dev": true
     },
-    "xxhashjs": {
-      "version": "0.2.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/xxhashjs/-/xxhashjs-0.2.2.tgz",
-      "integrity": "sha1-imJRVnYhocRqWuIE2gJJx/jKqdg=",
-      "dev": true,
-      "requires": {
-        "cuint": "^0.2.2"
-      }
-    },
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/y18n/-/y18n-4.0.0.tgz",
@@ -8115,151 +8067,39 @@
       "dev": true
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "version": "3.1.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=",
       "dev": true
     },
     "yargs": {
-      "version": "13.3.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
+      "version": "12.0.5",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yargs/-/yargs-12.0.5.tgz",
+      "integrity": "sha1-BfWZe2CWR7ZPZrgeO0sQo2jnrRM=",
       "dev": true,
-      "optional": true,
       "requires": {
-        "cliui": "^5.0.0",
+        "cliui": "^4.0.0",
+        "decamelize": "^1.2.0",
         "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^3.0.0",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
+        "require-main-filename": "^1.0.1",
         "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
+        "string-width": "^2.0.0",
         "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
-          "dev": true,
-          "optional": true
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true,
-          "optional": true
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
+        "y18n": "^3.2.1 || ^4.0.0",
+        "yargs-parser": "^11.1.1"
       }
     },
     "yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
+      "version": "11.1.1",
+      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yargs-parser/-/yargs-parser-11.1.1.tgz",
+      "integrity": "sha1-h5oIZZc7yp9rq1y987HGfsfTvPQ=",
       "dev": true,
-      "optional": true,
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
-    "yazl": {
-      "version": "2.5.1",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/yazl/-/yazl-2.5.1.tgz",
-      "integrity": "sha1-o9ZdPdZZpbCTeFDoYJ8i//orXDU=",
-      "requires": {
-        "buffer-crc32": "~0.2.3"
-      }
-    },
-    "zip-webpack-plugin": {
-      "version": "3.0.0",
-      "resolved": "https://build-artifactory.eng.vmware.com/api/npm/npm/zip-webpack-plugin/-/zip-webpack-plugin-3.0.0.tgz",
-      "integrity": "sha1-Y7PBc/GoegBpFc1zKKPEC0TcjjI=",
-      "requires": {
-        "webpack-sources": "^1.1.0",
-        "yazl": "^2.4.3"
       }
     }
   }

--- a/packages/angular/projects/vcd/sdk/src/new/package.json
+++ b/packages/angular/projects/vcd/sdk/src/new/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "zip-webpack-plugin": "3.0.0"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "0.803.29"
+  }
+}


### PR DESCRIPTION
[VACE-2623] Add support for UI Plugins Incremental Loading in the @vcd/plugin-builders

Implement support for UI Plugin Incremental loading.
Update the readme for the plugin builders describing the new features.
Introduce new options:
- vcdVersion used to turn on/off the incremental loading and for future versioning decisions
- externalLibs allowing the user to specify his external deps
- librariesConfig incremental loading scoping and versioning
- ignoreDefaultExternals ignore the default list of external libraries

Implemented for new and old plugin builder

Remove builder for 10.2 from builders.json, new version of the package
has to be released in order to support it.

Testing Done
Create 2 plugins with incremental loading enabled
Verify the bundles are generated correctly
Verify the plugins work in the vcd ui
Verify the scoping works
Verify ignore defaut externals works
Verify define externals via angular.json works
Verify the plugins with turned off incremental loading work

Signed-off-by: Nikola Vladimirov Iliev <nvladimirovi@vmware.com>