### PR TITLE
Split plugin-builders package into two

### DIFF
--- a/packages/angular/angular.json
+++ b/packages/angular/angular.json
@@ -70,6 +70,33 @@
         }
       }
     },
+    "@vcd/plugin-builders-new": {
+      "projectType": "library",
+      "root": "projects/vcd/plugin-builders",
+      "sourceRoot": "projects/vcd/plugin-builders/src",
+      "prefix": "lib",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-ng-packagr:build",
+          "options": {
+            "tsConfig": "projects/vcd/plugin-builders/tsconfig.lib.json",
+            "project": "projects/vcd/plugin-builders/ng-package-new.json"
+          }
+        },
+        "lint": {
+          "builder": "@angular-devkit/build-angular:tslint",
+          "options": {
+            "tsConfig": [
+              "projects/vcd/plugin-builders/tsconfig.lib.json",
+              "projects/vcd/plugin-builders/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**"
+            ]
+          }
+        }
+      }
+    },
     "@vcd/schematics": {
       "projectType": "library",
       "root": "projects/vcd/schematics",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -5,20 +5,26 @@
     "ng": "ng",
     "build": "npm run build:sdk && npm run build:schematics && npm run build:plugin-builders",
     "build:sdk": "ng build @vcd/sdk && npm run sdk:build:prod",
-    "build:plugin-builders": "npm run plugin-builders:install:dev:dep && ng build @vcd/plugin-builders && npm run plugin-builders:build",
+    "build:plugin-builders": "npm run plugin-builders:install:dev:dep && ng build @vcd/plugin-builders && ng build @vcd/plugin-builders-new && npm run plugin-builders:build:schematics && npm run plugin-builders:build && npm run plugin-builders:build:new",
     "build:schematics": "ng build @vcd/schematics && npm run schematics:build:prod",
+
 
     "sdk:build": "tsc -p ./projects/vcd/sdk/tsconfig.schematics.json",
     "sdk:build:prod": "npm run sdk:build && npm run sdk:copy:schemas && npm run sdk:fix:backwards:compatability",
     "sdk:copy:schemas": "cp -R ./projects/vcd/sdk/src/schematics ./dist/vcd/sdk",
     "sdk:fix:backwards:compatability": "node ./scripts/update_packagejson.js",
 
+    "plugin-builders:install:dev:dep": "cd ./projects/vcd/plugin-builders && npm i && cd ./src/lib/new && npm i",
     "plugin-builders:build:schematics": "tsc -p ./projects/vcd/plugin-builders/tsconfig.schematics.json",
-    "plugin-builders:copy:schemas": "cp -R ./projects/vcd/plugin-builders/src/lib/schematics ./dist/vcd/plugin-builders",
-    "plugin-builders:build": "tsc --build ./projects/vcd/plugin-builders/tsconfig.json && npm run plugin-builders:cpy:schema && npm run plugin-builders:cpy:builders && npm run plugin-builders:build:schematics && npm run plugin-builders:copy:schemas",
+
+    "plugin-builders:build": "tsc --build ./projects/vcd/plugin-builders/tsconfig.json && npm run plugin-builders:cpy:schema && npm run plugin-builders:cpy:builders && cp -R ./projects/vcd/plugin-builders/src/lib/schematics ./dist/vcd/plugin-builders",
     "plugin-builders:cpy:schema": "cp ./projects/vcd/plugin-builders/src/lib/base/schema.json ./dist/vcd/plugin-builders",
     "plugin-builders:cpy:builders": "cp ./projects/vcd/plugin-builders/builders.json ./dist/vcd/plugin-builders",
-    "plugin-builders:install:dev:dep": "cd ./projects/vcd/plugin-builders && npm i && cd ./src/lib/new && npm i",
+
+    "plugin-builders:build:new": "tsc --build ./projects/vcd/plugin-builders/tsconfig-new.json && npm run plugin-builders:cpy:schema:new && npm run plugin-builders:cpy:builders:new && cp -R ./projects/vcd/plugin-builders/src/lib/schematics ./dist/vcd/plugin-builders-new",
+    "plugin-builders:cpy:schema:new": "cp ./projects/vcd/plugin-builders/src/lib/new/schema.json ./dist/vcd/plugin-builders-new",
+    "plugin-builders:cpy:builders:new": "cp ./projects/vcd/plugin-builders/builders-new.json ./dist/vcd/plugin-builders-new/builders.json",
+
 
     "schematics:build": "tsc -p ./projects/vcd/schematics/tsconfig.json",
     "schematics:build:prod": "npm run schematics:build && npm run schematics:copy:schemas",

--- a/packages/angular/projects/vcd/plugin-builders/builders-new.json
+++ b/packages/angular/projects/vcd/plugin-builders/builders-new.json
@@ -1,0 +1,10 @@
+
+{
+    "builders": {
+        "plugin-builder": {
+            "implementation": "./new/index.js",
+            "schema": "./schema.json",
+            "description": "Build vCloud Director UI Plugin for version 10.1+"
+        }
+    }
+}

--- a/packages/angular/projects/vcd/plugin-builders/ng-package-new.json
+++ b/packages/angular/projects/vcd/plugin-builders/ng-package-new.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../../dist/vcd/plugin-builders-new",
+  "lib": {
+    "entryFile": "src/public-api-new.ts"
+  },
+  "whitelistedNonPeerDependencies": [
+    "zip-webpack-plugin"
+  ]
+}

--- a/packages/angular/projects/vcd/plugin-builders/src/public-api-new.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/public-api-new.ts
@@ -1,0 +1,5 @@
+/*
+ * Public API Surface of plugin-builders
+ */
+
+export * from './lib/new';

--- a/packages/angular/projects/vcd/plugin-builders/tsconfig-new.json
+++ b/packages/angular/projects/vcd/plugin-builders/tsconfig-new.json
@@ -2,13 +2,13 @@
     "extends": "../../../tsconfig.json",
     "compilerOptions": {
       "module": "commonjs",
-      "outDir": "../../../dist/vcd/plugin-builders",
+      "outDir": "../../../dist/vcd/plugin-builders-new",
       "importHelpers": false,
       "sourceMap": false,
       "target": "ES2015",
       "skipLibCheck": true
     },
     "include": [
-      "./src/lib/base/**/*.ts"
+      "./src/lib/new/**/*.ts"
     ]
 }


### PR DESCRIPTION
Because the plugin builder which has to be used is different
for different angular version we need to either release new version
or split the package into two parts (TBD).

Signed-off-by: Nikola Vladimirov Iliev <nvladimirovi@vmware.com>