### PR TITLE
Publish the new interface contract in the sdk

### DIFF
--- a/api-client/projects/vcd/sdk/src/common/container-hooks.ts
+++ b/api-client/projects/vcd/sdk/src/common/container-hooks.ts
@@ -178,3 +178,16 @@ export abstract class _EntityActionExtensionComponent {
      abstract performAction(menuItemUrn: string, entityUrn: string): Observable<{ refreshRequested: boolean }>;
 }
 export const EntityActionExtensionComponent: typeof _EntityActionExtensionComponent = containerHooks.EntityActionExtensionComponent;
+
+export abstract class _WizardExtensionComponent<P, R, E> {
+    /**
+     * Define method which will be executed by the Extension Point Orchestrator,
+     * when certain event is triggered.
+     * @param payload - the payload of the request triggered by the Core UI.
+     * @param response - the response from the request triggered by the Core UI.
+     * @param error - the Core UI will reprot any error that may appear during execution.
+     */
+    abstract performAction(payload: P, response: R, error: E): void;
+}
+
+export const WizardExtensionComponent: typeof _WizardExtensionComponent = containerHooks.WizardExtensionComponent;


### PR DESCRIPTION
This new extension contract will be used to
register new type of extension points which
will be allowed to execute callbacks at certain point
of time. This executions will be orchestrated by
the Core UI.

Tracked by: VACE-2819

Testing Done:
- Create two ext points from the new type
- Verfiy they are loaded and compiled
- Verify their actions are executed at the right time
- Verify they are renderd properly