### PR TITLE
Added analytics support 

### DIFF
--- a/.github/workflows/development-workflow.yml
+++ b/.github/workflows/development-workflow.yml
@@ -107,10 +107,34 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
-  publish-release:
+  patch-cli:
     if: ${{ github.event.action == 'released' }}
     runs-on: ubuntu-latest
     needs: [dependencies, test]
+    name: Publish @latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            **/node_modules
+          key: ${{github.sha}}-dependencies
+      - uses: actions/cache@v2
+        with:
+          path: |
+            **/dist
+            **/lib
+          key: ${{github.sha}}-artifacts
+      - uses: MerthinTechnologies/edit-json-action@v1
+        with:
+          filename: './lib/analytics/telemetry.json'
+          key: 'host'
+          value: 'scapi'
+
+  publish-release:
+    if: ${{ github.event.action == 'released' }}
+    runs-on: ubuntu-latest
+    needs: [patch-cli]
     name: Publish @latest
     steps:
       - uses: actions/checkout@v2

--- a/packages/care-package/uiplugins-plugin/src/UIPluginComponentDeployer.ts
+++ b/packages/care-package/uiplugins-plugin/src/UIPluginComponentDeployer.ts
@@ -66,7 +66,7 @@ export class UIPluginComponentDeployer implements ComponentDeployer {
     async deploy(location: string): Promise<any> {
         return this.traverse(location, async (file: string, pluginMetadata: any, existingPlugin?: any) => {
             if (existingPlugin) {
-                throw new Error(`Plugin already exists ${existingPlugin.pluginName}. Use --force option to override`);
+                throw new Error(`Plugin already exists. Updated is not supported. Use --force option to clean up and deploy.`);
             }
             console.log(`Creating new plugin ${pluginMetadata.pluginName}`);
             const pluginMetadataResponse = (await this.uiPluginsApi.addUiPlugin(pluginMetadata)).body;

--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -1,5 +1,16 @@
 #!/usr/bin/env node
 
-require('@oclif/command').run()
-.then(require('@oclif/command/flush'))
-.catch(require('@oclif/errors/handle'))
+const collector_1 = require('../lib/analytics/collector');
+const payload_1 = require("../lib/analytics/payload");
+
+require('@oclif/command')
+    .run()
+    .then(require('@oclif/command/flush'))
+    .catch((error) => {
+        const oclifHandler = require('@oclif/errors/handle');
+        return collector_1.AnalyticsCollector
+            .send(payload_1.EventType.FAILED, null, error)
+            .then(() => {
+                oclifHandler(error);
+            })
+    })

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vcd/ext-cli",
   "description": "CLI tool for working with Cloud Director extensions",
-  "version": "0.0.12-alpha.7",
+  "version": "0.0.12-alpha.8",
   "author": "VMware",
   "license": "BSD-2",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -67,6 +67,11 @@
   "main": "lib/index.js",
   "oclif": {
     "commands": "./lib/commands",
+    "hooks": {
+      "init": "./lib/hooks/init/analytics",
+      "prerun": "./lib/hooks/prerun/analytics",
+      "postrun": "./lib/hooks/postrun/analytics"
+    },
     "bin": "vcd-ext",
     "plugins": [
       "@oclif/plugin-help"

--- a/packages/cli/src/ScaffoldingBaseCommand.ts
+++ b/packages/cli/src/ScaffoldingBaseCommand.ts
@@ -11,7 +11,7 @@ export default abstract class ScaffoldingBaseCommand extends Command {
             `vcd-ext:${type}`
         );
 
-        await new Promise((resolve, reject) => {
+        await new Promise<void>((resolve, reject) => {
             env.run(`vcd-ext:${type}`, generatorOptions, (err: Error | null) => {
                 if (err) { reject(err); } else { resolve(); }
             });

--- a/packages/cli/src/analytics/collector.ts
+++ b/packages/cli/src/analytics/collector.ts
@@ -1,0 +1,63 @@
+import * as https from 'https';
+import * as debug from 'debug';
+import { URL } from 'url';
+import { v4 as uuidv4 } from 'uuid';
+import { HookKeyOrOptions } from '@oclif/config/lib/hooks';
+import { ConsentStore } from './store';
+import * as telemetryEndpoint from './telemetry.json';
+import { CLIAnalyticsEvent, EventType } from './payload';
+const pjson = require('../../package.json');
+
+const log = debug('vcd-ext:analytics');
+
+
+export class AnalyticsCollector {
+    static store = new ConsentStore();
+    static cliRunId = uuidv4();
+
+    static async send(eventType: EventType, options?: HookKeyOrOptions<'prerun'> | HookKeyOrOptions<'postrun'>, error?: Error) {
+        if (!this.store.hasConsent()) {
+            return;
+        }
+        // tslint:disable-next-line: max-line-length
+        const endpoint = `https://${telemetryEndpoint.host}.vmware.com/sc/api/collectors/${telemetryEndpoint.collectorId}/batch`;
+        const urlObj = new URL(endpoint);
+        // System properties
+        const payload = new CLIAnalyticsEvent(
+            `urn:vcloud:ext:sdk:cli:${this.store.getInstanceId()}`,
+            this.cliRunId,
+            eventType,
+            {
+                command: options ? options.Command.id : undefined,
+                errorCode: error ? error.message : undefined,
+                os: process.platform,
+                nodeVersion: process.version,
+                cliVersion: pjson.version,
+                isCIRun: this.store.isCIRun()
+            }
+        );
+
+        const postData = JSON.stringify(payload);
+
+        const requestOptions: https.RequestOptions = {
+            protocol: urlObj.protocol,
+            hostname: urlObj.hostname,
+            port: urlObj.port,
+            path: urlObj.pathname,
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'Content-Length': postData.length
+            }
+        };
+        log(`Analytics payload:
+${postData}`);
+        return new Promise<void>((resolve) => {
+            const req = https.request(requestOptions, log);
+            req.on('error', log);
+            req.on('close', resolve);
+            req.write(postData);
+            req.end();
+        });
+    }
+}

--- a/packages/cli/src/analytics/payload.ts
+++ b/packages/cli/src/analytics/payload.ts
@@ -1,0 +1,49 @@
+import { v4 as uuidv4 } from 'uuid';
+
+export interface CloudEvent {
+    specversion: string;
+    datacontenttype?: string;
+    dataschema?: string;
+    type: string;
+    source: string;
+    subject?: string;
+    id: string;
+    time?: string;
+    data?: any;
+}
+
+export interface SuperColliderEvent extends CloudEvent {
+    '@table': string;
+}
+
+export interface CLIAnalyticsPayload {
+    command?: string;
+    errorCode?: string;
+    os: string;
+    nodeVersion: string;
+    cliVersion: string;
+    isCIRun?: boolean;
+}
+
+export enum EventType {
+    PRERUN = 'CLI_COMMAND_PRERUN',
+    SUCCESS = 'CLI_COMMAND_SUCCESS',
+    FAILED = 'CLI_COMMAND_FAILED'
+}
+
+export class CLIAnalyticsEvent implements SuperColliderEvent {
+    '@table' = 'vcd_ext_cli';
+    specversion = '1.0';
+    id: string;
+    time: string;
+
+    constructor(
+        public source: string,
+        public subject: string,
+        public type: EventType,
+        public data: CLIAnalyticsPayload
+    ) {
+        this.id = uuidv4();
+        this.time = new Date().toISOString();
+    }
+}

--- a/packages/cli/src/analytics/store.ts
+++ b/packages/cli/src/analytics/store.ts
@@ -1,0 +1,122 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as debug from 'debug';
+import { v4 as uuidv4 } from 'uuid';
+import * as inquirer from 'inquirer';
+
+const log = debug('vcd-ext:analytics');
+
+const DEFAULT_CONFIG_LOCATION = path.join(findHomeDir(), '.vcd', 'analytics');
+
+function findHomeDir(): string {
+    if (process.env.HOME) {
+        try {
+            fs.accessSync(process.env.HOME);
+            return process.env.HOME;
+            // tslint:disable-next-line:no-empty
+        } catch (ignore) { }
+    }
+    if (process.platform !== 'win32') {
+        return '';
+    }
+    if (process.env.HOMEDRIVE && process.env.HOMEPATH) {
+        const dir = path.join(process.env.HOMEDRIVE, process.env.HOMEPATH);
+        try {
+            fs.accessSync(dir);
+            return dir;
+            // tslint:disable-next-line:no-empty
+        } catch (ignore) { }
+    }
+    if (process.env.USERPROFILE) {
+        try {
+            fs.accessSync(process.env.USERPROFILE);
+            return process.env.USERPROFILE;
+            // tslint:disable-next-line:no-empty
+        } catch (ignore) { }
+    }
+    return '';
+}
+
+const loadConfig = () => {
+    if (fs.existsSync(DEFAULT_CONFIG_LOCATION)) {
+        const fileContent = fs.readFileSync(DEFAULT_CONFIG_LOCATION).toString();
+        const config = JSON.parse(fileContent);
+        return config;
+    }
+    return null;
+};
+
+const updateConfig = (config: any) => {
+    const dirName = path.dirname(DEFAULT_CONFIG_LOCATION);
+    if (!fs.existsSync(dirName)) {
+        log(`Config location doesn't exists. Creating: ${dirName}`);
+        fs.mkdirSync(dirName);
+    }
+    fs.writeFileSync(DEFAULT_CONFIG_LOCATION, JSON.stringify(config));
+};
+
+export class ConsentStore {
+
+    config: any;
+
+    constructor() {
+        this.config = loadConfig();
+    }
+
+    isConsentAsked(): boolean {
+        if (this.config && this.config.agreed !== undefined) {
+            return true;
+        }
+        return false;
+    }
+
+    isCIRun(): boolean {
+        if (process.env.ENABLE_VCD_SDK_CLI_ANALYTICS && process.env.ENABLE_VCD_SDK_CLI_ANALYTICS === 'true') {
+            return true;
+        }
+        return false;
+    }
+
+    hasConsent(): boolean {
+        if (this.isCIRun()) {
+            return true;
+        }
+        if (this.config && this.config.agreed !== undefined) {
+            return this.config.agreed;
+        }
+        return false;
+    }
+
+    async promptAndStore() {
+        const answers = await inquirer.prompt({
+            type: 'confirm',
+            name: 'agreed',
+            default: true,
+            message: 'VMware\'s Customer Experience Improvement Program ("CEIP") provides VMware with information ' +
+            'that enables VMware to improve its products and services, to fix problems, and to advise you ' +
+            'on how best to deploy and use our products. As part of the CEIP, VMware collects technical ' +
+            'information about your organization\'s use of VMware products and services on a regular basis. ' +
+            'This information does not personally identify any individual. ' +
+            '\nAdditional information regarding the data collected through CEIP and the purposes for which it ' +
+            'is used by VMware is set forth in the Trust & Assurance Center at http://www.vmware.com/trustvmware/ceip.html. ' +
+            'If you prefer not to participate in VMware\'s CEIP for this product, you should use vcd-ext analytics command to opt out. ' +
+            '\nYou may join or leave VMware\'s CEIP for this product at any time.\n'
+        });
+        this.storeConset(answers.agreed);
+    }
+
+    storeConset(agreed: boolean) {
+        if (!this.config) {
+            this.config = {
+                instanceId: uuidv4()
+            };
+        }
+        updateConfig({
+            ...this.config,
+            agreed
+        });
+    }
+    getInstanceId() {
+        return this.config.instanceId;
+    }
+}

--- a/packages/cli/src/analytics/telemetry.json
+++ b/packages/cli/src/analytics/telemetry.json
@@ -1,0 +1,4 @@
+{
+    "host": "scapi-stg",
+    "collectorId": "vcd-ext-cli.v0"
+}

--- a/packages/cli/src/commands/analytics.ts
+++ b/packages/cli/src/commands/analytics.ts
@@ -1,0 +1,36 @@
+import Command, { flags } from '@oclif/command';
+import { ConsentStore } from '../analytics/store';
+
+export default class Analytics extends Command {
+
+    static description = 'Configures the gathering of usage metrics';
+
+    static examples = [
+        `$ vcd-ext analytics <on|off|prompt>
+`,
+    ];
+
+    static flags = {
+        help: flags.help({ char: 'h', description: 'Provides usage for the current command.' }),
+    };
+
+    static args = [
+        { name: 'setting', required: true, description: `The value of the setting is one of the following:
+ * 'on'     - enables analytics gathering and reporting for the current user.
+ * 'off'    - disables analytics gathering and reporting for the current user.
+ * 'prompt' - Prompts the user to set the status interactively.`
+        }
+    ];
+
+    async run() {
+        const { args } = this.parse(Analytics);
+        const setting = args.setting;
+        const store = new ConsentStore();
+
+        if (setting !== 'prompt') {
+            store.storeConset(setting === 'on');
+            return Promise.resolve();
+        }
+        return store.promptAndStore();
+    }
+}

--- a/packages/cli/src/commands/build.ts
+++ b/packages/cli/src/commands/build.ts
@@ -16,7 +16,8 @@ export default class Build extends Command {
             required: false,
             default: '',
             description: 'Comma separated list of element names to be deployed. If not provided it deployes all elements.'
-        })
+        }),
+        ci: flags.boolean({ description: 'Indicates the command is run within CI environment. It skips analytics consent prompt.'})
     };
 
     async run() {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -23,7 +23,8 @@ export default class Deploy extends Command {
             required: false,
             default: '',
             description: 'Comma separated list of subcomponent names to be deployed. If not provided it deployes all subcomponents.'
-        })
+        }),
+        ci: flags.boolean({ description: 'Indicates the command is run within CI environment. It skips analytics consent prompt.'})
     };
 
     static args = [{ name: 'name', required: false }];

--- a/packages/cli/src/commands/login.ts
+++ b/packages/cli/src/commands/login.ts
@@ -13,6 +13,7 @@ export default class Login extends Command {
 
     static flags = {
         help: flags.help({ char: 'h', description: 'Provides usage for the current command.' }),
+        ci: flags.boolean({ description: 'Indicates the command is run within CI environment. It skips analytics consent prompt.'})
     };
 
     static args = [

--- a/packages/cli/src/commands/pack.ts
+++ b/packages/cli/src/commands/pack.ts
@@ -17,7 +17,8 @@ export default class Pack extends Command {
             required: false,
             default: '',
             description: 'Comma separated list of element names to be packed. If not provided it packs all elements.'
-        })
+        }),
+        ci: flags.boolean({ description: 'Indicates the command is run within CI environment. It skips analytics consent prompt.'})
     };
 
     static args = [{ name: 'name', required: false, description: 'Optional archive name' }];

--- a/packages/cli/src/hooks/init/analytics.ts
+++ b/packages/cli/src/hooks/init/analytics.ts
@@ -1,0 +1,12 @@
+import { Hook } from '@oclif/config';
+
+import { ConsentStore } from '../../analytics/store';
+
+const hook: Hook<'init'> = async (options) => {
+    const store = new ConsentStore();
+    if (!store.isConsentAsked() && !options.argv.includes('--ci')) {
+        return store.promptAndStore();
+    }
+    return Promise.resolve();
+};
+export default hook;

--- a/packages/cli/src/hooks/postrun/analytics.ts
+++ b/packages/cli/src/hooks/postrun/analytics.ts
@@ -1,0 +1,8 @@
+import { Hook } from '@oclif/config';
+import { AnalyticsCollector } from '../../analytics/collector';
+import { EventType } from '../../analytics/payload';
+
+const hook: Hook<'postrun'> = async (options) => {
+    return AnalyticsCollector.send(EventType.SUCCESS, options);
+};
+export default hook;

--- a/packages/cli/src/hooks/prerun/analytics.ts
+++ b/packages/cli/src/hooks/prerun/analytics.ts
@@ -1,0 +1,8 @@
+import { Hook } from '@oclif/config';
+import { AnalyticsCollector } from '../../analytics/collector';
+import { EventType } from '../../analytics/payload';
+
+const hook: Hook<'prerun'> = async (options) => {
+    return AnalyticsCollector.send(EventType.PRERUN, options);
+};
+export default hook;


### PR DESCRIPTION
 - Added following hooks:
   - init: ask for consent
   - prerun: send prerun event
   - postrun: send success event
- Updated the run script to handle any error and send error event
- Added analytics command to enable opt in/out
- Added --ci flag to relevent commands to skip consent prompt
- Added handling of cloud events

Testing Done:
```
vcd-ext use
vcd-ext use --ci
vcd-ext analytics on/off
```