### PR TITLE
[Docs] Bugfixes

### DIFF
--- a/docs/_docs/defined_entities_getting_started.md
+++ b/docs/_docs/defined_entities_getting_started.md
@@ -15,7 +15,7 @@ This quickstart shows you how to create types project, add a type and deploy it 
 ## Create a types project
 Run the following command to generate a new project:
 ```bash
-vcd-ext new types-demo
+vcd-ext new
 ? Your solution name types-demo
 ? Specify first version 0.0.1
 ? Specify vendor name MyCompany

--- a/docs/_docs/ui_plugins_getting_started.md
+++ b/docs/_docs/ui_plugins_getting_started.md
@@ -14,11 +14,7 @@ This quick start shows you how to create UI Plugins project, how to host the pro
 
 ## Creating the UI plugin project
 
-To create the plugin project, you need to install the VCD Extensibility CLI as a global npm package
-
-`npm i -g @vcd/ext-cli`
-
-Once the package is available, open a terminal, go to your desired directory and run
+Run the following command to generate a new project:
 
 `vcd-ext new`
 

--- a/docs/_includes/sidenav.html
+++ b/docs/_includes/sidenav.html
@@ -17,9 +17,10 @@
       {% else %}
         {% assign items = cat.items | sort: 'order' | where: 'hasMore', true %}
         {% assign firstItem = cat.items | first %}
+        {% assign checkedItemsCount = items | where: 'url', page.url | size %}
         <section class="nav-group collapsible">
-          <input id="tabexample1" type="checkbox">
-          <label for="tabexample1">
+          <input id="tabexample-{{ cat.name }}" type="checkbox" {% if checkedItemsCount == 0 %} checked {% endif %}>
+          <label for="tabexample-{{ cat.name }}">
             {% if firstItem.iconShape %} <clr-icon shape="{{ firstItem.iconShape }}"></clr-icon> {% endif %}
             {{ cat.name }}
           </label>

--- a/docs/_use_cases/approvals.md
+++ b/docs/_use_cases/approvals.md
@@ -8,7 +8,7 @@ labels:
     iconShape: tasks
   - name: UI Plugins
     iconShape: plugin
-    link: /docs/ui_plugins_intro
+    link: /docs/ui_plugins/overview
 category: Use Cases
 order: 2
 permalink: /use_cases/approvals/

--- a/docs/_use_cases/ticketing.md
+++ b/docs/_use_cases/ticketing.md
@@ -9,7 +9,7 @@ labels:
     link: /docs/defined_entities_intro
   - name: UI Plugins
     iconShape: plugin
-    link: /docs/ui_plugins_intro
+    link: /docs/ui_plugins/overview
 category: Use Cases
 order: 1
 permalink: /use_cases/ticketing/


### PR DESCRIPTION
- Removed project name from `vcd-ext new` command in defined_entities_getting_started
- Removed the SDK install from the ui_plugins_getting_started
- Fixed the sidenav to properly expand/colapse
- Fixed the UI plugins label with the proper link

Signed-off-by: Milko Slavov <mslavov@vmware.com>