### PR TITLE
[Plugin builder] Add option for preserving the main file

### DIFF
--- a/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
@@ -114,9 +114,12 @@ async function commandBuilder(
     // Export the plugin module
     modulePath = modulePath.substr(0, modulePath.indexOf('.ts'));
     const entryPointContents = `export * from '${modulePath}';`;
-    patchEntryPoint(entryPointPath, entryPointContents);
 
-        // Define amd lib
+    if (!options.preserveMainFile) {
+        patchEntryPoint(entryPointPath, entryPointContents);
+    }
+
+    // Define amd lib
     config.output.filename = 'bundle.js';
     config.output.library = moduleName;
     config.output.libraryTarget = 'amd';

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/base/schema.json
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/base/schema.json
@@ -6,6 +6,11 @@
             "description": "Based on the this some features will be turned on or off.",
             "default": ""
         },
+        "preserveMainFile": {
+            "type": "boolean",
+            "description": "Preserve main file contents.",
+            "default": false
+        },
         "modulePath": {
             "type": "string",
             "description": "Path to module like loadChildren",

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/interfaces.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/interfaces.ts
@@ -162,6 +162,10 @@ export type ExtensionScope = 'tenant' | 'service-provder';
 export interface BasePluginBuilderSchema {
     enableRuntimeDependecyManagement: boolean;
     /**
+     * Preserve main plugin file contents.
+     */
+    preserveMainFile: boolean;
+    /**
      * A string of the form `path/to/file#exportName`
      * that acts as a path to include to bundle.
      */


### PR DESCRIPTION
Add new option to preserve the main file, this option
would be mainly used by plugins which are bundled
with different  angular version then the vCD UI Platform.

Testing Done:
- Verify old plugins can still be compiled
- Verify this option works for different Angular
version plugins.