### PR TITLE
Upgrade @vcd/angular-client to 0.0.2-alpha.4

### DIFF
--- a/packages/angular/projects/vcd/sdk/CHANGELOG.md
+++ b/packages/angular/projects/vcd/sdk/CHANGELOG.md
@@ -1,0 +1,2 @@
+# 0.12.2-alpha.3 (2021-06-10)
+- Upgrade `@vcd/angular-client` to `0.0.2-alpha.4`  which enables JWT in VcdApiClient

--- a/packages/angular/projects/vcd/sdk/package-lock.json
+++ b/packages/angular/projects/vcd/sdk/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@vcd/angular-client": {
-      "version": "0.0.2-alpha.3",
-      "resolved": "https://registry.npmjs.org/@vcd/angular-client/-/angular-client-0.0.2-alpha.3.tgz",
-      "integrity": "sha512-yzWxJen0j8m9RkpW43LhfYNys2ACt1eyM4csIgMHogsTXegBCv9qV/piDazy5rtdDPqeDk1niYrZQlodBiRYfQ==",
+      "version": "0.0.2-alpha.4",
+      "resolved": "https://registry.npmjs.org/@vcd/angular-client/-/angular-client-0.0.2-alpha.4.tgz",
+      "integrity": "sha512-O/qqpFXRjJRWQNf959qqRr5QHPIPaCwmb8kE8DZ0wBFY0zDfbhZjRq+TpL/EAR4XTqWwKRamMSzG+J4YdJpJog==",
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/packages/angular/projects/vcd/sdk/package.json
+++ b/packages/angular/projects/vcd/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/sdk",
-  "version": "0.12.2-alpha.2",
+  "version": "0.12.2-alpha.3",
   "description": "Angular-based client for the Cloud Director API.",
   "author": "VMware",
   "license": "BSD-2-Clause",

--- a/packages/angular/projects/vcd/sdk/package.json
+++ b/packages/angular/projects/vcd/sdk/package.json
@@ -12,7 +12,7 @@
   },
   "module": "esm5/vcd-sdk.js",
   "dependencies": {
-    "@vcd/angular-client": "0.0.2-alpha.3"
+    "@vcd/angular-client": "0.0.2-alpha.4"
   },
   "peerDependencies": {
     "@angular-devkit/schematics": "7.3.8",


### PR DESCRIPTION
`@vcd/angular-client` @ `0.0.2-alpha.4` enables JWT in VcdApiClient

#Testing
- Use a VCD build in which `x-vcloud-authorization` usage has been removed
- Create a plugin that gets data from the backend using VcdApiClient
- Observe:
-- If this code change is not applied - no data can be retrieved from the backend
-- After applying this code change - the plugin can retrieve data from the backend