### PR TITLE
[Draft] Angular Apps support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 target/
 dist/
-lib/
 node/
 node_modules/
 ui_ext_api.ini

--- a/packages/angular/projects/vcd/plugin-builders/package-lock.json
+++ b/packages/angular/projects/vcd/plugin-builders/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/plugin-builders",
-  "version": "0.12.1-alpha.5",
+  "version": "0.12.1-alpha.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/angular/projects/vcd/plugin-builders/package-lock.json
+++ b/packages/angular/projects/vcd/plugin-builders/package-lock.json
@@ -1144,6 +1144,15 @@
         }
       }
     },
+    "@types/anymatch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-3.0.0.tgz",
+      "integrity": "sha512-qLChUo6yhpQ9k905NwL74GU7TxH+9UODwwQ6ICNI+O6EDMExqH/Cv9NsbmcZ7yC/rRXJ/AHCzfgjsFRY5fKjYw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "*"
+      }
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -1177,6 +1186,46 @@
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
       "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
       "dev": true
+    },
+    "@types/tapable": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-2.2.2.tgz",
+      "integrity": "sha512-ujqOVJEeLcwpDVJPnp/k3u1UXmTKq5urJq9fO8aUKg8Vlel5RNOFbVKEfqfh6wGfF/M+HiTJlBJMLC1aDfyf0Q==",
+      "dev": true,
+      "requires": {
+        "tapable": "^2.2.0"
+      },
+      "dependencies": {
+        "tapable": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+          "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+          "dev": true
+        }
+      }
+    },
+    "@types/uglify-js": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.1.tgz",
+      "integrity": "sha512-O3MmRAk6ZuAKa9CHgg0Pr0+lUOqoMLpc9AS4R8ano2auvsg7IE8syF3Xh/NPr26TWklxYcqoEEFdzLLs1fV9PQ==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      }
+    },
+    "@types/webpack": {
+      "version": "4.39.2",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.39.2.tgz",
+      "integrity": "sha512-3c7+vcmyyIi3RBoOdXs8k3E9rQVIy6yOBqK0DFk6lnJ76JUfbDBWbEf1JflzyPQf56W4ToE+2YPnbxbucniW5w==",
+      "dev": true,
+      "requires": {
+        "@types/anymatch": "*",
+        "@types/node": "*",
+        "@types/tapable": "*",
+        "@types/uglify-js": "*",
+        "@types/webpack-sources": "*",
+        "source-map": "^0.6.0"
+      }
     },
     "@types/webpack-sources": {
       "version": "0.1.8",

--- a/packages/angular/projects/vcd/plugin-builders/package.json
+++ b/packages/angular/projects/vcd/plugin-builders/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/plugin-builders",
-  "version": "0.12.1-alpha.5",
+  "version": "0.12.1-alpha.6",
   "description": "Angular CLI-compatible tools for building Cloud Director plugins.",
   "author": "VMware",
   "license": "BSD-2-Clause",

--- a/packages/angular/projects/vcd/plugin-builders/package.json
+++ b/packages/angular/projects/vcd/plugin-builders/package.json
@@ -10,7 +10,8 @@
     "zip-webpack-plugin": "3.0.0"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "0.803.29"
+    "@angular-devkit/build-angular": "0.803.29",
+    "@types/webpack": "^4.39.2"
   },
   "peerDependencies": {
     "@angular-devkit/build-angular": "0.8.0",

--- a/packages/angular/projects/vcd/plugin-builders/provenance.json
+++ b/packages/angular/projects/vcd/plugin-builders/provenance.json
@@ -1,4336 +1,5815 @@
 {
-  "id": "http://vmware.com/schemas/software_provenance-0.2.0.json",
-  "root": "0.12.1-alpha.5",
-  "all-components": {
-    "name": "@vcd/plugin-builders",
-    "version": "0.12.1-alpha.5",
-    "source_repositories": [
-      {
-        "content": "source",
-        "host": "github.com",
-        "protocol": "git",
-        "paths": [
-          "/vmware/vcd-ext-sdk/tree/main/packages/angular/projects/vcd/plugin-builders"
-        ],
-        "branch": "main"
-      }
-    ],
-    "components": {},
-    "artifact_repositories": [
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@angular-devkit/architect/-/architect-0.803.29.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@angular-devkit/build-angular/-/build-angular-0.803.29.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@angular-devkit/build-optimizer/-/build-optimizer-0.803.29.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@angular-devkit/build-webpack/-/build-webpack-0.803.29.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@angular-devkit/core/-/core-8.3.29.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/code-frame/-/code-frame-7.10.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/compat-data/-/compat-data-7.12.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/core/-/core-7.8.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/generator/-/generator-7.12.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helper-wrap-function/-/helper-wrap-function-7.12.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/helpers/-/helpers-7.12.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/highlight/-/highlight-7.10.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/parser/-/parser-7.12.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-classes/-/plugin-transform-classes-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-spread/-/plugin-transform-spread-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/preset-env/-/preset-env-7.8.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/runtime/-/runtime-7.12.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/template/-/template-7.12.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/traverse/-/traverse-7.12.9.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@babel/types/-/types-7.12.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@istanbuljs/schema/-/schema-0.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@ngtools/webpack/-/webpack-8.3.29.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@npmcli/move-file/-/move-file-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@types/glob/-/glob-7.1.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@types/json-schema/-/json-schema-7.0.6.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@types/minimatch/-/minimatch-3.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@types/node/-/node-14.14.10.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@types/source-list-map/-/source-list-map-0.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@types/webpack-sources/-/webpack-sources-0.1.8.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/ast/-/ast-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/leb128/-/leb128-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/utf8/-/utf8-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@xtuc/ieee754/-/ieee754-1.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/@xtuc/long/-/long-4.2.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/accepts/-/accepts-1.3.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/acorn/-/acorn-6.4.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/aggregate-error/-/aggregate-error-3.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ajv/-/ajv-6.12.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ajv-errors/-/ajv-errors-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ajv-keywords/-/ajv-keywords-3.5.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/amdefine/-/amdefine-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ansi-colors/-/ansi-colors-3.2.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ansi-html/-/ansi-html-0.0.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ansi-regex/-/ansi-regex-2.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ansi-styles/-/ansi-styles-3.2.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/anymatch/-/anymatch-3.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/aproba/-/aproba-1.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/argparse/-/argparse-1.0.10.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/arr-diff/-/arr-diff-4.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/arr-flatten/-/arr-flatten-1.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/arr-union/-/arr-union-3.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/array-flatten/-/array-flatten-2.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/array-union/-/array-union-2.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/array-uniq/-/array-uniq-1.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/array-unique/-/array-unique-0.3.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/asap/-/asap-2.0.6.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/asn1/-/asn1-0.2.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/asn1.js/-/asn1.js-5.4.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/assert/-/assert-1.5.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/assert-plus/-/assert-plus-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/assign-symbols/-/assign-symbols-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/async/-/async-2.6.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/async-each/-/async-each-1.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/async-limiter/-/async-limiter-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/asynckit/-/asynckit-0.4.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/atob/-/atob-2.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/autoprefixer/-/autoprefixer-9.6.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/aws-sign2/-/aws-sign2-0.7.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/aws4/-/aws4-1.11.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/balanced-match/-/balanced-match-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/base/-/base-0.11.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/base64-js/-/base64-js-1.5.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/batch/-/batch-0.6.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/big.js/-/big.js-5.2.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/binary-extensions/-/binary-extensions-2.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/bindings/-/bindings-1.5.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/bluebird/-/bluebird-3.7.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/bn.js/-/bn.js-5.1.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/body-parser/-/body-parser-1.19.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/bonjour/-/bonjour-3.5.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/brace-expansion/-/brace-expansion-1.1.11.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/braces/-/braces-3.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/brorand/-/brorand-1.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/browserify-aes/-/browserify-aes-1.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/browserify-cipher/-/browserify-cipher-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/browserify-des/-/browserify-des-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/browserify-rsa/-/browserify-rsa-4.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/browserify-sign/-/browserify-sign-4.2.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/browserify-zlib/-/browserify-zlib-0.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/browserslist/-/browserslist-4.10.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/buffer/-/buffer-4.9.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "build-artifactory.eng.vmware.com",
-        "path": "/api/npm/npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/buffer-from/-/buffer-from-1.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/buffer-indexof/-/buffer-indexof-1.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/buffer-xor/-/buffer-xor-1.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/bytes/-/bytes-3.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/cacache/-/cacache-12.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/cache-base/-/cache-base-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/call-bind/-/call-bind-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/caller-callsite/-/caller-callsite-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/caller-path/-/caller-path-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/callsites/-/callsites-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/camelcase/-/camelcase-5.3.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/caseless/-/caseless-0.12.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/chalk/-/chalk-2.4.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/chokidar/-/chokidar-3.4.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/chownr/-/chownr-1.1.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/cipher-base/-/cipher-base-1.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/circular-dependency-plugin/-/circular-dependency-plugin-5.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/class-utils/-/class-utils-0.3.6.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/clean-css/-/clean-css-4.2.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/clean-stack/-/clean-stack-2.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/cliui/-/cliui-5.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/clone/-/clone-2.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/clone-deep/-/clone-deep-4.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/collection-visit/-/collection-visit-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/color-convert/-/color-convert-1.9.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/color-name/-/color-name-1.1.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/colorette/-/colorette-1.2.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/combined-stream/-/combined-stream-1.0.8.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/commander/-/commander-2.20.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/commondir/-/commondir-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/component-emitter/-/component-emitter-1.3.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/compressible/-/compressible-2.0.18.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/compression/-/compression-1.7.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/concat-map/-/concat-map-0.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/concat-stream/-/concat-stream-1.6.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/console-browserify/-/console-browserify-1.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/constants-browserify/-/constants-browserify-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/content-disposition/-/content-disposition-0.5.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/content-type/-/content-type-1.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/convert-source-map/-/convert-source-map-1.7.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/cookie/-/cookie-0.4.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/cookie-signature/-/cookie-signature-1.0.6.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/copy-concurrently/-/copy-concurrently-1.0.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/copy-descriptor/-/copy-descriptor-0.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/copy-webpack-plugin/-/copy-webpack-plugin-6.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/core-js/-/core-js-3.6.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/core-js-compat/-/core-js-compat-3.8.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/core-util-is/-/core-util-is-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/cosmiconfig/-/cosmiconfig-5.2.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/coverage-istanbul-loader/-/coverage-istanbul-loader-2.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/create-ecdh/-/create-ecdh-4.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/create-hash/-/create-hash-1.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/create-hmac/-/create-hmac-1.1.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/cross-spawn/-/cross-spawn-6.0.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/crypto-browserify/-/crypto-browserify-3.12.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/css-parse/-/css-parse-1.7.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/cyclist/-/cyclist-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/dashdash/-/dashdash-1.14.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/debug/-/debug-4.3.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/decamelize/-/decamelize-1.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/decode-uri-component/-/decode-uri-component-0.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/deep-equal/-/deep-equal-1.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/default-gateway/-/default-gateway-4.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/define-properties/-/define-properties-1.1.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/define-property/-/define-property-2.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/del/-/del-4.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/delayed-stream/-/delayed-stream-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/depd/-/depd-1.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/des.js/-/des.js-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/destroy/-/destroy-1.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/detect-node/-/detect-node-2.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/diffie-hellman/-/diffie-hellman-5.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/dir-glob/-/dir-glob-3.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/dns-equal/-/dns-equal-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/dns-packet/-/dns-packet-1.3.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/dns-txt/-/dns-txt-2.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/domain-browser/-/domain-browser-1.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/duplexify/-/duplexify-3.7.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ee-first/-/ee-first-1.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/electron-to-chromium/-/electron-to-chromium-1.3.609.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/elliptic/-/elliptic-6.5.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/emoji-regex/-/emoji-regex-7.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/emojis-list/-/emojis-list-2.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/encodeurl/-/encodeurl-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/end-of-stream/-/end-of-stream-1.4.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/errno/-/errno-0.1.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/error-ex/-/error-ex-1.3.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/es-abstract/-/es-abstract-1.18.0-next.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/es-to-primitive/-/es-to-primitive-1.2.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/escalade/-/escalade-3.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/escape-html/-/escape-html-1.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/eslint-scope/-/eslint-scope-4.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/esprima/-/esprima-4.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/esrecurse/-/esrecurse-4.3.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/estraverse/-/estraverse-4.3.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/etag/-/etag-1.8.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/eventemitter3/-/eventemitter3-4.0.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/events/-/events-3.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/eventsource/-/eventsource-1.0.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/execa/-/execa-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/expand-brackets/-/expand-brackets-2.1.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/express/-/express-4.17.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/extend/-/extend-3.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/extend-shallow/-/extend-shallow-3.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/extglob/-/extglob-2.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/extsprintf/-/extsprintf-1.3.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/fast-glob/-/fast-glob-3.2.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/fastq/-/fastq-1.9.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/faye-websocket/-/faye-websocket-0.10.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/figgy-pudding/-/figgy-pudding-3.5.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/file-loader/-/file-loader-4.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/fill-range/-/fill-range-7.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/finalhandler/-/finalhandler-1.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/find-cache-dir/-/find-cache-dir-3.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/find-up/-/find-up-3.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/flush-write-stream/-/flush-write-stream-1.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/follow-redirects/-/follow-redirects-1.13.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/for-in/-/for-in-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/forever-agent/-/forever-agent-0.6.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/form-data/-/form-data-2.3.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/forwarded/-/forwarded-0.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/fragment-cache/-/fragment-cache-0.2.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/fresh/-/fresh-0.5.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/from2/-/from2-2.3.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/fs-minipass/-/fs-minipass-2.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/fs.realpath/-/fs.realpath-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/fsevents/-/fsevents-2.1.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/function-bind/-/function-bind-1.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/gensync/-/gensync-1.0.0-beta.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/get-caller-file/-/get-caller-file-2.0.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/get-intrinsic/-/get-intrinsic-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/get-stream/-/get-stream-4.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/get-value/-/get-value-2.0.6.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/getpass/-/getpass-0.1.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/glob/-/glob-7.1.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/glob-parent/-/glob-parent-5.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/globals/-/globals-11.12.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/globby/-/globby-11.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/graceful-fs/-/graceful-fs-4.2.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/handle-thing/-/handle-thing-2.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/har-schema/-/har-schema-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/har-validator/-/har-validator-5.1.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/has/-/has-1.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/has-flag/-/has-flag-3.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/has-symbols/-/has-symbols-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/has-value/-/has-value-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/has-values/-/has-values-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/hash-base/-/hash-base-3.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/hash.js/-/hash.js-1.1.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/hmac-drbg/-/hmac-drbg-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/hpack.js/-/hpack.js-2.1.6.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/html-entities/-/html-entities-1.3.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/http-deceiver/-/http-deceiver-1.2.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/http-errors/-/http-errors-1.7.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/http-proxy/-/http-proxy-1.18.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/http-signature/-/http-signature-1.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/https-browserify/-/https-browserify-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/iconv-lite/-/iconv-lite-0.4.24.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ieee754/-/ieee754-1.2.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/iferr/-/iferr-0.1.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ignore/-/ignore-5.1.8.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/image-size/-/image-size-0.5.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/import-cwd/-/import-cwd-2.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/import-fresh/-/import-fresh-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/import-from/-/import-from-2.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/import-local/-/import-local-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/imurmurhash/-/imurmurhash-0.1.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/indent-string/-/indent-string-4.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/infer-owner/-/infer-owner-1.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/inflight/-/inflight-1.0.6.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/inherits/-/inherits-2.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/internal-ip/-/internal-ip-4.3.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/invariant/-/invariant-2.2.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ip/-/ip-1.1.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ip-regex/-/ip-regex-2.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-absolute-url/-/is-absolute-url-3.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-arguments/-/is-arguments-1.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-arrayish/-/is-arrayish-0.2.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-binary-path/-/is-binary-path-2.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-buffer/-/is-buffer-1.1.6.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-callable/-/is-callable-1.2.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-core-module/-/is-core-module-2.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-date-object/-/is-date-object-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-descriptor/-/is-descriptor-0.1.6.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-directory/-/is-directory-0.3.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-extendable/-/is-extendable-0.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-extglob/-/is-extglob-2.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-glob/-/is-glob-4.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-negative-zero/-/is-negative-zero-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-number/-/is-number-7.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-path-cwd/-/is-path-cwd-2.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-path-inside/-/is-path-inside-2.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-plain-object/-/is-plain-object-2.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-regex/-/is-regex-1.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-stream/-/is-stream-1.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-symbol/-/is-symbol-1.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-typedarray/-/is-typedarray-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-windows/-/is-windows-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/is-wsl/-/is-wsl-1.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/isarray/-/isarray-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/isexe/-/isexe-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/isobject/-/isobject-3.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/isstream/-/isstream-0.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/jest-worker/-/jest-worker-24.9.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/js-tokens/-/js-tokens-4.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/js-yaml/-/js-yaml-3.14.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/jsbn/-/jsbn-0.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/jsesc/-/jsesc-2.5.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/json-schema/-/json-schema-0.2.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/json3/-/json3-3.3.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/json5/-/json5-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/jsprim/-/jsprim-1.4.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/karma-source-map-support/-/karma-source-map-support-1.4.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/killable/-/killable-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/kind-of/-/kind-of-6.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/less/-/less-3.9.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/less-loader/-/less-loader-5.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/leven/-/leven-3.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/levenary/-/levenary-1.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/license-webpack-plugin/-/license-webpack-plugin-2.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/loader-runner/-/loader-runner-2.4.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/loader-utils/-/loader-utils-1.2.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/locate-path/-/locate-path-3.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/lodash/-/lodash-4.17.21.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/loglevel/-/loglevel-1.7.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/loose-envify/-/loose-envify-1.4.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/lru-cache/-/lru-cache-5.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/magic-string/-/magic-string-0.25.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/make-dir/-/make-dir-3.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/mamacro/-/mamacro-0.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/map-cache/-/map-cache-0.2.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/map-visit/-/map-visit-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/md5.js/-/md5.js-1.3.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/media-typer/-/media-typer-0.3.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/memory-fs/-/memory-fs-0.4.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/merge-source-map/-/merge-source-map-1.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/merge-stream/-/merge-stream-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/merge2/-/merge2-1.4.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/methods/-/methods-1.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/micromatch/-/micromatch-4.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/miller-rabin/-/miller-rabin-4.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/mime/-/mime-1.6.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/mime-db/-/mime-db-1.44.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/mime-types/-/mime-types-2.1.27.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/minimatch/-/minimatch-3.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/minimist/-/minimist-1.2.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/minipass/-/minipass-3.1.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/minipass-collect/-/minipass-collect-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/minipass-flush/-/minipass-flush-1.0.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/minizlib/-/minizlib-2.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/mississippi/-/mississippi-3.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/mixin-deep/-/mixin-deep-1.3.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/mkdirp/-/mkdirp-0.5.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/move-concurrently/-/move-concurrently-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ms/-/ms-2.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/multicast-dns/-/multicast-dns-6.2.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/nan/-/nan-2.14.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/nanomatch/-/nanomatch-1.2.13.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/negotiator/-/negotiator-0.6.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/neo-async/-/neo-async-2.6.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/nice-try/-/nice-try-1.0.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/node-forge/-/node-forge-0.10.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/node-libs-browser/-/node-libs-browser-2.2.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/node-releases/-/node-releases-1.1.67.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/normalize-path/-/normalize-path-3.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/normalize-range/-/normalize-range-0.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/normalize-url/-/normalize-url-1.9.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/npm-run-path/-/npm-run-path-2.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/num2fraction/-/num2fraction-1.2.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/oauth-sign/-/oauth-sign-0.9.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/object-assign/-/object-assign-4.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/object-copy/-/object-copy-0.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/object-inspect/-/object-inspect-1.8.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/object-is/-/object-is-1.1.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/object-keys/-/object-keys-1.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/object-visit/-/object-visit-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/object.assign/-/object.assign-4.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/object.pick/-/object.pick-1.3.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/obuf/-/obuf-1.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/on-finished/-/on-finished-2.3.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/on-headers/-/on-headers-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/once/-/once-1.4.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/open/-/open-6.4.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/opn/-/opn-5.5.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/original/-/original-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/os-browserify/-/os-browserify-0.3.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/p-finally/-/p-finally-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/p-limit/-/p-limit-2.3.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/p-locate/-/p-locate-3.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/p-map/-/p-map-4.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/p-retry/-/p-retry-3.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/p-try/-/p-try-2.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/pako/-/pako-1.0.11.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/parallel-transform/-/parallel-transform-1.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/parse-asn1/-/parse-asn1-5.1.6.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/parse-json/-/parse-json-4.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/parse5/-/parse5-4.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/parseurl/-/parseurl-1.3.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/pascalcase/-/pascalcase-0.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/path-browserify/-/path-browserify-0.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/path-dirname/-/path-dirname-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/path-exists/-/path-exists-3.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/path-is-inside/-/path-is-inside-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/path-key/-/path-key-2.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/path-parse/-/path-parse-1.0.6.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/path-type/-/path-type-4.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/pbkdf2/-/pbkdf2-3.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/performance-now/-/performance-now-2.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/picomatch/-/picomatch-2.2.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/pify/-/pify-4.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/pinkie/-/pinkie-2.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/pkg-dir/-/pkg-dir-4.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/pkg-up/-/pkg-up-3.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/portfinder/-/portfinder-1.0.28.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/posix-character-classes/-/posix-character-classes-0.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/postcss/-/postcss-7.0.17.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/postcss-import/-/postcss-import-12.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/postcss-load-config/-/postcss-load-config-2.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/postcss-loader/-/postcss-loader-3.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/prepend-http/-/prepend-http-1.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/process/-/process-0.11.10.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/promise/-/promise-7.3.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/promise-inflight/-/promise-inflight-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/proxy-addr/-/proxy-addr-2.0.6.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/prr/-/prr-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/psl/-/psl-1.8.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/public-encrypt/-/public-encrypt-4.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/pump/-/pump-3.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/pumpify/-/pumpify-1.5.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/punycode/-/punycode-2.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/qs/-/qs-6.5.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/query-string/-/query-string-4.3.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/querystring/-/querystring-0.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/querystring-es3/-/querystring-es3-0.2.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/querystringify/-/querystringify-2.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/randombytes/-/randombytes-2.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/randomfill/-/randomfill-1.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/range-parser/-/range-parser-1.2.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/raw-body/-/raw-body-2.4.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/raw-loader/-/raw-loader-3.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/read-cache/-/read-cache-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/readable-stream/-/readable-stream-2.3.7.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/readdirp/-/readdirp-3.5.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/regenerate/-/regenerate-1.4.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/regenerator-transform/-/regenerator-transform-0.14.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/regex-not/-/regex-not-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/regexpu-core/-/regexpu-core-4.7.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/regjsgen/-/regjsgen-0.5.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/regjsparser/-/regjsparser-0.6.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/repeat-element/-/repeat-element-1.1.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/repeat-string/-/repeat-string-1.6.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/request/-/request-2.88.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/require-directory/-/require-directory-2.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/require-main-filename/-/require-main-filename-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/requires-port/-/requires-port-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/resolve/-/resolve-1.19.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/resolve-cwd/-/resolve-cwd-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/resolve-from/-/resolve-from-3.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/resolve-url/-/resolve-url-0.2.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ret/-/ret-0.1.15.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/retry/-/retry-0.12.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/reusify/-/reusify-1.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/rimraf/-/rimraf-2.7.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ripemd160/-/ripemd160-2.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/run-parallel/-/run-parallel-1.1.10.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/run-queue/-/run-queue-1.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/rxjs/-/rxjs-6.4.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/safe-buffer/-/safe-buffer-5.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/safe-regex/-/safe-regex-1.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/safer-buffer/-/safer-buffer-2.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/sass/-/sass-1.22.9.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/sass-loader/-/sass-loader-7.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/sax/-/sax-0.5.8.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/schema-utils/-/schema-utils-2.7.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/select-hose/-/select-hose-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/selfsigned/-/selfsigned-1.10.8.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/semver/-/semver-6.3.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/send/-/send-0.17.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/serialize-javascript/-/serialize-javascript-4.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/serve-index/-/serve-index-1.9.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/serve-static/-/serve-static-1.14.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/set-blocking/-/set-blocking-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/set-value/-/set-value-2.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/setimmediate/-/setimmediate-1.0.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/setprototypeof/-/setprototypeof-1.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/sha.js/-/sha.js-2.4.11.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/shallow-clone/-/shallow-clone-3.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/shebang-command/-/shebang-command-1.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/shebang-regex/-/shebang-regex-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/signal-exit/-/signal-exit-3.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/slash/-/slash-3.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/snapdragon/-/snapdragon-0.8.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/snapdragon-node/-/snapdragon-node-2.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/snapdragon-util/-/snapdragon-util-3.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/sockjs/-/sockjs-0.3.20.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/sockjs-client/-/sockjs-client-1.4.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/sort-keys/-/sort-keys-1.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "build-artifactory.eng.vmware.com",
-        "path": "/api/npm/npm/source-list-map/-/source-list-map-2.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "build-artifactory.eng.vmware.com",
-        "path": "/api/npm/npm/source-map/-/source-map-0.6.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/source-map-loader/-/source-map-loader-0.2.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/source-map-resolve/-/source-map-resolve-0.5.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/source-map-support/-/source-map-support-0.5.13.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/source-map-url/-/source-map-url-0.4.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/spdy/-/spdy-4.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/spdy-transport/-/spdy-transport-3.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.3.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/split-string/-/split-string-3.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/sprintf-js/-/sprintf-js-1.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/sshpk/-/sshpk-1.16.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ssri/-/ssri-6.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/static-extend/-/static-extend-0.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/statuses/-/statuses-1.5.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/stream-browserify/-/stream-browserify-2.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/stream-each/-/stream-each-1.2.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/stream-http/-/stream-http-2.8.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/stream-shift/-/stream-shift-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/string-width/-/string-width-3.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/string_decoder/-/string_decoder-1.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/strip-ansi/-/strip-ansi-3.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/strip-eof/-/strip-eof-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/style-loader/-/style-loader-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/stylus/-/stylus-0.54.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/stylus-loader/-/stylus-loader-3.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/supports-color/-/supports-color-5.5.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/tapable/-/tapable-1.1.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/tar/-/tar-6.1.11.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/terser/-/terser-4.6.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/terser-webpack-plugin/-/terser-webpack-plugin-3.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/through2/-/through2-2.0.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/thunky/-/thunky-1.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/timers-browserify/-/timers-browserify-2.0.12.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/to-fast-properties/-/to-fast-properties-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/to-object-path/-/to-object-path-0.3.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/to-regex/-/to-regex-3.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/to-regex-range/-/to-regex-range-5.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/toidentifier/-/toidentifier-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/tough-cookie/-/tough-cookie-2.5.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/tree-kill/-/tree-kill-1.2.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/tslib/-/tslib-1.14.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/tty-browserify/-/tty-browserify-0.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/tweetnacl/-/tweetnacl-0.14.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/type-is/-/type-is-1.6.18.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/typedarray/-/typedarray-0.0.6.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/typescript/-/typescript-3.5.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/union-value/-/union-value-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/unique-filename/-/unique-filename-1.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/unique-slug/-/unique-slug-2.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/unpipe/-/unpipe-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/unset-value/-/unset-value-1.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/upath/-/upath-1.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/uri-js/-/uri-js-4.4.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/urix/-/urix-0.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/url/-/url-0.11.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/url-parse/-/url-parse-1.5.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/use/-/use-3.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/util/-/util-0.11.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/util-deprecate/-/util-deprecate-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/utils-merge/-/utils-merge-1.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/uuid/-/uuid-3.4.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/vary/-/vary-1.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/verror/-/verror-1.10.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/vm-browserify/-/vm-browserify-1.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/watchpack/-/watchpack-1.7.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/wbuf/-/wbuf-1.7.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/webpack/-/webpack-4.39.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/webpack-core/-/webpack-core-0.6.9.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/webpack-log/-/webpack-log-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/webpack-merge/-/webpack-merge-4.2.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "build-artifactory.eng.vmware.com",
-        "path": "/api/npm/npm/webpack-sources/-/webpack-sources-1.4.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/webpack-subresource-integrity/-/webpack-subresource-integrity-1.1.0-rc.6.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/websocket-driver/-/websocket-driver-0.6.5.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/websocket-extensions/-/websocket-extensions-0.1.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/when/-/when-3.6.4.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/which/-/which-1.3.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/which-module/-/which-module-2.0.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/worker-farm/-/worker-farm-1.7.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/worker-plugin/-/worker-plugin-3.2.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/wrap-ansi/-/wrap-ansi-5.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/wrappy/-/wrappy-1.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/ws/-/ws-6.2.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/xtend/-/xtend-4.0.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/y18n/-/y18n-4.0.3.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/yallist/-/yallist-3.1.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/yargs/-/yargs-13.3.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/yargs-parser/-/yargs-parser-13.1.2.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "build-artifactory.eng.vmware.com",
-        "path": "/api/npm/npm/yazl/-/yazl-2.5.1.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "registry.npmjs.org",
-        "path": "/yocto-queue/-/yocto-queue-0.1.0.tgz"
-      },
-      {
-        "content": "binary",
-        "protocol": "HTTPS",
-        "host": "build-artifactory.eng.vmware.com",
-        "path": "/api/npm/npm/zip-webpack-plugin/-/zip-webpack-plugin-3.0.0.tgz"
-      }
-    ]
+  "id": "http://vmware.com/schemas/software_provenance-0.2.5.json",
+  "root": "0.12.1-alpha.6",
+  "tools": {
+    "https://github.com/": null
+  },
+  "all_components": {
+    "component": {
+      "typename": "comp.build.git",
+      "name": "@vcd/plugin-builders",
+      "version": "0.12.1-alpha.6",
+      "source_repositories": [
+        {
+          "content": "source",
+          "host": "github.com",
+          "protocol": "git",
+          "paths": [
+            "/vmware/vcd-ext-sdk/tree/main/packages/angular/projects/vcd/plugin-builders"
+          ],
+          "branch": "main"
+        }
+      ],
+      "components": [],
+      "artifact_repositories": [
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@angular-devkit/architect/-/architect-0.803.29.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@angular-devkit/build-angular/-/build-angular-0.803.29.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@angular-devkit/build-optimizer/-/build-optimizer-0.803.29.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@angular-devkit/build-webpack/-/build-webpack-0.803.29.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@angular-devkit/core/-/core-8.3.29.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/code-frame/-/code-frame-7.10.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/compat-data/-/compat-data-7.12.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/core/-/core-7.8.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/generator/-/generator-7.12.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-define-map/-/helper-define-map-7.10.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helper-wrap-function/-/helper-wrap-function-7.12.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/helpers/-/helpers-7.12.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/highlight/-/highlight-7.10.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/parser/-/parser-7.12.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-classes/-/plugin-transform-classes-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-spread/-/plugin-transform-spread-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.12.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/preset-env/-/preset-env-7.8.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/runtime/-/runtime-7.12.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/template/-/template-7.12.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/traverse/-/traverse-7.12.9.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@babel/types/-/types-7.12.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@istanbuljs/schema/-/schema-0.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@ngtools/webpack/-/webpack-8.3.29.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@npmcli/move-file/-/move-file-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@types/anymatch/-/anymatch-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@types/glob/-/glob-7.1.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@types/json-schema/-/json-schema-7.0.6.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@types/minimatch/-/minimatch-3.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@types/node/-/node-14.14.10.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@types/source-list-map/-/source-list-map-0.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@types/tapable/-/tapable-2.2.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@types/uglify-js/-/uglify-js-3.13.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@types/webpack/-/webpack-4.39.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@types/webpack-sources/-/webpack-sources-0.1.8.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/ast/-/ast-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/leb128/-/leb128-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/utf8/-/utf8-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@xtuc/ieee754/-/ieee754-1.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/@xtuc/long/-/long-4.2.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/accepts/-/accepts-1.3.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/acorn/-/acorn-6.4.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/aggregate-error/-/aggregate-error-3.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ajv/-/ajv-6.12.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ajv-errors/-/ajv-errors-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ajv-keywords/-/ajv-keywords-3.5.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/amdefine/-/amdefine-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ansi-colors/-/ansi-colors-3.2.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ansi-html/-/ansi-html-0.0.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ansi-regex/-/ansi-regex-2.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ansi-styles/-/ansi-styles-3.2.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/anymatch/-/anymatch-3.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/aproba/-/aproba-1.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/argparse/-/argparse-1.0.10.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/arr-diff/-/arr-diff-4.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/arr-flatten/-/arr-flatten-1.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/arr-union/-/arr-union-3.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/array-flatten/-/array-flatten-2.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/array-union/-/array-union-2.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/array-uniq/-/array-uniq-1.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/array-unique/-/array-unique-0.3.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/asap/-/asap-2.0.6.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/asn1/-/asn1-0.2.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/asn1.js/-/asn1.js-5.4.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/assert/-/assert-1.5.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/assert-plus/-/assert-plus-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/assign-symbols/-/assign-symbols-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/async/-/async-2.6.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/async-each/-/async-each-1.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/async-limiter/-/async-limiter-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/asynckit/-/asynckit-0.4.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/atob/-/atob-2.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/autoprefixer/-/autoprefixer-9.6.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/aws-sign2/-/aws-sign2-0.7.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/aws4/-/aws4-1.11.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/balanced-match/-/balanced-match-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/base/-/base-0.11.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/base64-js/-/base64-js-1.5.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/batch/-/batch-0.6.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/big.js/-/big.js-5.2.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/binary-extensions/-/binary-extensions-2.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/bindings/-/bindings-1.5.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/bluebird/-/bluebird-3.7.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/bn.js/-/bn.js-5.1.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/body-parser/-/body-parser-1.19.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/bonjour/-/bonjour-3.5.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/brace-expansion/-/brace-expansion-1.1.11.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/braces/-/braces-3.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/brorand/-/brorand-1.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/browserify-aes/-/browserify-aes-1.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/browserify-cipher/-/browserify-cipher-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/browserify-des/-/browserify-des-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/browserify-rsa/-/browserify-rsa-4.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/browserify-sign/-/browserify-sign-4.2.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/browserify-zlib/-/browserify-zlib-0.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/browserslist/-/browserslist-4.10.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/buffer/-/buffer-4.9.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "build-artifactory.eng.vmware.com",
+          "paths": [
+            "/api/npm/npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/buffer-from/-/buffer-from-1.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/buffer-indexof/-/buffer-indexof-1.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/buffer-xor/-/buffer-xor-1.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/bytes/-/bytes-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/cacache/-/cacache-12.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/cache-base/-/cache-base-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/call-bind/-/call-bind-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/caller-callsite/-/caller-callsite-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/caller-path/-/caller-path-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/callsites/-/callsites-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/camelcase/-/camelcase-5.3.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/caseless/-/caseless-0.12.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/chalk/-/chalk-2.4.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/chokidar/-/chokidar-3.4.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/chownr/-/chownr-1.1.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/cipher-base/-/cipher-base-1.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/circular-dependency-plugin/-/circular-dependency-plugin-5.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/class-utils/-/class-utils-0.3.6.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/clean-css/-/clean-css-4.2.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/clean-stack/-/clean-stack-2.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/cliui/-/cliui-5.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/clone/-/clone-2.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/clone-deep/-/clone-deep-4.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/collection-visit/-/collection-visit-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/color-convert/-/color-convert-1.9.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/color-name/-/color-name-1.1.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/colorette/-/colorette-1.2.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/combined-stream/-/combined-stream-1.0.8.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/commander/-/commander-2.20.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/commondir/-/commondir-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/component-emitter/-/component-emitter-1.3.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/compressible/-/compressible-2.0.18.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/compression/-/compression-1.7.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/concat-map/-/concat-map-0.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/concat-stream/-/concat-stream-1.6.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/console-browserify/-/console-browserify-1.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/constants-browserify/-/constants-browserify-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/content-disposition/-/content-disposition-0.5.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/content-type/-/content-type-1.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/convert-source-map/-/convert-source-map-1.7.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/cookie/-/cookie-0.4.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/cookie-signature/-/cookie-signature-1.0.6.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/copy-concurrently/-/copy-concurrently-1.0.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/copy-descriptor/-/copy-descriptor-0.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/copy-webpack-plugin/-/copy-webpack-plugin-6.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/core-js/-/core-js-3.6.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/core-js-compat/-/core-js-compat-3.8.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/core-util-is/-/core-util-is-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/cosmiconfig/-/cosmiconfig-5.2.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/coverage-istanbul-loader/-/coverage-istanbul-loader-2.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/create-ecdh/-/create-ecdh-4.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/create-hash/-/create-hash-1.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/create-hmac/-/create-hmac-1.1.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/cross-spawn/-/cross-spawn-6.0.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/crypto-browserify/-/crypto-browserify-3.12.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/css-parse/-/css-parse-1.7.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/cyclist/-/cyclist-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/dashdash/-/dashdash-1.14.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/debug/-/debug-4.3.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/decamelize/-/decamelize-1.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/decode-uri-component/-/decode-uri-component-0.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/deep-equal/-/deep-equal-1.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/default-gateway/-/default-gateway-4.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/define-properties/-/define-properties-1.1.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/define-property/-/define-property-2.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/del/-/del-4.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/delayed-stream/-/delayed-stream-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/depd/-/depd-1.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/des.js/-/des.js-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/destroy/-/destroy-1.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/detect-node/-/detect-node-2.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/diffie-hellman/-/diffie-hellman-5.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/dir-glob/-/dir-glob-3.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/dns-equal/-/dns-equal-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/dns-packet/-/dns-packet-1.3.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/dns-txt/-/dns-txt-2.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/domain-browser/-/domain-browser-1.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/duplexify/-/duplexify-3.7.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ee-first/-/ee-first-1.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/electron-to-chromium/-/electron-to-chromium-1.3.609.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/elliptic/-/elliptic-6.5.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/emoji-regex/-/emoji-regex-7.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/emojis-list/-/emojis-list-2.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/encodeurl/-/encodeurl-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/end-of-stream/-/end-of-stream-1.4.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/errno/-/errno-0.1.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/error-ex/-/error-ex-1.3.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/es-abstract/-/es-abstract-1.18.0-next.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/es-to-primitive/-/es-to-primitive-1.2.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/escalade/-/escalade-3.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/escape-html/-/escape-html-1.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/eslint-scope/-/eslint-scope-4.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/esprima/-/esprima-4.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/esrecurse/-/esrecurse-4.3.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/estraverse/-/estraverse-4.3.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/etag/-/etag-1.8.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/eventemitter3/-/eventemitter3-4.0.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/events/-/events-3.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/eventsource/-/eventsource-1.0.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/execa/-/execa-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/expand-brackets/-/expand-brackets-2.1.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/express/-/express-4.17.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/extend/-/extend-3.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/extend-shallow/-/extend-shallow-3.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/extglob/-/extglob-2.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/extsprintf/-/extsprintf-1.3.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/fast-glob/-/fast-glob-3.2.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/fastq/-/fastq-1.9.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/faye-websocket/-/faye-websocket-0.10.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/figgy-pudding/-/figgy-pudding-3.5.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/file-loader/-/file-loader-4.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/fill-range/-/fill-range-7.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/finalhandler/-/finalhandler-1.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/find-cache-dir/-/find-cache-dir-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/find-up/-/find-up-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/flush-write-stream/-/flush-write-stream-1.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/follow-redirects/-/follow-redirects-1.13.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/for-in/-/for-in-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/forever-agent/-/forever-agent-0.6.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/form-data/-/form-data-2.3.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/forwarded/-/forwarded-0.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/fragment-cache/-/fragment-cache-0.2.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/fresh/-/fresh-0.5.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/from2/-/from2-2.3.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/fs-minipass/-/fs-minipass-2.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/fs.realpath/-/fs.realpath-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/fsevents/-/fsevents-2.1.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/function-bind/-/function-bind-1.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/gensync/-/gensync-1.0.0-beta.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/get-caller-file/-/get-caller-file-2.0.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/get-intrinsic/-/get-intrinsic-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/get-stream/-/get-stream-4.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/get-value/-/get-value-2.0.6.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/getpass/-/getpass-0.1.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/glob/-/glob-7.1.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/glob-parent/-/glob-parent-5.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/globals/-/globals-11.12.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/globby/-/globby-11.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/graceful-fs/-/graceful-fs-4.2.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/handle-thing/-/handle-thing-2.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/har-schema/-/har-schema-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/har-validator/-/har-validator-5.1.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/has/-/has-1.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/has-flag/-/has-flag-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/has-symbols/-/has-symbols-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/has-value/-/has-value-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/has-values/-/has-values-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/hash-base/-/hash-base-3.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/hash.js/-/hash.js-1.1.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/hmac-drbg/-/hmac-drbg-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/hpack.js/-/hpack.js-2.1.6.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/html-entities/-/html-entities-1.3.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/http-deceiver/-/http-deceiver-1.2.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/http-errors/-/http-errors-1.7.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/http-proxy/-/http-proxy-1.18.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/http-signature/-/http-signature-1.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/https-browserify/-/https-browserify-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/iconv-lite/-/iconv-lite-0.4.24.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ieee754/-/ieee754-1.2.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/iferr/-/iferr-0.1.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ignore/-/ignore-5.1.8.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/image-size/-/image-size-0.5.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/import-cwd/-/import-cwd-2.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/import-fresh/-/import-fresh-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/import-from/-/import-from-2.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/import-local/-/import-local-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/imurmurhash/-/imurmurhash-0.1.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/indent-string/-/indent-string-4.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/infer-owner/-/infer-owner-1.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/inflight/-/inflight-1.0.6.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/inherits/-/inherits-2.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/internal-ip/-/internal-ip-4.3.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/invariant/-/invariant-2.2.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ip/-/ip-1.1.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ip-regex/-/ip-regex-2.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-absolute-url/-/is-absolute-url-3.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-arguments/-/is-arguments-1.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-arrayish/-/is-arrayish-0.2.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-binary-path/-/is-binary-path-2.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-buffer/-/is-buffer-1.1.6.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-callable/-/is-callable-1.2.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-core-module/-/is-core-module-2.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-date-object/-/is-date-object-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-descriptor/-/is-descriptor-0.1.6.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-directory/-/is-directory-0.3.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-extendable/-/is-extendable-0.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-extglob/-/is-extglob-2.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-glob/-/is-glob-4.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-negative-zero/-/is-negative-zero-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-number/-/is-number-7.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-path-cwd/-/is-path-cwd-2.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-path-inside/-/is-path-inside-2.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-plain-object/-/is-plain-object-2.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-regex/-/is-regex-1.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-stream/-/is-stream-1.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-symbol/-/is-symbol-1.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-typedarray/-/is-typedarray-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-windows/-/is-windows-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/is-wsl/-/is-wsl-1.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/isarray/-/isarray-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/isexe/-/isexe-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/isobject/-/isobject-3.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/isstream/-/isstream-0.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/jest-worker/-/jest-worker-24.9.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/js-tokens/-/js-tokens-4.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/js-yaml/-/js-yaml-3.14.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/jsbn/-/jsbn-0.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/jsesc/-/jsesc-2.5.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/json-schema/-/json-schema-0.2.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/json3/-/json3-3.3.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/json5/-/json5-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/jsprim/-/jsprim-1.4.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/karma-source-map-support/-/karma-source-map-support-1.4.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/killable/-/killable-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/kind-of/-/kind-of-6.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/less/-/less-3.9.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/less-loader/-/less-loader-5.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/leven/-/leven-3.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/levenary/-/levenary-1.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/license-webpack-plugin/-/license-webpack-plugin-2.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/loader-runner/-/loader-runner-2.4.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/loader-utils/-/loader-utils-1.2.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/locate-path/-/locate-path-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/lodash/-/lodash-4.17.21.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/loglevel/-/loglevel-1.7.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/loose-envify/-/loose-envify-1.4.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/lru-cache/-/lru-cache-5.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/magic-string/-/magic-string-0.25.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/make-dir/-/make-dir-3.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/mamacro/-/mamacro-0.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/map-cache/-/map-cache-0.2.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/map-visit/-/map-visit-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/md5.js/-/md5.js-1.3.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/media-typer/-/media-typer-0.3.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/memory-fs/-/memory-fs-0.4.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/merge-source-map/-/merge-source-map-1.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/merge-stream/-/merge-stream-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/merge2/-/merge2-1.4.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/methods/-/methods-1.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/micromatch/-/micromatch-4.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/miller-rabin/-/miller-rabin-4.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/mime/-/mime-1.6.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/mime-db/-/mime-db-1.44.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/mime-types/-/mime-types-2.1.27.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/minimatch/-/minimatch-3.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/minimist/-/minimist-1.2.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/minipass/-/minipass-3.1.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/minipass-collect/-/minipass-collect-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/minipass-flush/-/minipass-flush-1.0.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/minizlib/-/minizlib-2.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/mississippi/-/mississippi-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/mixin-deep/-/mixin-deep-1.3.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/mkdirp/-/mkdirp-0.5.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/move-concurrently/-/move-concurrently-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ms/-/ms-2.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/multicast-dns/-/multicast-dns-6.2.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/nan/-/nan-2.14.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/nanomatch/-/nanomatch-1.2.13.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/negotiator/-/negotiator-0.6.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/neo-async/-/neo-async-2.6.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/nice-try/-/nice-try-1.0.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/node-forge/-/node-forge-0.10.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/node-libs-browser/-/node-libs-browser-2.2.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/node-releases/-/node-releases-1.1.67.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/normalize-path/-/normalize-path-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/normalize-range/-/normalize-range-0.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/normalize-url/-/normalize-url-1.9.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/npm-run-path/-/npm-run-path-2.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/num2fraction/-/num2fraction-1.2.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/oauth-sign/-/oauth-sign-0.9.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/object-assign/-/object-assign-4.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/object-copy/-/object-copy-0.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/object-inspect/-/object-inspect-1.8.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/object-is/-/object-is-1.1.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/object-keys/-/object-keys-1.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/object-visit/-/object-visit-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/object.assign/-/object.assign-4.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/object.pick/-/object.pick-1.3.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/obuf/-/obuf-1.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/on-finished/-/on-finished-2.3.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/on-headers/-/on-headers-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/once/-/once-1.4.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/open/-/open-6.4.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/opn/-/opn-5.5.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/original/-/original-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/os-browserify/-/os-browserify-0.3.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/p-finally/-/p-finally-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/p-limit/-/p-limit-2.3.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/p-locate/-/p-locate-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/p-map/-/p-map-4.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/p-retry/-/p-retry-3.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/p-try/-/p-try-2.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/pako/-/pako-1.0.11.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/parallel-transform/-/parallel-transform-1.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/parse-asn1/-/parse-asn1-5.1.6.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/parse-json/-/parse-json-4.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/parse5/-/parse5-4.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/parseurl/-/parseurl-1.3.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/pascalcase/-/pascalcase-0.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/path-browserify/-/path-browserify-0.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/path-dirname/-/path-dirname-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/path-exists/-/path-exists-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/path-is-inside/-/path-is-inside-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/path-key/-/path-key-2.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/path-parse/-/path-parse-1.0.6.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/path-type/-/path-type-4.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/pbkdf2/-/pbkdf2-3.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/performance-now/-/performance-now-2.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/picomatch/-/picomatch-2.2.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/pify/-/pify-4.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/pinkie/-/pinkie-2.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/pkg-dir/-/pkg-dir-4.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/pkg-up/-/pkg-up-3.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/portfinder/-/portfinder-1.0.28.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/posix-character-classes/-/posix-character-classes-0.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/postcss/-/postcss-7.0.17.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/postcss-import/-/postcss-import-12.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/postcss-load-config/-/postcss-load-config-2.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/postcss-loader/-/postcss-loader-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/prepend-http/-/prepend-http-1.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/process/-/process-0.11.10.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/promise/-/promise-7.3.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/promise-inflight/-/promise-inflight-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/proxy-addr/-/proxy-addr-2.0.6.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/prr/-/prr-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/psl/-/psl-1.8.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/public-encrypt/-/public-encrypt-4.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/pump/-/pump-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/pumpify/-/pumpify-1.5.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/punycode/-/punycode-2.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/qs/-/qs-6.5.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/query-string/-/query-string-4.3.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/querystring/-/querystring-0.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/querystring-es3/-/querystring-es3-0.2.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/querystringify/-/querystringify-2.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/randombytes/-/randombytes-2.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/randomfill/-/randomfill-1.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/range-parser/-/range-parser-1.2.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/raw-body/-/raw-body-2.4.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/raw-loader/-/raw-loader-3.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/read-cache/-/read-cache-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/readable-stream/-/readable-stream-2.3.7.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/readdirp/-/readdirp-3.5.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/regenerate/-/regenerate-1.4.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/regenerator-transform/-/regenerator-transform-0.14.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/regex-not/-/regex-not-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/regexpu-core/-/regexpu-core-4.7.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/regjsgen/-/regjsgen-0.5.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/regjsparser/-/regjsparser-0.6.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/repeat-element/-/repeat-element-1.1.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/repeat-string/-/repeat-string-1.6.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/request/-/request-2.88.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/require-directory/-/require-directory-2.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/require-main-filename/-/require-main-filename-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/requires-port/-/requires-port-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/resolve/-/resolve-1.19.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/resolve-cwd/-/resolve-cwd-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/resolve-from/-/resolve-from-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/resolve-url/-/resolve-url-0.2.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ret/-/ret-0.1.15.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/retry/-/retry-0.12.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/reusify/-/reusify-1.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/rimraf/-/rimraf-2.7.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ripemd160/-/ripemd160-2.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/run-parallel/-/run-parallel-1.1.10.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/run-queue/-/run-queue-1.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/rxjs/-/rxjs-6.4.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/safe-buffer/-/safe-buffer-5.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/safe-regex/-/safe-regex-1.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/safer-buffer/-/safer-buffer-2.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/sass/-/sass-1.22.9.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/sass-loader/-/sass-loader-7.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/sax/-/sax-0.5.8.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/schema-utils/-/schema-utils-2.7.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/select-hose/-/select-hose-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/selfsigned/-/selfsigned-1.10.8.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/semver/-/semver-6.3.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/send/-/send-0.17.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/serialize-javascript/-/serialize-javascript-4.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/serve-index/-/serve-index-1.9.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/serve-static/-/serve-static-1.14.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/set-blocking/-/set-blocking-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/set-value/-/set-value-2.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/setimmediate/-/setimmediate-1.0.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/setprototypeof/-/setprototypeof-1.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/sha.js/-/sha.js-2.4.11.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/shallow-clone/-/shallow-clone-3.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/shebang-command/-/shebang-command-1.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/shebang-regex/-/shebang-regex-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/signal-exit/-/signal-exit-3.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/slash/-/slash-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/snapdragon/-/snapdragon-0.8.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/snapdragon-node/-/snapdragon-node-2.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/snapdragon-util/-/snapdragon-util-3.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/sockjs/-/sockjs-0.3.20.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/sockjs-client/-/sockjs-client-1.4.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/sort-keys/-/sort-keys-1.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "build-artifactory.eng.vmware.com",
+          "paths": [
+            "/api/npm/npm/source-list-map/-/source-list-map-2.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "build-artifactory.eng.vmware.com",
+          "paths": [
+            "/api/npm/npm/source-map/-/source-map-0.6.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/source-map-loader/-/source-map-loader-0.2.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/source-map-resolve/-/source-map-resolve-0.5.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/source-map-support/-/source-map-support-0.5.13.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/source-map-url/-/source-map-url-0.4.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/spdy/-/spdy-4.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/spdy-transport/-/spdy-transport-3.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.3.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/split-string/-/split-string-3.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/sprintf-js/-/sprintf-js-1.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/sshpk/-/sshpk-1.16.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ssri/-/ssri-6.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/static-extend/-/static-extend-0.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/statuses/-/statuses-1.5.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/stream-browserify/-/stream-browserify-2.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/stream-each/-/stream-each-1.2.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/stream-http/-/stream-http-2.8.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/stream-shift/-/stream-shift-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/string-width/-/string-width-3.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/string_decoder/-/string_decoder-1.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/strip-ansi/-/strip-ansi-3.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/strip-eof/-/strip-eof-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/style-loader/-/style-loader-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/stylus/-/stylus-0.54.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/stylus-loader/-/stylus-loader-3.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/supports-color/-/supports-color-5.5.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/tapable/-/tapable-1.1.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/tar/-/tar-6.1.11.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/terser/-/terser-4.6.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/terser-webpack-plugin/-/terser-webpack-plugin-3.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/through2/-/through2-2.0.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/thunky/-/thunky-1.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/timers-browserify/-/timers-browserify-2.0.12.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/to-fast-properties/-/to-fast-properties-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/to-object-path/-/to-object-path-0.3.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/to-regex/-/to-regex-3.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/to-regex-range/-/to-regex-range-5.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/toidentifier/-/toidentifier-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/tough-cookie/-/tough-cookie-2.5.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/tree-kill/-/tree-kill-1.2.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/tslib/-/tslib-1.14.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/tty-browserify/-/tty-browserify-0.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/tweetnacl/-/tweetnacl-0.14.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/type-is/-/type-is-1.6.18.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/typedarray/-/typedarray-0.0.6.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/typescript/-/typescript-3.5.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/union-value/-/union-value-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/unique-filename/-/unique-filename-1.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/unique-slug/-/unique-slug-2.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/unpipe/-/unpipe-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/unset-value/-/unset-value-1.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/upath/-/upath-1.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/uri-js/-/uri-js-4.4.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/urix/-/urix-0.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/url/-/url-0.11.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/url-parse/-/url-parse-1.5.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/use/-/use-3.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/util/-/util-0.11.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/utils-merge/-/utils-merge-1.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/uuid/-/uuid-3.4.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/vary/-/vary-1.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/verror/-/verror-1.10.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/vm-browserify/-/vm-browserify-1.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/watchpack/-/watchpack-1.7.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/wbuf/-/wbuf-1.7.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/webpack/-/webpack-4.39.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/webpack-core/-/webpack-core-0.6.9.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/webpack-log/-/webpack-log-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/webpack-merge/-/webpack-merge-4.2.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "build-artifactory.eng.vmware.com",
+          "paths": [
+            "/api/npm/npm/webpack-sources/-/webpack-sources-1.4.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/webpack-subresource-integrity/-/webpack-subresource-integrity-1.1.0-rc.6.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/websocket-driver/-/websocket-driver-0.6.5.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/websocket-extensions/-/websocket-extensions-0.1.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/when/-/when-3.6.4.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/which/-/which-1.3.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/which-module/-/which-module-2.0.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/worker-farm/-/worker-farm-1.7.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/worker-plugin/-/worker-plugin-3.2.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/wrap-ansi/-/wrap-ansi-5.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/wrappy/-/wrappy-1.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/ws/-/ws-6.2.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/xtend/-/xtend-4.0.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/y18n/-/y18n-4.0.3.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/yallist/-/yallist-3.1.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/yargs/-/yargs-13.3.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/yargs-parser/-/yargs-parser-13.1.2.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "build-artifactory.eng.vmware.com",
+          "paths": [
+            "/api/npm/npm/yazl/-/yazl-2.5.1.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "registry.npmjs.org",
+          "paths": [
+            "/yocto-queue/-/yocto-queue-0.1.0.tgz"
+          ]
+        },
+        {
+          "content": "binary",
+          "protocol": "HTTPS",
+          "host": "build-artifactory.eng.vmware.com",
+          "paths": [
+            "/api/npm/npm/zip-webpack-plugin/-/zip-webpack-plugin-3.0.0.tgz"
+          ]
+        }
+      ],
+      "virtual_centers": [],
+      "target_repositories": [],
+      "all_ephemeral": "true"
+    }
   }
 }

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
@@ -182,7 +182,9 @@ async function commandBuilder(
     if (options.concatGeneratedFiles) {
         config.plugins.push(
             new ConcatWebpackPlugin({
-                concat: options.concatGeneratedFiles
+                concat: options.concatGeneratedFiles,
+                manifest: manifest,
+                manifestJsonPath: manifestJsonPath,
             })
         );
     }

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
@@ -99,8 +99,7 @@ async function commandBuilder(
     const entryPointOriginalContent = fs.readFileSync(entryPointPath, 'utf-8');
 
     // Load manifest file
-    const copyPlugin = config.plugins.find((x) => x && x['patterns']);
-    const manifestJsonPath = path.join(copyPlugin['patterns'][0].context, 'manifest.json');
+    const manifestJsonPath = path.join(`${config.context}/src/public`, 'manifest.json');
     const manifest: ExtensionManifest = JSON.parse(fs.readFileSync(manifestJsonPath, 'utf-8'));
     const manifestOriginalContent: string = fs.readFileSync(manifestJsonPath, 'utf-8');
 

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
@@ -21,12 +21,11 @@ import {
     extractExternalRegExps,
     filterRuntimeModules,
     nameVendorFile,
-    processManifestJsonFile,
     VCD_CUSTOM_LIB_SEPARATOR
 } from '../common/utilites';
 import * as postcssPreCalculateRem from '../common/postcss-precalculate-rem';
 
-export interface PluginBuilderSchema7X extends NormalizedBrowserBuilderSchema, BasePluginBuilderSchema {}
+export interface PluginBuilderSchema7X extends NormalizedBrowserBuilderSchema, BasePluginBuilderSchema { }
 
 export const defaultExternals = {
     common: [
@@ -57,12 +56,12 @@ export const PRE_CALCULATE_REM_OPTIONS: PrecalculateRemOptions = {
 export default createBuilder(commandBuilder as () => Promise<BuilderOutput>);
 
 async function commandBuilder(
-  options: PluginBuilderSchema7X,
-  context: BuilderContext,
-  ): Promise<BuilderOutput> {
+    options: PluginBuilderSchema7X,
+    context: BuilderContext,
+): Promise<BuilderOutput> {
     if (!options.modulePath) {
-            throw Error('Please define modulePath!');
-        }
+        throw Error('Please define modulePath!');
+    }
 
     // Build webpack configurtion
     const configs = await buildBrowserWebpackConfigFromContext(options, context);
@@ -75,7 +74,7 @@ async function commandBuilder(
     delete config.entry['polyfills'];
     delete config.optimization.runtimeChunk;
     delete config.optimization.splitChunks;
-    
+
     if (!options.precalculateRem) {
         delete config.entry['styles'];
     }
@@ -94,43 +93,38 @@ async function commandBuilder(
     const entryPointPath = config.entry['main'][0];
     const entryPointOriginalContent = fs.readFileSync(entryPointPath, 'utf-8');
 
+    // Load manifest file
+    const copyPlugin = config.plugins.find((x) => x && x['patterns']);
+    const manifestJsonPath = path.join(copyPlugin['patterns'][0].context, 'manifest.json');
+    const manifest: ExtensionManifest = JSON.parse(fs.readFileSync(manifestJsonPath, 'utf-8'));
+    const manifestOriginalContent: string = fs.readFileSync(manifestJsonPath, 'utf-8');
+
     // Patch the main.ts file to point to the plugin which will be compiled
     // tslint:disable-next-line:prefer-const
     let [modulePath, moduleName] = options.modulePath.split('#');
 
     if (options.enableRuntimeDependecyManagement) {
-            // Create unique jsonpFunction name
-            const copyPlugin = config.plugins.find((x) => x && x['patterns']);
-            const manifestJsonPath = path.join(copyPlugin['patterns'][0].context, 'manifest.json');
-            const manifest: ExtensionManifest = JSON.parse(fs.readFileSync(manifestJsonPath, 'utf-8'));
-            config.output.jsonpFunction = `vcdJsonp#${moduleName}#${manifest.urn}`;
+        // Create unique jsonpFunction name
+        config.output.jsonpFunction = `vcdJsonp#${moduleName}#${manifest.urn}`;
 
-            // Configure the vendor chunks
-            config.optimization.splitChunks = {
-                chunks: 'all',
-                cacheGroups: {
-                    vendor: {
-                        test: filterRuntimeModules(options),
-                        name: nameVendorFile(config, options, pluginLibsBundles),
-                    },
+        // Configure the vendor chunks
+        config.optimization.splitChunks = {
+            chunks: 'all',
+            cacheGroups: {
+                vendor: {
+                    test: filterRuntimeModules(options),
+                    name: nameVendorFile(config, options, pluginLibsBundles, manifest, manifestJsonPath),
                 },
-            };
-
-            // Transform manifest json file.
-            // TODO: Manifest json file has to be patched when a runtime dependecy is found
-            copyPlugin['patterns'][0].transform = processManifestJsonFile(
-                options.librariesConfig || {},
-                pluginLibsBundles,
-                config.output.jsonpFunction
-            );
-        }
+            },
+        };
+    }
 
     // Export the plugin module
     modulePath = modulePath.substr(0, modulePath.indexOf('.ts'));
     const entryPointContents = `export * from '${modulePath}';`;
 
     if (!options.preserveMainFile) {
-        patchEntryPoint(entryPointPath, entryPointContents);
+        patchFile(entryPointPath, entryPointContents);
     }
 
     // Define amd lib
@@ -141,7 +135,7 @@ async function commandBuilder(
     config.output.globalObject = `(typeof self !== 'undefined' ? self : this)`;
 
     if (!config.plugins || !config.plugins.length) {
-      config.plugins = [];
+        config.plugins = [];
     }
 
     if (options.precalculateRem) {
@@ -150,7 +144,7 @@ async function commandBuilder(
 
     // Get the angular compiler
     const ngCompilerPluginInstance = config.plugins.find(
-      x => x.constructor && x.constructor.name === 'AngularCompilerPlugin'
+        x => x.constructor && x.constructor.name === 'AngularCompilerPlugin'
     );
     if (ngCompilerPluginInstance) {
         if (options.forceDisableIvy) {
@@ -158,7 +152,7 @@ async function commandBuilder(
         }
         ngCompilerPluginInstance['_entryModule'] = `${modulePath}#${moduleName}`;
     }
-    
+
     if (options.concatGeneratedFiles) {
         config.plugins.push(
             new ConcatWebpackPlugin({
@@ -195,7 +189,8 @@ async function commandBuilder(
     })
     .toPromise()
     .then((result) => {
-        patchEntryPoint(entryPointPath, entryPointOriginalContent);
+        patchFile(entryPointPath, entryPointOriginalContent);
+        patchFile(manifestJsonPath, manifestOriginalContent);
 
         if (!result) {
             return Promise.reject({ success: false, info: `Something went wrong with ${__dirname}` });
@@ -204,22 +199,23 @@ async function commandBuilder(
         return Promise.resolve(result);
     })
     .catch((e) => {
-      console.error(e);
-      patchEntryPoint(entryPointPath, entryPointOriginalContent);
-      context.logger.error(e);
-      return Promise.reject({ success: false });
+        console.error(e);
+        patchFile(entryPointPath, entryPointOriginalContent);
+        patchFile(manifestJsonPath, manifestOriginalContent);
+        context.logger.error(e);
+        return Promise.reject({ success: false });
     });
 }
 
-function patchEntryPoint(entryPointPath: string, contents: string) {
-  fs.writeFileSync(entryPointPath, contents);
+function patchFile(entryPointPath: string, contents: string) {
+    fs.writeFileSync(entryPointPath, contents);
 }
 
 function precalculateRem(config: webpack.Configuration, precalculateRemOptions: PrecalculateRemOptions) {
     if (!precalculateRemOptions) {
         precalculateRemOptions = {};
     }
-    
+
     const precalculateRem = postcssPreCalculateRem.postCssPlugin({
         ...PRE_CALCULATE_REM_OPTIONS,
         ...precalculateRemOptions
@@ -232,15 +228,15 @@ function precalculateRem(config: webpack.Configuration, precalculateRemOptions: 
     for (let i = 0; i < cssPostCssConfigs.length; i++) {
         const cssPostCssConfig = cssPostCssConfigs[i];
 
-        const cssPostCssLoader: webpack.RuleSetUse = (cssPostCssConfig.use as webpack.RuleSetUse[]).find((useRule: {loader: string}) => {
+        const cssPostCssLoader: webpack.RuleSetUse = (cssPostCssConfig.use as webpack.RuleSetUse[]).find((useRule: { loader: string }) => {
             if (!(useRule).loader) {
                 return false;
             }
             return useRule.loader.includes("postcss-loader");
         });
-        const postcssPluginCreator = (cssPostCssLoader as {options: any}).options.plugins;
-        const postCssPlugins = (cssPostCssLoader as {options: any}).options.plugins = [];
-    
+        const postcssPluginCreator = (cssPostCssLoader as { options: any }).options.plugins;
+        const postCssPlugins = (cssPostCssLoader as { options: any }).options.plugins = [];
+
         postCssPlugins.push(postcssPluginCreator);
         postCssPlugins.push(precalculateRem);
     }

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
@@ -13,9 +13,10 @@ import { buildBrowserWebpackConfigFromContext } from '@angular-devkit/build-angu
 import { NormalizedBrowserBuilderSchema } from '@angular-devkit/build-angular/src/utils/normalize-builder-schema';
 import * as fs from 'fs';
 import * as path from 'path';
+import * as webpack from 'webpack';
 import * as ZipPlugin from 'zip-webpack-plugin';
 import { ConcatWebpackPlugin } from '../common/concat';
-import { BasePluginBuilderSchema, ExtensionManifest } from '../common/interfaces';
+import { BasePluginBuilderSchema, ExtensionManifest, PrecalculateRemOptions } from '../common/interfaces';
 import {
     extractExternalRegExps,
     filterRuntimeModules,
@@ -23,6 +24,7 @@ import {
     processManifestJsonFile,
     VCD_CUSTOM_LIB_SEPARATOR
 } from '../common/utilites';
+import * as postcssPreCalculateRem from '../common/postcss-precalculate-rem';
 
 export interface PluginBuilderSchema7X extends NormalizedBrowserBuilderSchema, BasePluginBuilderSchema {}
 
@@ -45,6 +47,13 @@ export const defaultExternals = {
     ]
 };
 
+export const PRE_CALCULATE_REM_OPTIONS: PrecalculateRemOptions = {
+    rootValue: 16,
+    propList: ['*'],
+    replace: true,
+    minRemValue: 0,
+};
+
 export default createBuilder(commandBuilder as () => Promise<BuilderOutput>);
 
 async function commandBuilder(
@@ -60,13 +69,17 @@ async function commandBuilder(
     const pluginLibsBundles = new Map<string, string>();
 
     // Get the configuration
-    const config = configs.config[0];
+    const config = configs.config[0] || configs.config as webpack.Configuration;
 
     // Make sure we are producing a single bundle
-    delete config.entry.polyfills;
+    delete config.entry['polyfills'];
     delete config.optimization.runtimeChunk;
     delete config.optimization.splitChunks;
-    delete config.entry.styles;
+    
+    if (!options.precalculateRem) {
+        delete config.entry['styles'];
+    }
+
     delete config.entry['polyfills-es5'];
 
     // List the external libraries which will be provided by vcd
@@ -78,7 +91,7 @@ async function commandBuilder(
 
     // preserve path to entry point
     // so that we can clear use it within `run` method to clear that file
-    const entryPointPath = config.entry.main[0];
+    const entryPointPath = config.entry['main'][0];
     const entryPointOriginalContent = fs.readFileSync(entryPointPath, 'utf-8');
 
     // Patch the main.ts file to point to the plugin which will be compiled
@@ -87,8 +100,8 @@ async function commandBuilder(
 
     if (options.enableRuntimeDependecyManagement) {
             // Create unique jsonpFunction name
-            const copyPlugin = config.plugins.find((x) => x && x.patterns);
-            const manifestJsonPath = path.join(copyPlugin.patterns[0].context, 'manifest.json');
+            const copyPlugin = config.plugins.find((x) => x && x['patterns']);
+            const manifestJsonPath = path.join(copyPlugin['patterns'][0].context, 'manifest.json');
             const manifest: ExtensionManifest = JSON.parse(fs.readFileSync(manifestJsonPath, 'utf-8'));
             config.output.jsonpFunction = `vcdJsonp#${moduleName}#${manifest.urn}`;
 
@@ -104,7 +117,8 @@ async function commandBuilder(
             };
 
             // Transform manifest json file.
-            copyPlugin.patterns[0].transform = processManifestJsonFile(
+            // TODO: Manifest json file has to be patched when a runtime dependecy is found
+            copyPlugin['patterns'][0].transform = processManifestJsonFile(
                 options.librariesConfig || {},
                 pluginLibsBundles,
                 config.output.jsonpFunction
@@ -120,7 +134,7 @@ async function commandBuilder(
     }
 
     // Define amd lib
-    config.output.filename = 'bundle.js';
+    config.output.filename = '[name].js';
     config.output.library = moduleName;
     config.output.libraryTarget = 'amd';
     // workaround to support bundle on nodejs
@@ -130,30 +144,28 @@ async function commandBuilder(
       config.plugins = [];
     }
 
+    if (options.precalculateRem) {
+        precalculateRem(config, options.precalculateRemOptions);
+    }
+
     // Get the angular compiler
     const ngCompilerPluginInstance = config.plugins.find(
       x => x.constructor && x.constructor.name === 'AngularCompilerPlugin'
     );
     if (ngCompilerPluginInstance) {
-        ngCompilerPluginInstance._compilerOptions.enableIvy = false;
-        ngCompilerPluginInstance._entryModule = `${modulePath}#${moduleName}`;
-    }
-
-    if (options.enableRuntimeDependecyManagement) {
-            config.plugins.push(
-                new ConcatWebpackPlugin({
-                    concat: [
-                        {
-                            inputs: [
-                                'bundle.js',
-                                'vendors~main.bundle.js'
-                            ],
-                            output: 'bundle.js'
-                        }
-                    ]
-                })
-            );
+        if (options.forceDisableIvy) {
+            ngCompilerPluginInstance['_compilerOptions'].enableIvy = false;
         }
+        ngCompilerPluginInstance['_entryModule'] = `${modulePath}#${moduleName}`;
+    }
+    
+    if (options.concatGeneratedFiles) {
+        config.plugins.push(
+            new ConcatWebpackPlugin({
+                concat: options.concatGeneratedFiles
+            })
+        );
+    }
 
     // Zip the result
     config.plugins.push(
@@ -162,13 +174,13 @@ async function commandBuilder(
             exclude: [
                 /\.html$/,
                 ...Object.keys(options.librariesConfig)
-                .filter((key) => {
-                    return options.librariesConfig[key].scope === 'external';
-                })
-                .map((key) => {
-                    const libBundleName = `${key.replace('/', VCD_CUSTOM_LIB_SEPARATOR)}@${options.librariesConfig[key].version}.bundle.js`;
-                    return libBundleName;
-                })
+                    .filter((key) => {
+                        return options.librariesConfig[key].scope === 'external';
+                    })
+                    .map((key) => {
+                        const libBundleName = `${key.replace('/', VCD_CUSTOM_LIB_SEPARATOR)}@${options.librariesConfig[key].version}.js`;
+                        return libBundleName;
+                    })
             ]
         }),
     );
@@ -201,4 +213,35 @@ async function commandBuilder(
 
 function patchEntryPoint(entryPointPath: string, contents: string) {
   fs.writeFileSync(entryPointPath, contents);
+}
+
+function precalculateRem(config: webpack.Configuration, precalculateRemOptions: PrecalculateRemOptions) {
+    if (!precalculateRemOptions) {
+        precalculateRemOptions = {};
+    }
+    
+    const precalculateRem = postcssPreCalculateRem.postCssPlugin({
+        ...PRE_CALCULATE_REM_OPTIONS,
+        ...precalculateRemOptions
+    });
+
+    const cssPostCssConfigs = config.module.rules.filter((rule) => {
+        return rule.test.toString() === "/\\.css$/" || rule.test.toString() === "/\\.scss$|\\.sass$/";
+    });
+
+    for (let i = 0; i < cssPostCssConfigs.length; i++) {
+        const cssPostCssConfig = cssPostCssConfigs[i];
+
+        const cssPostCssLoader: webpack.RuleSetUse = (cssPostCssConfig.use as webpack.RuleSetUse[]).find((useRule: {loader: string}) => {
+            if (!(useRule).loader) {
+                return false;
+            }
+            return useRule.loader.includes("postcss-loader");
+        });
+        const postcssPluginCreator = (cssPostCssLoader as {options: any}).options.plugins;
+        const postCssPlugins = (cssPostCssLoader as {options: any}).options.plugins = [];
+    
+        postCssPlugins.push(postcssPluginCreator);
+        postCssPlugins.push(precalculateRem);
+    }
 }

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
@@ -112,10 +112,30 @@ async function commandBuilder(
         config.optimization.splitChunks = {
             chunks: 'all',
             cacheGroups: {
+                // Generate js file per vender for those whcih will be shared
                 vendor: {
                     test: filterRuntimeModules(options),
                     name: nameVendorFile(config, options, pluginLibsBundles, manifest, manifestJsonPath),
+                    enforce: true,
                 },
+                // All other vendors go in common.js file
+                common: {
+                    test: (mod) => {
+                        if (!mod.context) {
+                            return false;
+                        }
+                        
+                        if (!Object.keys(options.librariesConfig).some((key) => {
+                                return mod.context.includes(key);
+                            })) {
+                            return true;
+                        }
+                        return false;
+                    },
+                    name: "common",
+                    reuseExistingChunk: true,
+                    enforce: true,
+                }
             },
         };
     }

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
@@ -24,6 +24,7 @@ import {
     VCD_CUSTOM_LIB_SEPARATOR
 } from '../common/utilites';
 import * as postcssPreCalculateRem from '../common/postcss-precalculate-rem';
+import { DefinePlugin } from "webpack";
 
 export interface PluginBuilderSchema7X extends NormalizedBrowserBuilderSchema, BasePluginBuilderSchema { }
 
@@ -190,6 +191,12 @@ async function commandBuilder(
                 manifestJsonPath: manifestJsonPath,
             })
         );
+    }
+
+    if (options.replaceGlobalVarUsage) {
+        config.plugins.push(
+            new DefinePlugin(options.replaceGlobalVarUsage)
+        )
     }
 
     // Exclude all already concatenated files from plugin zip

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
@@ -51,6 +51,7 @@ export const PRE_CALCULATE_REM_OPTIONS: PrecalculateRemOptions = {
     propList: ['*'],
     replace: true,
     minRemValue: 0,
+    replaceRootWithHost: true
 };
 
 export default createBuilder(commandBuilder as () => Promise<BuilderOutput>);

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
@@ -153,7 +153,7 @@ async function commandBuilder(
     }
 
     // Define amd lib
-    config.output.filename = '[name].js';
+    config.output.filename = 'bundle.js';
     config.output.library = moduleName;
     config.output.libraryTarget = 'amd';
     // workaround to support bundle on nodejs
@@ -204,6 +204,10 @@ async function commandBuilder(
     if (options.concatGeneratedFiles) {
         options.concatGeneratedFiles.forEach((concatPair) => {
             concatPair.inputs.forEach((inputFileName: string) => {
+                if (concatPair.output === inputFileName) {
+                    return;
+                }
+                
                 excludeConcatenatedFiles.push(inputFileName);
             });
         })

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/concat.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/concat.ts
@@ -93,6 +93,9 @@ export class ConcatWebpackPlugin {
             this.options.manifest.extensionPoints[0].scripts.push("scripts.js");
         }
 
-        fs.writeFileSync(this.options.manifestJsonPath, JSON.stringify(this.options.manifest, null, 4));
+        const manifest = JSON.stringify(this.options.manifest, null, 4);
+        fs.writeFileSync(this.options.manifestJsonPath, manifest);
+        // Add to compilation assets so other plugins relying on assets can access the lates version of the manifest
+        compilation.assets["manifest.json"] = new RawSource(Buffer.from(manifest, "utf-8") as any);
     }
 }

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/concat.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/concat.ts
@@ -1,11 +1,11 @@
 import * as fs from 'fs';
 import * as webpack from 'webpack';
 import { RawSource } from 'webpack-sources';
-import { ExtensionManifest } from "./interfaces";
+import { ExtensionManifest } from './interfaces';
 
 export interface ConcatWebpackPluginOptions {
-    manifest: ExtensionManifest,
-    manifestJsonPath: string,
+    manifest: ExtensionManifest;
+    manifestJsonPath: string;
     concat?: ConcatWebpackPluginOptionsEntries[];
 }
 
@@ -45,7 +45,7 @@ export class ConcatWebpackPlugin {
             } catch (e) {
                 logger.error(`${ConcatWebpackPlugin.name} failed.`);
                 callback(e);
-            } 
+            }
         });
     }
 
@@ -77,25 +77,25 @@ export class ConcatWebpackPlugin {
     }
 
     private registerStylesAndScriptsInManifest(compilation: webpack.compilation.Compilation) {
-        if (compilation.assets["common.css"]) {
+        if (compilation.assets['common.css']) {
             if (!this.options.manifest.extensionPoints[0].styles) {
                 this.options.manifest.extensionPoints[0].styles = [];
             }
 
-            this.options.manifest.extensionPoints[0].styles.push("common.css");
+            this.options.manifest.extensionPoints[0].styles.push('common.css');
         }
 
-        if (compilation.assets["scripts.js"]) {
+        if (compilation.assets['scripts.js']) {
             if (!this.options.manifest.extensionPoints[0].scripts) {
                 this.options.manifest.extensionPoints[0].scripts = [];
             }
 
-            this.options.manifest.extensionPoints[0].scripts.push("scripts.js");
+            this.options.manifest.extensionPoints[0].scripts.push('scripts.js');
         }
 
         const manifest = JSON.stringify(this.options.manifest, null, 4);
         fs.writeFileSync(this.options.manifestJsonPath, manifest);
         // Add to compilation assets so other plugins relying on assets can access the lates version of the manifest
-        compilation.assets["manifest.json"] = new RawSource(Buffer.from(manifest, "utf-8") as any);
+        compilation.assets['manifest.json'] = new RawSource(Buffer.from(manifest, 'utf-8') as any);
     }
 }

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/interfaces.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/interfaces.ts
@@ -158,6 +158,12 @@ export interface ExtensionPointManifest {
      * The route on which only top level extrension points will be registerd.
      */
     readonly route?: string;
+
+    /**
+     * Anuglar app custom styles and scripts list, loaded inside the shadow dom by the Core UI
+     */
+    styles?: string[];
+    scripts?: string[];
 }
 
 /**

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/interfaces.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/interfaces.ts
@@ -116,6 +116,10 @@ export interface ExtensionManifest {
         };
         jsonpFunction?: string;
     };
+    /**
+     * Containes the base px value of a plugin, used by the Core UI to calculate the rem scaler.
+     */
+    pluginBasePx?: number;
 }
 
 export type ExtensionLibScope = 'external' | 'bundled' | 'isolated';
@@ -234,4 +238,8 @@ export interface PrecalculateRemOptions {
      * Defaults to: 0
      */
     minRemValue?: number,
+    /**
+     * The name of the css var that will be multiplier of the original rem size.
+     */
+    remScalerName?: string;
 }

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/interfaces.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/interfaces.ts
@@ -1,3 +1,5 @@
+import { ConcatWebpackPluginOptionsEntries } from "./concat";
+
 export interface LibrariesConfig {
     [libName: string]: {
         version: string;
@@ -183,4 +185,53 @@ export interface BasePluginBuilderSchema {
      * List of libraries determining thier version, scope and file name (location).
      */
     librariesConfig: LibrariesConfig;
+    /**
+     * Force disable angular's ivy compiler if enabled
+     */
+    forceDisableIvy: boolean;
+    /**
+     * Enable/Disable Rem precalculation
+     */
+    precalculateRem: boolean;
+    /**
+     * Traverses all css and scss files and replaces all rem usages with calc(var(--plugin-name-css-scale-constant) * originalRemSize)
+     */
+    precalculateRemOptions: PrecalculateRemOptions;
+    /**
+     * List of files to be concatenated in a given file
+     */
+    concatGeneratedFiles: ConcatWebpackPluginOptionsEntries[]
+}
+export interface PrecalculateRemOptions {
+    /**
+     * How much px 1rem equals
+     * 
+     * Defaults to: 16
+     */
+    rootValue?: number,
+    /**
+     * List of CSS properties which rems will be precalculated
+     * 
+     * Example:
+     * propList: ['font-size']
+     * 
+     * will precalculate the rem only of the font-size css.
+     * 
+     * Defaults to: ["*"]
+     */
+    propList?: string[],
+    /**
+     * Replace given css property which subject to rem precalculations,
+     * if set to true replaces all properties from the `propList` with
+     * their alternative.
+     * 
+     * Defaults to: true
+     */
+    replace?: boolean,
+    /**
+     * Skip rem precalculation if the value is less or equal to this treshold.
+     * 
+     * Defaults to: 0
+     */
+    minRemValue?: number,
 }

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/interfaces.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/interfaces.ts
@@ -1,4 +1,4 @@
-import { ConcatWebpackPluginOptionsEntries } from "./concat";
+import { ConcatWebpackPluginOptionsEntries } from './concat';
 
 export interface LibrariesConfig {
     [libName: string]: {
@@ -221,35 +221,35 @@ export interface BasePluginBuilderSchema {
 export interface PrecalculateRemOptions {
     /**
      * How much px 1rem equals
-     * 
+     *
      * Defaults to: 16
      */
-    rootValue?: number,
+    rootValue?: number;
     /**
      * List of CSS properties which rems will be precalculated
-     * 
+     *
      * Example:
      * propList: ['font-size']
-     * 
+     *
      * will precalculate the rem only of the font-size css.
-     * 
-     * Defaults to: ["*"]
+     *
+     * Defaults to: ['*']
      */
-    propList?: string[],
+    propList?: string[];
     /**
      * Replace given css property which subject to rem precalculations,
      * if set to true replaces all properties from the `propList` with
      * their alternative.
-     * 
+     *
      * Defaults to: true
      */
-    replace?: boolean,
+    replace?: boolean;
     /**
      * Skip rem precalculation if the value is less or equal to this treshold.
-     * 
+     *
      * Defaults to: 0
      */
-    minRemValue?: number,
+    minRemValue?: number;
     /**
      * The name of the css var that will be multiplier of the original rem size.
      */

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/interfaces.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/interfaces.ts
@@ -210,7 +210,13 @@ export interface BasePluginBuilderSchema {
     /**
      * List of files to be concatenated in a given file
      */
-    concatGeneratedFiles: ConcatWebpackPluginOptionsEntries[]
+    concatGeneratedFiles: ConcatWebpackPluginOptionsEntries[];
+    /**
+     * List of global variables to be replaced.
+     */
+    replaceGlobalVarUsage: {
+        [key: string]: string;
+    };
 }
 export interface PrecalculateRemOptions {
     /**

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/interfaces.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/interfaces.ts
@@ -242,4 +242,10 @@ export interface PrecalculateRemOptions {
      * The name of the css var that will be multiplier of the original rem size.
      */
     remScalerName?: string;
+    /**
+     * Replace all :root usages with :host usages, this is needed to isolate the css vars
+     * for example, so once a css var is defined by the plugin it won't be accessible from outside,
+     * or vice versa.
+     */
+    replaceRootWithHost?: boolean;
 }

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/postcss-precalculate-rem.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/postcss-precalculate-rem.ts
@@ -11,7 +11,7 @@ const defaults: PrecalculateRemOptionsInternal = {
     rootValue: 16,
     unitPrecision: 5,
     selectorBlackList: [],
-    propList: ['font', 'font-size', 'line-height', 'letter-spacing'],
+    propList: ['*'],
     replace: true,
     mediaQuery: false,
     minRemValue: 0
@@ -73,10 +73,16 @@ export const postCssPlugin = postcss.plugin('postcss-rem-to-pixel', function(opt
 });
 
 function createRemReplace (rootValue, unitPrecision, minRemValue, scalerName: string) {
+    /**
+     * Example:
+     * m = '0.1rem';
+     * $1 = '0.1';
+     */
     return function (m, $1) {
-        if (!$1) return m;
-        const rems = parseFloat($1);
-        if (rems < minRemValue) return m;
+        if (!$1) {
+            return m
+        };
+
         const result = `calc(var(--${scalerName}) * ${m})`;
         
         return result;
@@ -156,7 +162,7 @@ function createPropListMatcher(propList) {
 // Not anything inside url()
 // Any digit followed by rem
 // !singlequotes|!doublequotes|!url()|remunit
-const remRegex = /"[^"]+"|'[^']+'|url\([^\)]+\)|(\d*\.?\d+)rem/g;
+const remRegex = /"[^"]+"|'[^']+'|url\([^\)]+\)|(\d*\.?\d+)rem|-(\d*\.?\d+)rem/g;
 
 const filterPropList = {
     exact: function (list) {

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/postcss-precalculate-rem.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/postcss-precalculate-rem.ts
@@ -1,0 +1,198 @@
+import * as postcss from 'postcss';
+import { PrecalculateRemOptions } from "./interfaces";
+
+const defaults: PrecalculateRemOptions & {unitPrecision: number, selectorBlackList: string[], mediaQuery: boolean} = {
+    rootValue: 16,
+    unitPrecision: 5,
+    selectorBlackList: [],
+    propList: ['font', 'font-size', 'line-height', 'letter-spacing'],
+    replace: true,
+    mediaQuery: false,
+    minRemValue: 0
+};
+
+export const postCssPlugin = postcss.plugin('postcss-rem-to-pixel', function(options: any) {
+    const opts = {
+        ...defaults,
+        ...options,
+    };
+    const remReplace = createRemReplace(opts.rootValue, opts.unitPrecision, opts.minRemValue);
+
+    const satisfyPropList = createPropListMatcher(opts.propList);
+
+    return function (css) {
+
+        css.walkDecls(function (decl, i) {
+            // This should be the fastest test and will remove most declarations
+            if (decl.value.indexOf('rem') === -1) return;
+
+            if (!satisfyPropList(decl.prop)) return;
+
+            // TODO: `decl.parent.selector` is present in postcss version v5.2.18
+            if (blacklistedSelector(opts.selectorBlackList, (decl.parent as { selector: string }).selector)) return;
+
+            // calc(0.5 * 1rem)
+            const value = decl.value.replace(remRegex, remReplace);
+
+            // if px unit already exists, do not add or replace
+            if (declarationExists(decl.parent, decl.prop, value)) return;
+
+            if (opts.replace) {
+                decl.value = value;
+            } else {
+                decl.parent.insertAfter(i, decl.clone({ value: value }));
+            }
+        });
+
+        if (opts.mediaQuery) {
+            css.walkAtRules('media', function (rule) {
+                if (rule.params.indexOf('rem') === -1) return;
+                rule.params = rule.params.replace(remRegex, remReplace);
+            });
+        }
+
+    };
+});
+
+function createRemReplace (rootValue, unitPrecision, minRemValue) {
+    return function (m, $1) {
+        if (!$1) return m;
+        const rems = parseFloat($1);
+        if (rems < minRemValue) return m;
+        const result = `calc(var(--vcav-base-size) * ${m})`;
+        
+        return result;
+    };
+}
+
+function toFixed(number, precision) {
+    const multiplier = Math.pow(10, precision + 1),
+    wholeNumber = Math.floor(number * multiplier);
+    return Math.round(wholeNumber / 10) * 10 / multiplier;
+}
+
+function declarationExists(decls, prop, value) {
+    return decls.some(function (decl) {
+        return (decl.prop === prop && decl.value === value);
+    });
+}
+
+function blacklistedSelector(blacklist, selector) {
+    if (typeof selector !== 'string') return;
+    return blacklist.some(function (regex) {
+        if (typeof regex === 'string') return selector.indexOf(regex) !== -1;
+        return selector.match(regex);
+    });
+}
+
+function createPropListMatcher(propList) {
+    const hasWild = propList.indexOf('*') > -1;
+    const matchAll = (hasWild && propList.length === 1);
+    const lists = {
+        exact: filterPropList.exact(propList),
+        contain: filterPropList.contain(propList),
+        startWith: filterPropList.startWith(propList),
+        endWith: filterPropList.endWith(propList),
+        notExact: filterPropList.notExact(propList),
+        notContain: filterPropList.notContain(propList),
+        notStartWith: filterPropList.notStartWith(propList),
+        notEndWith: filterPropList.notEndWith(propList)
+    };
+    return function (prop) {
+        if (matchAll) return true;
+        return (
+            (
+                hasWild ||
+                lists.exact.indexOf(prop) > -1 ||
+                lists.contain.some(function (m) {
+                    return prop.indexOf(m) > -1;
+                }) ||
+                lists.startWith.some(function (m) {
+                    return prop.indexOf(m) === 0;
+                }) ||
+                lists.endWith.some(function (m) {
+                    return prop.indexOf(m) === prop.length - m.length;
+                })
+            ) &&
+            !(
+                lists.notExact.indexOf(prop) > -1 ||
+                lists.notContain.some(function (m) {
+                    return prop.indexOf(m) > -1;
+                }) ||
+                lists.notStartWith.some(function (m) {
+                    return prop.indexOf(m) === 0;
+                }) ||
+                lists.notEndWith.some(function (m) {
+                    return prop.indexOf(m) === prop.length - m.length;
+                })
+            )
+        );
+    };
+}
+
+
+// excluding regex trick: http://www.rexegg.com/regex-best-trick.html
+
+// Not anything inside double quotes
+// Not anything inside single quotes
+// Not anything inside url()
+// Any digit followed by rem
+// !singlequotes|!doublequotes|!url()|remunit
+const remRegex = /"[^"]+"|'[^']+'|url\([^\)]+\)|(\d*\.?\d+)rem/g;
+
+const filterPropList = {
+    exact: function (list) {
+        return list.filter(function (m) {
+            return m.match(/^[^\*\!]+$/);
+        });
+    },
+    contain: function (list) {
+        return list.filter(function (m) {
+            return m.match(/^\*.+\*$/);
+        }).map(function (m) {
+            return m.substr(1, m.length - 2);
+        });
+    },
+    endWith: function (list) {
+        return list.filter(function (m) {
+            return m.match(/^\*[^\*]+$/);
+        }).map(function (m) {
+            return m.substr(1);
+        });
+    },
+    startWith: function (list) {
+        return list.filter(function (m) {
+            return m.match(/^[^\*\!]+\*$/);
+        }).map(function (m) {
+            return m.substr(0, m.length - 1);
+        });
+    },
+    notExact: function (list) {
+        return list.filter(function (m) {
+            return m.match(/^\![^\*].*$/);
+        }).map(function (m) {
+            return m.substr(1);
+        });
+    },
+    notContain: function (list) {
+        return list.filter(function (m) {
+            return m.match(/^\!\*.+\*$/);
+        }).map(function (m) {
+            return m.substr(2, m.length - 3);
+        });
+    },
+    notEndWith: function (list) {
+        return list.filter(function (m) {
+            return m.match(/^\!\*[^\*]+$/);
+        }).map(function (m) {
+            return m.substr(2);
+        });
+    },
+    notStartWith: function (list) {
+        return list.filter(function (m) {
+            return m.match(/^\![^\*]+\*$/);
+        }).map(function (m) {
+            return m.substr(1, m.length - 2);
+        });
+    }
+};

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/postcss-precalculate-rem.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/postcss-precalculate-rem.ts
@@ -31,6 +31,14 @@ export const postCssPlugin = postcss.plugin('postcss-rem-to-pixel', function(opt
     const satisfyPropList = createPropListMatcher(opts.propList);
 
     return function (css) {
+        if (options.replaceRootWithHost) {
+            css.walkRules(function (rule, i) {
+                const rootSelectorIndex = rule.selector.indexOf(":root");
+                if (rootSelectorIndex !== -1) {
+                    rule.selector = rule.selector.replace(":root", ":host");
+                }
+            });
+        }
 
         css.walkDecls(function (decl, i) {
             // This should be the fastest test and will remove most declarations

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/utilites.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/utilites.ts
@@ -94,8 +94,10 @@ export function addLibToManifest(
         manifest.externals.jsonpFunction = jsonpFunction;
     }
 
-    let [libName, version] = packageName.split("@").filter(Boolean);
-    libName = `@${libName}`;
+    const packageNameAndVersion = packageName.split('@').filter(Boolean);
+    const libName = `@${packageNameAndVersion[0]}`;
+    const version = packageNameAndVersion[1];
+
     const preDefinedLocation = librariesConfig[libName].location;
     const scope: LibraryConfigScopeTypes = librariesConfig[libName].scope;
 
@@ -148,7 +150,13 @@ export function filterRuntimeModules(options: BasePluginBuilderSchema) {
 /**
  * Name the result bundles after the filtering phase.
  */
-export function nameVendorFile(config: any, options: BasePluginBuilderSchema, pluginLibsBundles: Map<string, string>, manifest: ExtensionManifest, manifestJsonPath: string) {
+export function nameVendorFile(
+    config: any,
+    options: BasePluginBuilderSchema,
+    pluginLibsBundles: Map<string, string>,
+    manifest: ExtensionManifest,
+    manifestJsonPath: string
+) {
     return (module) => {
         return splitVendorsIntoChunks(module, config.context, options.librariesConfig, (packageName: string) => {
             packageName = packageName.replace(VCD_CUSTOM_LIB_SEPARATOR, '/');

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/utilites.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/utilites.ts
@@ -152,7 +152,7 @@ export function nameVendorFile(config: any, options: BasePluginBuilderSchema, pl
     return (module) => {
         return splitVendorsIntoChunks(module, config.context, options.librariesConfig, (packageName: string) => {
             packageName = packageName.replace(VCD_CUSTOM_LIB_SEPARATOR, '/');
-            pluginLibsBundles.set(packageName, `${packageName}.js`);
+            pluginLibsBundles.set(packageName, `${packageName}.bundle.js`);
 
             addLibToManifest(
                 options.librariesConfig,

--- a/packages/angular/projects/vcd/plugin-builders/src/lib/common/utilites.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/common/utilites.ts
@@ -146,7 +146,7 @@ export function nameVendorFile(config: any, options: BasePluginBuilderSchema, pl
     return (module) => {
         return splitVendorsIntoChunks(module, config.context, options.librariesConfig, (packageName: string) => {
             packageName = packageName.replace(VCD_CUSTOM_LIB_SEPARATOR, '/');
-            pluginLibsBundles.set(packageName, `${packageName}.bundle.js`);
+            pluginLibsBundles.set(packageName, `${packageName}.js`);
         });
     };
 }

--- a/packages/angular/projects/vcd/plugin-builders/tslint.json
+++ b/packages/angular/projects/vcd/plugin-builders/tslint.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tslint.json",
   "rules": {
+    "no-string-literal": false,
     "directive-selector": [
       true,
       "attribute",

--- a/packages/care-package/uiplugins-plugin/templates/new/package.json
+++ b/packages/care-package/uiplugins-plugin/templates/new/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@angular/cli": "9.1.12",
     "@vcd/ext-cli": "0.0.13-beta.0",
-    "@vcd/plugin-builders": "0.12.1-alpha.5",
+    "@vcd/plugin-builders": "0.12.1-alpha.6",
     "rxjs": "6.2.0",
     "rxjs-compat": "6.2.0"
   }

--- a/packages/care-package/uiplugins-plugin/templates/new/tsconfig.json
+++ b/packages/care-package/uiplugins-plugin/templates/new/tsconfig.json
@@ -23,5 +23,8 @@
     "exclude": [
         "node_modules",
         "dist"
-    ]
+    ],
+    "angularCompilerOptions": {
+        "enableIvy": false,
+    },
 }


### PR DESCRIPTION
**Angular Isolation**
This PR gives the user the ability to create UI Plugins with Angular and Clarity isolation.

**Window Object Isolation**
Using webpack DefinePlugin the user will be able to isolate the window object as well.

**CSS Isolation**
Using our PrecalculateRem postcss plugin the user will be able to isolate the styles of the plugin in combination with Shadow DOM.

**Breaking Change**
After this change plugin developers will have to disable ivy using tsconfig.json or use angular.json 
Example:
// tsconfig.json
...
.
"angularCompilerOptions": {
        "enableIvy": false,
 },

// angular.json
"builder": "@vcd/plugin-builders:plugin-builder",
          "options": {
           "modulePath": "src/main/your.plugin.module.ts#YourModule",
           "forceDisableIvy": true
...
.