### PR TITLE
Plugin builder wasn't returning error code != 0 in case of an error

### DIFF
--- a/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
+++ b/packages/angular/projects/vcd/plugin-builders/src/lib/base/index.ts
@@ -182,9 +182,14 @@ async function commandBuilder(
       webpackConfiguration: () => (config)
     })
     .toPromise()
-    .then(() => {
-      patchEntryPoint(entryPointPath, entryPointOriginalContent);
-      return Promise.resolve({ success: true });
+    .then((result) => {
+        patchEntryPoint(entryPointPath, entryPointOriginalContent);
+
+        if (!result) {
+            return Promise.reject({ success: false, info: `Something went wrong with ${__dirname}` });
+        }
+
+        return Promise.resolve(result);
     })
     .catch((e) => {
       console.error(e);


### PR DESCRIPTION
Issue: Plugin builder wasn't returning error code != 0 in case of an error
Fix: In case angular builder result is null return rejected promise,
pointing the user that the issue is with the vcd plugin builder.
In case that the angular builder fail just return the result
of the original angular builder.

Testing Done:
Verified after the fix the status code after failing build is != 0