### PR TITLE
Bump "@vcd/angular-client" and @vcd/sdk to "0.13.0"

### DIFF
--- a/packages/angular/projects/vcd/sdk/CHANGELOG.md
+++ b/packages/angular/projects/vcd/sdk/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.13.0 (2022-08-04)
+- Bumped up @vcd/angular-client to 0.0.2-alpha.9 - 1) VcdApiClient can work with absolute URLs 2) Auto API version range is from '37.0' to '33.0'
+
 # 0.12.2-alpha.5 (2021-06-24)
 - Bumped up @vcd/angular-client to 0.0.2-alpha.6 - fixing a bug with using Etag headers
 - Bumped up @vcd/node-client to 0.0.5-alpha.5 - adding token expiration validation

--- a/packages/angular/projects/vcd/sdk/package-lock.json
+++ b/packages/angular/projects/vcd/sdk/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@vcd/angular-client": {
-      "version": "0.0.2-alpha.6",
-      "resolved": "https://registry.npmjs.org/@vcd/angular-client/-/angular-client-0.0.2-alpha.6.tgz",
-      "integrity": "sha512-hShLBHTAt4HGLM2pNOpIf1n57NXzS+0bejaqG/3dGnCuSQC7/nxrucA8X4xR63FYWsCoBEboCzJlZzZciCnOEQ==",
+      "version": "0.0.2-alpha.9",
+      "resolved": "https://registry.npmjs.org/@vcd/angular-client/-/angular-client-0.0.2-alpha.9.tgz",
+      "integrity": "sha512-P45H9WoVooWfCCeNOsx4oMX8JZ2C2g5x5l5G7mKxArGeRzBr/8p/R3iGtwBqg311Ki7/YAPT3ewITGcMdBEVrg==",
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/packages/angular/projects/vcd/sdk/package.json
+++ b/packages/angular/projects/vcd/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vcd/sdk",
-  "version": "0.12.2-alpha.7",
+  "version": "0.13.0",
   "description": "Angular-based client for the Cloud Director API.",
   "author": "VMware",
   "license": "BSD-2-Clause",
@@ -12,13 +12,13 @@
   },
   "module": "esm5/vcd-sdk.js",
   "dependencies": {
-    "@vcd/angular-client": "0.0.2-alpha.6"
+    "@vcd/angular-client": "0.0.2-alpha.9"
   },
   "peerDependencies": {
     "@angular-devkit/schematics": "7.3.8",
     "@angular/common": "4.4.4 || 8.2.14",
     "@angular/core": "4.4.4 || 8.2.14",
-    "@vcd/angular-client": "0.0.2-alpha.6",
+    "@vcd/angular-client": "0.0.2-alpha.9",
     "@ngrx/core": "1.2.0",
     "@ngrx/store": "2.2.2",
     "@schematics/angular": "9.1.4",


### PR DESCRIPTION
@vcd/angular-client changes:
1) VcdApiClient can work with absolute URLs
2) Auto API version range is from '37.0' to '33.0'

Signed-off-by: Ivo Rahov <irahov@vmware.com>