### PR TITLE
Current version of CLI cannot execute serve command when logged in as tenant

### DIFF
--- a/packages/care-package/core/package.json
+++ b/packages/care-package/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vcd/care-package",
   "description": "Manages CARE Packages",
-  "version": "0.0.2-beta.5",
+  "version": "0.0.2-beta.6",
   "author": "VMware",
   "license": "BSD-2",
   "dependencies": {

--- a/packages/care-package/core/src/CarePackage.ts
+++ b/packages/care-package/core/src/CarePackage.ts
@@ -176,7 +176,6 @@ export class CarePackage {
         if (!this.fromSource) {
             throw new Error('Serve operation can only be triggered from CARE package source project');
         }
-        await this.validatePlatformVersion(clientConfig);
         // TODO extract 'serve' as a const variable
         return this.runOperationOnElements('serve', only, clientConfig, options);
     }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vcd/ext-cli",
   "description": "CLI tool for working with Cloud Director extensions",
-  "version": "0.0.13-beta.6",
+  "version": "0.0.13-beta.7",
   "author": "VMware",
   "license": "BSD-2",
   "pkg": {
@@ -15,7 +15,7 @@
     "@oclif/command": "^1.5.19",
     "@oclif/config": "^1.13.3",
     "@oclif/plugin-help": "^2.2.1",
-    "@vcd/care-package": "0.0.2-beta.5",
+    "@vcd/care-package": "0.0.2-beta.6",
     "@vcd/node-client": "0.0.6-alpha.2",
     "adm-zip": "^0.4.16",
     "debug": "^4.2.0",


### PR DESCRIPTION
Issue: Current version of CLI cannot execute serve command when authenticated as tenant.

Fix: Remove platform version validation when using "serve" command, since the endpoint is only available for System users and it fails with 403 Forbidden for tenant users.

Signed-off-by: Lyubomir Stoychev <stoychevl@vmware.com>